### PR TITLE
reformat cuda headers

### DIFF
--- a/src/applications/solvers/simpleFoam/cyclic_simple.cuh
+++ b/src/applications/solvers/simpleFoam/cyclic_simple.cuh
@@ -21,87 +21,177 @@
 
 namespace brae {
 
-struct CyclicLdu {
+struct CyclicLdu
+{
     std::vector<scalar> diag, upper, lower;            // base lduMatrix incl. cyclic diagonal additions
     std::vector<std::vector<scalar>> ifCoeff;          // [interface][face]: result[own] += ifCoeff*psi[nbr]
 };
 
-inline std::vector<scalar> cyclicLduAmul(const CyclicLdu& L, const PrimitiveMesh& m,
-                                         const std::vector<CyclicInterface>& cyclics, const std::vector<scalar>& psi) {
+inline std::vector<scalar> cyclicLduAmul(
+    const CyclicLdu& L,
+    const PrimitiveMesh& m,
+    const std::vector<CyclicInterface>& cyclics,
+    const std::vector<scalar>& psi)
+{
     const label nC = m.nCells(), nIf = m.nInternalFaces();
-    const std::vector<label>& own = m.owner(); const std::vector<label>& nei = m.neighbour();
+    const std::vector<label>& own = m.owner();
+    const std::vector<label>& nei = m.neighbour();
     std::vector<scalar> y(nC);
-    for (label c = 0; c < nC; ++c) y[c] = L.diag[c] * psi[c];
-    for (label f = 0; f < nIf; ++f) { y[own[f]] += L.upper[f] * psi[nei[f]]; y[nei[f]] += L.lower[f] * psi[own[f]]; }
-    for (std::size_t ci = 0; ci < cyclics.size(); ++ci) { const CyclicInterface& c = cyclics[ci];
-        for (std::size_t i = 0; i < c.faceCells.size(); ++i) y[c.faceCells[i]] += L.ifCoeff[ci][i] * psi[c.nbrFaceCells[i]]; }
+    for (label c = 0; c < nC; ++c)
+        y[c] = L.diag[c] * psi[c];
+    for (label f = 0; f < nIf; ++f)
+    {
+        y[own[f]] += L.upper[f] * psi[nei[f]];
+        y[nei[f]] += L.lower[f] * psi[own[f]];
+    }
+    for (std::size_t ci = 0; ci < cyclics.size(); ++ci)
+    {
+        const CyclicInterface& c = cyclics[ci];
+        for (std::size_t i = 0; i < c.faceCells.size(); ++i)
+            y[c.faceCells[i]] += L.ifCoeff[ci][i] * psi[c.nbrFaceCells[i]];
+    }
     return y;
 }
 
 // Jacobi-preconditioned BiCGStab for the (possibly non-symmetric) cyclic system L x = b.
-inline int cyclicBiCGStab(const CyclicLdu& L, const PrimitiveMesh& m, const std::vector<CyclicInterface>& cyclics,
-                          std::vector<scalar>& x, const std::vector<scalar>& b, scalar tol, int maxIter) {
+inline int cyclicBiCGStab(
+    const CyclicLdu& L,
+    const PrimitiveMesh& m,
+    const std::vector<CyclicInterface>& cyclics,
+    std::vector<scalar>& x,
+    const std::vector<scalar>& b,
+    scalar tol,
+    int maxIter)
+{
     const label nC = m.nCells();
     auto amul = [&](const std::vector<scalar>& v) { return cyclicLduAmul(L, m, cyclics, v); };
-    auto dot  = [&](const std::vector<scalar>& a, const std::vector<scalar>& c) { scalar s = 0; for (label i = 0; i < nC; ++i) s += a[i]*c[i]; return s; };
-    std::vector<scalar> r = b; { const std::vector<scalar> Ax = amul(x); for (label i = 0; i < nC; ++i) r[i] -= Ax[i]; }
+    auto dot = [&](const std::vector<scalar>& a, const std::vector<scalar>& c)
+    {
+        scalar s = 0;
+        for (label i = 0; i < nC; ++i)
+            s += a[i]*c[i];
+        return s;
+    };
+    std::vector<scalar> r = b;
+    {
+        const std::vector<scalar> Ax = amul(x);
+        for (label i = 0; i < nC; ++i)
+            r[i] -= Ax[i];
+    }
     std::vector<scalar> r0 = r, p(nC, 0), v(nC, 0), s(nC), t, y(nC), z(nC);
     scalar rho = 1, alpha = 1, omega = 1;
-    for (int it = 0; it < maxIter; ++it) {
-        const scalar rho1 = dot(r0, r); if (std::fabs(rho1) < 1e-300) break;
-        const scalar beta = (rho1/rho)*(alpha/omega); rho = rho1;
-        for (label i = 0; i < nC; ++i) p[i] = r[i] + beta*(p[i] - omega*v[i]);
-        for (label i = 0; i < nC; ++i) y[i] = p[i]/L.diag[i];
-        v = amul(y); alpha = rho1/dot(r0, v);
-        for (label i = 0; i < nC; ++i) s[i] = r[i] - alpha*v[i];
-        if (std::sqrt(dot(s, s)) < tol) { for (label i = 0; i < nC; ++i) x[i] += alpha*y[i]; return it+1; }
-        for (label i = 0; i < nC; ++i) z[i] = s[i]/L.diag[i];
-        t = amul(z); const scalar tt = dot(t, t); omega = tt > 1e-300 ? dot(t, s)/tt : 0.0;
-        for (label i = 0; i < nC; ++i) { x[i] += alpha*y[i] + omega*z[i]; r[i] = s[i] - omega*t[i]; }
+    for (int it = 0; it < maxIter; ++it)
+    {
+        const scalar rho1 = dot(r0, r);
+        if (std::fabs(rho1) < 1e-300) break;
+        const scalar beta = (rho1/rho)*(alpha/omega);
+        rho = rho1;
+        for (label i = 0; i < nC; ++i)
+            p[i] = r[i] + beta*(p[i] - omega*v[i]);
+        for (label i = 0; i < nC; ++i)
+            y[i] = p[i]/L.diag[i];
+        v = amul(y);
+        alpha = rho1/dot(r0, v);
+        for (label i = 0; i < nC; ++i)
+            s[i] = r[i] - alpha*v[i];
+        if (std::sqrt(dot(s, s)) < tol)
+        {
+            for (label i = 0; i < nC; ++i)
+                x[i] += alpha*y[i];
+            return it+1;
+        }
+        for (label i = 0; i < nC; ++i)
+            z[i] = s[i]/L.diag[i];
+        t = amul(z);
+        const scalar tt = dot(t, t);
+        omega = tt > 1e-300 ? dot(t, s)/tt : 0.0;
+        for (label i = 0; i < nC; ++i)
+        {
+            x[i] += alpha*y[i] + omega*z[i];
+            r[i] = s[i] - omega*t[i];
+        }
         if (std::sqrt(dot(r, r)) < tol) return it+1;
     }
     return maxIter;
 }
 
 // Cyclic-aware fvMatrix::relax, sumOff includes the |cyclic interface coeff|.
-inline void cyclicRelax(CyclicLdu& L, std::vector<vector>& source, const FvVectorMatrix& M0,
-                        const GeometricField<vector>& U, const PrimitiveMesh& m, const FvGeometry& g,
-                        const std::vector<FvPatch>& fvp, const std::vector<CyclicInterface>& cyclics, scalar alpha) {
+inline void cyclicRelax(
+    CyclicLdu& L,
+    std::vector<vector>& source,
+    const FvVectorMatrix& M0,
+    const GeometricField<vector>& U,
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp,
+    const std::vector<CyclicInterface>& cyclics,
+    scalar alpha)
+{
     if (alpha <= 0.0) return;
     const label nC = m.nCells(), nIf = m.nInternalFaces();
-    const std::vector<label>& own = m.owner(); const std::vector<label>& nei = m.neighbour();
+    const std::vector<label>& own = m.owner();
+    const std::vector<label>& nei = m.neighbour();
     const std::vector<scalar> D0 = L.diag;
     std::vector<scalar> sumOff(nC, 0.0);
-    for (label f = 0; f < nIf; ++f) { sumOff[own[f]] += std::fabs(L.upper[f]); sumOff[nei[f]] += std::fabs(L.lower[f]); }
-    for (std::size_t ci = 0; ci < cyclics.size(); ++ci) for (std::size_t i = 0; i < cyclics[ci].faceCells.size(); ++i)
-        sumOff[cyclics[ci].faceCells[i]] += std::fabs(L.ifCoeff[ci][i]);
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i)
-        L.diag[fvp[pi].faceCells[i]] += cmptMagMax(M0.internalCoeffs[pi][i]);
-    for (label c = 0; c < nC; ++c) L.diag[c] = std::fmax(std::fabs(L.diag[c]), sumOff[c]) / alpha;
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i)
-        L.diag[fvp[pi].faceCells[i]] -= cmptMin(M0.internalCoeffs[pi][i]);
-    for (label c = 0; c < nC; ++c) source[c] += (L.diag[c] - D0[c]) * U.internal[c];
+    for (label f = 0; f < nIf; ++f)
+    {
+        sumOff[own[f]] += std::fabs(L.upper[f]);
+        sumOff[nei[f]] += std::fabs(L.lower[f]);
+    }
+    for (std::size_t ci = 0; ci < cyclics.size(); ++ci)
+        for (std::size_t i = 0; i < cyclics[ci].faceCells.size(); ++i)
+            sumOff[cyclics[ci].faceCells[i]] += std::fabs(L.ifCoeff[ci][i]);
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        for (label i = 0; i < fvp[pi].size; ++i)
+            L.diag[fvp[pi].faceCells[i]] += cmptMagMax(M0.internalCoeffs[pi][i]);
+    for (label c = 0; c < nC; ++c)
+        L.diag[c] = std::fmax(std::fabs(L.diag[c]), sumOff[c]) / alpha;
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        for (label i = 0; i < fvp[pi].size; ++i)
+            L.diag[fvp[pi].faceCells[i]] -= cmptMin(M0.internalCoeffs[pi][i]);
+    for (label c = 0; c < nC; ++c)
+        source[c] += (L.diag[c] - D0[c]) * U.internal[c];
 }
 
 // One cyclic SIMPLE iteration on the periodic channel. Drives the flow with body force g=(gx,0,0).
-inline void cyclicSimpleStep(const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& fvp,
-                             const std::vector<CyclicInterface>& cyclics,
-                             GeometricField<vector>& U, GeometricField<scalar>& p, SurfaceScalarField& phi,
-                             scalar nu, scalar gx, scalar relaxU, scalar relaxP, scalar tolU, scalar tolP) {
+inline void cyclicSimpleStep(
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp,
+    const std::vector<CyclicInterface>& cyclics,
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    scalar nu,
+    scalar gx,
+    scalar relaxU,
+    scalar relaxP,
+    scalar tolU,
+    scalar tolP)
+{
     const label nC = m.nCells(), nIf = m.nInternalFaces();
-    const std::vector<scalar>& V = g.V(); const std::vector<scalar>& magSf = g.magSf();
+    const std::vector<scalar>& V = g.V();
+    const std::vector<scalar>& magSf = g.magSf();
     auto pcmp = [](const vector& v, int k) { return k == 0 ? v.x : (k == 1 ? v.y : v.z); };
     auto pset = [](vector& v, int k, scalar s) { if (k==0) v.x=s; else if (k==1) v.y=s; else v.z=s; };
 
-    // --- momentum operator: div(phi,U) - laplacian(nu,U), + body force ---
+    // momentum operator: div(phi,U) - laplacian(nu,U), + body force
     FvVectorMatrix M0 = fvm::div(phi.internal, phi.boundary, U, m, fvp);
     addEqual(M0, fvm::laplacian(U, nu, m, g, fvp), -1.0);
-    for (label c = 0; c < nC; ++c) M0.source[c].x += gx * V[c];
+    for (label c = 0; c < nC; ++c)
+        M0.source[c].x += gx * V[c];
 
-    CyclicLdu Lm; Lm.diag = M0.diag; Lm.upper = M0.upper; Lm.lower = M0.lower; Lm.ifCoeff.resize(cyclics.size());
-    for (std::size_t ci = 0; ci < cyclics.size(); ++ci) { const CyclicInterface& c = cyclics[ci];
+    CyclicLdu Lm;
+    Lm.diag = M0.diag;
+    Lm.upper = M0.upper;
+    Lm.lower = M0.lower;
+    Lm.ifCoeff.resize(cyclics.size());
+    for (std::size_t ci = 0; ci < cyclics.size(); ++ci)
+    {
+        const CyclicInterface& c = cyclics[ci];
         Lm.ifCoeff[ci].resize(c.faceCells.size());
-        for (std::size_t i = 0; i < c.faceCells.size(); ++i) {
+        for (std::size_t i = 0; i < c.faceCells.size(); ++i)
+        {
             const scalar phi_c = phi.boundary[c.patch][i];
             const scalar cl = nu * magSf[fvp[c.patch].start + i] * c.deltaCoeffs[i];
             Lm.diag[c.faceCells[i]] += std::fmax(phi_c, 0.0) + cl;
@@ -113,88 +203,143 @@ inline void cyclicSimpleStep(const PrimitiveMesh& m, const FvGeometry& g, const 
 
     // diagC = relaxed diag + real-patch internalCoeffs (cmptAv); used for A() and the component solve.
     std::vector<scalar> diagC = Lm.diag;
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i)
-        diagC[fvp[pi].faceCells[i]] += cmptAv(M0.internalCoeffs[pi][i]);
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        for (label i = 0; i < fvp[pi].size; ++i)
+            diagC[fvp[pi].faceCells[i]] += cmptAv(M0.internalCoeffs[pi][i]);
 
     // momentum predictor: solve (Lm == src - V*grad(p)) per component.
     const std::vector<vector> gradP = fvc::gaussGrad(p, m, g, fvp);
-    for (int k = 0; k < 3; ++k) {
-        CyclicLdu Lk = Lm; Lk.diag = diagC;                      // solve uses the boundary-folded diagonal
+    for (int k = 0; k < 3; ++k)
+    {
+        CyclicLdu Lk = Lm;
+        Lk.diag = diagC;                      // solve uses the boundary-folded diagonal
         std::vector<scalar> b(nC), xk(nC);
-        for (label c = 0; c < nC; ++c) { b[c] = pcmp(src[c], k) - V[c]*pcmp(gradP[c], k); xk[c] = pcmp(U.internal[c], k); }
-        for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i)
-            b[fvp[pi].faceCells[i]] += pcmp(M0.boundaryCoeffs[pi][i], k);
+        for (label c = 0; c < nC; ++c)
+        {
+            b[c] = pcmp(src[c], k) - V[c]*pcmp(gradP[c], k);
+            xk[c] = pcmp(U.internal[c], k);
+        }
+        for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            for (label i = 0; i < fvp[pi].size; ++i)
+                b[fvp[pi].faceCells[i]] += pcmp(M0.boundaryCoeffs[pi][i], k);
         cyclicBiCGStab(Lk, m, cyclics, xk, b, tolU, 2000);
-        for (label c = 0; c < nC; ++c) pset(U.internal[c], k, xk[c]);
+        for (label c = 0; c < nC; ++c)
+            pset(U.internal[c], k, xk[c]);
     }
     U.evaluateBoundary();
 
-    // --- A, rAU, H, HbyA ---
+    // A, rAU, H, HbyA
     std::vector<scalar> A(nC), rAU(nC);
-    for (label c = 0; c < nC; ++c) { A[c] = diagC[c]/V[c]; rAU[c] = 1.0/A[c]; }
+    for (label c = 0; c < nC; ++c)
+    {
+        A[c] = diagC[c]/V[c];
+        rAU[c] = 1.0/A[c];
+    }
     GeometricField<vector> HbyA = buildCyclicField<vector>(std::vector<vector>(nC), fvp, cyclics, /*wallNoSlip*/true);
-    for (int k = 0; k < 3; ++k) {
-        CyclicLdu Lk = Lm; Lk.diag = diagC;
-        std::vector<scalar> Uk(nC); for (label c = 0; c < nC; ++c) Uk[c] = pcmp(U.internal[c], k);
+    for (int k = 0; k < 3; ++k)
+    {
+        CyclicLdu Lk = Lm;
+        Lk.diag = diagC;
+        std::vector<scalar> Uk(nC);
+        for (label c = 0; c < nC; ++c)
+            Uk[c] = pcmp(U.internal[c], k);
         const std::vector<scalar> Apsi = cyclicLduAmul(Lk, m, cyclics, Uk);
         std::vector<scalar> Hk(nC);
-        for (label c = 0; c < nC; ++c) Hk[c] = diagC[c]*Uk[c] - Apsi[c] + pcmp(src[c], k);   // H = (D - L)psi + source
-        for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i) {
-            const label fc = fvp[pi].faceCells[i]; const vector ic = M0.internalCoeffs[pi][i];
-            Hk[fc] += (cmptAv(ic) - pcmp(ic, k))*Uk[fc] + pcmp(M0.boundaryCoeffs[pi][i], k); }
-        for (label c = 0; c < nC; ++c) pset(HbyA.internal[c], k, rAU[c]*Hk[c]/V[c]);
+        for (label c = 0; c < nC; ++c)
+            Hk[c] = diagC[c]*Uk[c] - Apsi[c] + pcmp(src[c], k);   // H = (D - L)psi + source
+        for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            for (label i = 0; i < fvp[pi].size; ++i)
+            {
+                const label fc = fvp[pi].faceCells[i];
+                const vector ic = M0.internalCoeffs[pi][i];
+                Hk[fc] += (cmptAv(ic) - pcmp(ic, k))*Uk[fc] + pcmp(M0.boundaryCoeffs[pi][i], k);
+            }
+        for (label c = 0; c < nC; ++c)
+            pset(HbyA.internal[c], k, rAU[c]*Hk[c]/V[c]);
     }
     HbyA.evaluateBoundary();
     SurfaceScalarField phiHbyA = fvc::flux(HbyA, m, g, fvp);
 
-    // --- pressure: laplacian(rAU,p) == div(phiHbyA) ---
+    // pressure: laplacian(rAU,p) == div(phiHbyA)
     const SurfaceScalarField rAUf = fvc::interpolate(rAU, m, g, fvp);
     GeometricField<scalar> rAUfld = buildCyclicField<scalar>(rAU, fvp, cyclics);
     FvScalarMatrix Mp = fvm::laplacian(rAUf, p, m, g, fvp);
     const std::vector<scalar> dphi = fvc::div(phiHbyA, m, g, fvp);
-    for (label c = 0; c < nC; ++c) Mp.source[c] += V[c]*dphi[c];
+    for (label c = 0; c < nC; ++c)
+        Mp.source[c] += V[c]*dphi[c];
 
-    CyclicLdu Lp; Lp.diag = Mp.diag; Lp.upper = Mp.upper; Lp.lower = Mp.lower; Lp.ifCoeff.resize(cyclics.size());
+    CyclicLdu Lp;
+    Lp.diag = Mp.diag;
+    Lp.upper = Mp.upper;
+    Lp.lower = Mp.lower;
+    Lp.ifCoeff.resize(cyclics.size());
     std::vector<scalar> pcoeff_store;                                  // cyclic pressure face coeffs (for flux)
     std::vector<std::vector<scalar>> pcoeff(cyclics.size());
-    for (std::size_t ci = 0; ci < cyclics.size(); ++ci) { const CyclicInterface& c = cyclics[ci];
-        Lp.ifCoeff[ci].resize(c.faceCells.size()); pcoeff[ci].resize(c.faceCells.size());
-        for (std::size_t i = 0; i < c.faceCells.size(); ++i) {
+    for (std::size_t ci = 0; ci < cyclics.size(); ++ci)
+    {
+        const CyclicInterface& c = cyclics[ci];
+        Lp.ifCoeff[ci].resize(c.faceCells.size());
+        pcoeff[ci].resize(c.faceCells.size());
+        for (std::size_t i = 0; i < c.faceCells.size(); ++i)
+        {
             const scalar rf = rAUfld.boundary[c.patch]->value()[i];    // coupled rAU at the cyclic face
             const scalar coeff = rf * magSf[fvp[c.patch].start + i] * c.deltaCoeffs[i];
-            Lp.diag[c.faceCells[i]] -= coeff; Lp.ifCoeff[ci][i] = coeff; pcoeff[ci][i] = coeff;
+            Lp.diag[c.faceCells[i]] -= coeff;
+            Lp.ifCoeff[ci][i] = coeff;
+            pcoeff[ci][i] = coeff;
         }
     }
     Lp.diag = Lp.diag;  // (real pressure patches are zeroGradient here -> no internalCoeffs)
-    std::vector<scalar> b(nC); for (label c = 0; c < nC; ++c) b[c] = Mp.source[c];
+    std::vector<scalar> b(nC);
+    for (label c = 0; c < nC; ++c)
+        b[c] = Mp.source[c];
     // negate to SPD form and solve.
-    CyclicLdu Lpn = Lp; for (auto& d : Lpn.diag) d = -d; for (auto& u : Lpn.upper) u = -u; for (auto& l : Lpn.lower) l = -l;
-    for (auto& vv : Lpn.ifCoeff) for (auto& e : vv) e = -e;
-    for (auto& bb : b) bb = -bb;
+    CyclicLdu Lpn = Lp;
+    for (auto& d : Lpn.diag)
+        d = -d;
+    for (auto& u : Lpn.upper)
+        u = -u;
+    for (auto& l : Lpn.lower)
+        l = -l;
+    for (auto& vv : Lpn.ifCoeff)
+        for (auto& e : vv)
+            e = -e;
+    for (auto& bb : b)
+        bb = -bb;
     // Pure-Neumann periodic pressure is singular (constant nullspace). The RHS div(phiHbyA) is zero-mean
     // (cyclic fluxes cancel pairwise, walls carry none), so a tiny SYMMETRIC diagonal shift removes the
     // singularity without exciting the nullspace or breaking x-periodicity (unlike a single-cell pin).
-    scalar dsum = 0; for (scalar d : Lpn.diag) dsum += std::fabs(d);
+    scalar dsum = 0;
+    for (scalar d : Lpn.diag)
+        dsum += std::fabs(d);
     const scalar eps = 1e-10 * (dsum / nC);
-    for (auto& d : Lpn.diag) d += eps;
+    for (auto& d : Lpn.diag)
+        d += eps;
     const std::vector<scalar> pPrev = p.internal;
     cyclicBiCGStab(Lpn, m, cyclics, p.internal, b, tolP, 4000);
     p.evaluateBoundary();
 
     // conservative flux: phi = phiHbyA - pEqn.flux()
-    for (label f = 0; f < nIf; ++f) phi.internal[f] = phiHbyA.internal[f] - (Mp.upper[f]*p.internal[m.neighbour()[f]] - Mp.lower[f]*p.internal[m.owner()[f]]);
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) phi.boundary[pi].assign(fvp[pi].size, 0.0);
-    for (std::size_t ci = 0; ci < cyclics.size(); ++ci) { const CyclicInterface& c = cyclics[ci];
-        for (std::size_t i = 0; i < c.faceCells.size(); ++i) {
+    for (label f = 0; f < nIf; ++f)
+        phi.internal[f] = phiHbyA.internal[f] - (Mp.upper[f]*p.internal[m.neighbour()[f]] - Mp.lower[f]*p.internal[m.owner()[f]]);
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        phi.boundary[pi].assign(fvp[pi].size, 0.0);
+    for (std::size_t ci = 0; ci < cyclics.size(); ++ci)
+    {
+        const CyclicInterface& c = cyclics[ci];
+        for (std::size_t i = 0; i < c.faceCells.size(); ++i)
+        {
             const scalar flux = pcoeff[ci][i]*(p.internal[c.nbrFaceCells[i]] - p.internal[c.faceCells[i]]);
             phi.boundary[c.patch][i] = phiHbyA.boundary[c.patch][i] - flux;
         }
     }
     // p relaxation, momentum corrector.
-    for (label c = 0; c < nC; ++c) p.internal[c] = pPrev[c] + relaxP*(p.internal[c] - pPrev[c]);
+    for (label c = 0; c < nC; ++c)
+        p.internal[c] = pPrev[c] + relaxP*(p.internal[c] - pPrev[c]);
     p.evaluateBoundary();
     const std::vector<vector> gPn = fvc::gaussGrad(p, m, g, fvp);
-    for (label c = 0; c < nC; ++c) U.internal[c] = HbyA.internal[c] - rAU[c]*gPn[c];
+    for (label c = 0; c < nC; ++c)
+        U.internal[c] = HbyA.internal[c] - rAU[c]*gPn[c];
     U.evaluateBoundary();
 }
 

--- a/src/applications/solvers/simpleFoam/device_simple_foam.cuh
+++ b/src/applications/solvers/simpleFoam/device_simple_foam.cuh
@@ -39,7 +39,8 @@
 
 namespace brae {
 
-struct DeviceSimpleControls {
+struct DeviceSimpleControls
+{
     scalar nu = 1e-5, relaxU = 0.7, relaxP = 0.3, relaxK = 0.7, relaxEps = 0.7;
     vector bodyForce{0, 0, 0};                     // constant momentum source (drives periodic/cyclic channels). +V*g.
     scalar tolU = 1e-8, tolP = 1e-7, tolKE = 1e-8;
@@ -68,31 +69,43 @@ struct DeviceSimpleControls {
     bool   sa = false;                             // RASModel SpalartAllmaras (one-equation: the "k" slot holds nuTilda; no 2nd scalar).
     SpalartAllmarasCoeffs saCoeffs;                // SA coeffs (default = OF) + nutUSpaldingWallFunction E/kappa.
     bool   needRef = false;                        // no fixedValue-p patch -> singular pressure: adjustPhi + setReference.
-    label  pRefCell = 0; scalar pRefValue = 0.0;   // pressure reference (fvSolution SIMPLE.pRefCell/pRefValue).
+    label  pRefCell = 0;
+    scalar pRefValue = 0.0;                        // pressure reference (fvSolution SIMPLE.pRefCell/pRefValue).
     int    pcgCheckEvery = 1;      // pressure AMG-PCG residual-read cadence (BRAE_PCG_CHECK_EVERY). 1 = exact per-iter
                                    // (bit-identical); K>1 cuts (K-1)/K of the PCG host syncs (overshoots conv by <K).
     bool   corrScaling = false;    // AMG coarse-correction scaling + flexible CG (BRAE_CORR_SCALING). Cuts AMG cycles
-                                   // ~2× at scale (graded meshes); nonlinear precond -> not bit-identical to off.
+                                   // ~2x at scale (graded meshes); nonlinear precond -> not bit-identical to off.
     std::string caseDir = ".";     // case directory, for the AMG hierarchy cache (constant/polyMesh/.brae_amgcache).
     bool   writeCache = false;     // write the mesh + AMG caches this run (set by -partition or BRAE_MESH_CACHE).
 };
 // OF-style per-field solve report for one SIMPLE step (matches OpenFOAM's "Solving for Ux/Uy/Uz/p" + continuity block).
-struct DeviceSimpleResidual {
+struct DeviceSimpleResidual
+{
     scalar Ux = 0, Uy = 0, Uz = 0, p = 0, pFinal = 0;
-    scalar UxFinal = 0, UyFinal = 0, UzFinal = 0;  int UxIters = 0, UyIters = 0, UzIters = 0;  // U per-component final + nIter
+    scalar UxFinal = 0, UyFinal = 0, UzFinal = 0;
+    int UxIters = 0, UyIters = 0, UzIters = 0;     // U per-component final + nIter
     int pIters = 0;
     scalar contLocal = 0, contGlobal = 0;          // time step continuity errors, raw (driver applies deltaT + cumulative)
 };
 
-class DeviceSimpleSolver {
+class DeviceSimpleSolver
+{
 public:
-    DeviceSimpleSolver(const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& fvp,
-                       const GeometricField<vector>& U, const GeometricField<scalar>& p, const SurfaceScalarField& phi,
-                       const DeviceSimpleControls& ctl,
-                       const GeometricField<scalar>* k = nullptr, const GeometricField<scalar>* eps = nullptr,
-                       const GeometricField<scalar>* nut = nullptr,
-                       const GeometricField<scalar>* ReThetat = nullptr, const GeometricField<scalar>* gammaInt = nullptr)
-        : fvp_(fvp), ctl_(ctl), nC_(m.nCells()), nIf_(m.nInternalFaces()) {
+    DeviceSimpleSolver(
+        const PrimitiveMesh& m,
+        const FvGeometry& g,
+        const std::vector<FvPatch>& fvp,
+        const GeometricField<vector>& U,
+        const GeometricField<scalar>& p,
+        const SurfaceScalarField& phi,
+        const DeviceSimpleControls& ctl,
+        const GeometricField<scalar>* k = nullptr,
+        const GeometricField<scalar>* eps = nullptr,
+        const GeometricField<scalar>* nut = nullptr,
+        const GeometricField<scalar>* ReThetat = nullptr,
+        const GeometricField<scalar>* gammaInt = nullptr)
+        : fvp_(fvp), ctl_(ctl), nC_(m.nCells()), nIf_(m.nInternalFaces())
+    {
         // cyclic (periodic) interfaces: a SEPARATE lduInterface (OF cyclicFvPatchField::updateInterfaceMatrix),
         // NOT merged into the owner-sorted LDU. Both sides of each pair are stored (symmetric coupling).
         const std::vector<CyclicInterface> cyclics = buildCyclicInterfaces(m, g, fvp);
@@ -109,36 +122,89 @@ public:
         dbP_  = buildDeviceBoundary(p, fvp, g);
         wall_ = buildDeviceWallData(m, g, fvp, U);
         // all-extrapolated boundary -> gathers a cell field to boundary faces (nuEff_bnd = adjacent cell value)
-        { std::vector<label> ty, fc; std::vector<scalar> ref, dc, ms;
-          for (std::size_t pi = 0; pi < fvp.size(); ++pi) { if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
-            for (label i = 0; i < fvp[pi].size; ++i) {
-              ty.push_back(0); fc.push_back(fvp[pi].faceCells[i]); ref.push_back(0.0);
-              dc.push_back(fvp[pi].deltaCoeffs[i]); ms.push_back(g.magSf()[fvp[pi].start + i]); } }
-          dbExtrap_.n = (int)ty.size(); dbExtrap_.bcType.copyFrom(ty); dbExtrap_.refValue.copyFrom(ref);
-          dbExtrap_.deltaCoeffs.copyFrom(dc); dbExtrap_.magSf.copyFrom(ms); dbExtrap_.faceCell.copyFrom(fc);
-          dbExtrap_.valueFraction.copyFrom(std::vector<scalar>(ty.size(), 0.0)); dbExtrap_.mixedMask.copyFrom(std::vector<label>(ty.size(), 0)); }
+        {
+            std::vector<label> ty, fc;
+            std::vector<scalar> ref, dc, ms;
+            for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            {
+                if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
+                for (label i = 0; i < fvp[pi].size; ++i)
+                {
+                    ty.push_back(0);
+                    fc.push_back(fvp[pi].faceCells[i]);
+                    ref.push_back(0.0);
+                    dc.push_back(fvp[pi].deltaCoeffs[i]);
+                    ms.push_back(g.magSf()[fvp[pi].start + i]);
+                }
+            }
+            dbExtrap_.n = (int)ty.size();
+            dbExtrap_.bcType.copyFrom(ty);
+            dbExtrap_.refValue.copyFrom(ref);
+            dbExtrap_.deltaCoeffs.copyFrom(dc);
+            dbExtrap_.magSf.copyFrom(ms);
+            dbExtrap_.faceCell.copyFrom(fc);
+            dbExtrap_.valueFraction.copyFrom(std::vector<scalar>(ty.size(), 0.0));
+            dbExtrap_.mixedMask.copyFrom(std::vector<label>(ty.size(), 0));
+        }
         // any freestreamVelocity/Pressure (mixed) far-field patch present -> run the per-step valueFraction update.
         for (std::size_t pi = 0; pi < fvp.size(); ++pi)
-            if (U.boundary[pi]->bcCategory() == 5 || p.boundary[pi]->bcCategory() == 5) { hasMixed_ = true; break; }
+            if (U.boundary[pi]->bcCategory() == 5 || p.boundary[pi]->bcCategory() == 5)
+            {
+                hasMixed_ = true;
+                break;
+            }
         // any pressureInletOutletVelocity (directionMixed) U patch present -> run its per-step updateCoeffs.
         for (std::size_t pi = 0; pi < fvp.size(); ++pi)
-            if (U.boundary[pi]->bcCategory() == 6) { hasPiov_ = true; break; }
+            if (U.boundary[pi]->bcCategory() == 6)
+            {
+                hasPiov_ = true;
+                break;
+            }
         // any slip/symmetry U patch -> run its per-step updateCoeffs (general non-axis-aligned normal).
         for (std::size_t pi = 0; pi < fvp.size(); ++pi)
-            if (U.boundary[pi]->isSymmetry()) { hasSym_ = true; break; }
+            if (U.boundary[pi]->isSymmetry())
+            {
+                hasSym_ = true;
+                break;
+            }
         // any totalPressure p patch -> recompute its fixedValue refValue each step from the patch velocity + flux.
         for (std::size_t pi = 0; pi < fvp.size(); ++pi)
-            if (p.boundary[pi]->bcCategory() == 7) { hasTotalP_ = true; break; }
+            if (p.boundary[pi]->bcCategory() == 7)
+            {
+                hasTotalP_ = true;
+                break;
+            }
         // per-boundary-face wall mask + nearWallDist y (for the true boundary nut = nutkWallFunction at walls).
-        { const std::vector<std::vector<scalar>> yW = nearWallDist(m, g, fvp);
-          std::vector<label> isW; std::vector<scalar> yv;
-          for (std::size_t pi = 0; pi < fvp.size(); ++pi) { if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue; const bool wall = (fvp[pi].type == "wall");
-              for (label i = 0; i < fvp[pi].size; ++i) { isW.push_back(wall ? 1 : 0); yv.push_back(wall ? yW[pi][i] : 0.0); } }
-          bndIsWall_.copyFrom(isW); bndY_.copyFrom(yv); }
+        {
+            const std::vector<std::vector<scalar>> yW = nearWallDist(m, g, fvp);
+            std::vector<label> isW;
+            std::vector<scalar> yv;
+            for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            {
+                if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
+                const bool wall = (fvp[pi].type == "wall");
+                for (label i = 0; i < fvp[pi].size; ++i)
+                {
+                    isW.push_back(wall ? 1 : 0);
+                    yv.push_back(wall ? yW[pi][i] : 0.0);
+                }
+            }
+            bndIsWall_.copyFrom(isW);
+            bndY_.copyFrom(yv);
+        }
         // adjustPhi adjustable mask (patch order = phiBnd_ order): a face is adjustable iff its U patch does NOT
         // fix the flux (zeroGradient/inletOutlet/calculated) -> OF "!fixesValue || isA<inletOutlet>".
-        { std::vector<label> adj; for (std::size_t pi = 0; pi < fvp.size(); ++pi) { if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue; const bool fixed = U.boundary[pi]->fixesValue();
-              for (label i = 0; i < fvp[pi].size; ++i) adj.push_back(fixed ? 0 : 1); } adjustMask_.copyFrom(adj); }
+        {
+            std::vector<label> adj;
+            for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            {
+                if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
+                const bool fixed = U.boundary[pi]->fixesValue();
+                for (label i = 0; i < fvp[pi].size; ++i)
+                    adj.push_back(fixed ? 0 : 1);
+            }
+            adjustMask_.copyFrom(adj);
+        }
         nuBndConst_.copyFrom(std::vector<scalar>(dbExtrap_.n, ctl.nu));
         // AMG hierarchy for the pressure Laplacian (static: faceWeights = |Sf|), built from the mesh internal faces.
         // The cyclic interface is NOT in the AMG: a Galerkin coarse operator built from the internal-face restriction
@@ -148,16 +214,27 @@ public:
         // host cyclicPCG. cyclicGAMGInterface is the deferred perf path; for now AMG is only used on non-cyclic cases.
         const std::vector<label> ownerInt(m.owner().begin(), m.owner().begin() + nIf_), neiInt(m.neighbour());
         std::vector<scalar> fwAMG(g.magSf().begin(), g.magSf().begin() + nIf_);   // default: geometric face area (bit-identical)
-        if (std::getenv("BRAE_AMG_SOC")) {   // SoC ON: weight = LAPLACIAN coupling magSf*deltaCoeffs (the real matrix strength,
+        if (std::getenv("BRAE_AMG_SOC"))   // SoC ON: weight = LAPLACIAN coupling magSf*deltaCoeffs (the real matrix strength,
+        {
             const auto& dcg = g.deltaCoeffs();                                    // up to ~constant rAU) so agglomerate()'s
-            for (label f = 0; f < nIf_; ++f) fwAMG[f] *= dcg[f];                  // strong-face filter sees the true anisotropy
+            for (label f = 0; f < nIf_; ++f)
+                fwAMG[f] *= dcg[f];                  // strong-face filter sees the true anisotropy
         }
         amg_ = buildOrLoadAMG(ownerInt, neiInt, fwAMG, nC_, ctl_.caseDir + "/constant/polyMesh", ctl_.writeCache);
 
         // initial device state.
-        { std::vector<scalar> ux(nC_), uy(nC_), uz(nC_);
-          for (label c = 0; c < nC_; ++c) { ux[c]=U.internal[c].x; uy[c]=U.internal[c].y; uz[c]=U.internal[c].z; }
-          Uk_[0].copyFrom(ux); Uk_[1].copyFrom(uy); Uk_[2].copyFrom(uz); }
+        {
+            std::vector<scalar> ux(nC_), uy(nC_), uz(nC_);
+            for (label c = 0; c < nC_; ++c)
+            {
+                ux[c]=U.internal[c].x;
+                uy[c]=U.internal[c].y;
+                uz[c]=U.internal[c].z;
+            }
+            Uk_[0].copyFrom(ux);
+            Uk_[1].copyFrom(uy);
+            Uk_[2].copyFrom(uz);
+        }
         dp_.copyFrom(p.internal);
         phiInt_.copyFrom(phi.internal);             // internal-face flux (cyclic flux is held separately in cyc_.phi)
         // initialise the persistent cyclic-face flux. The host phi was built with the cyclic patch as a zeroGradient
@@ -165,23 +242,39 @@ public:
         // for rotational it is NOT conservative). Recompute it on the device from U_init with the proper coupled +
         // rotated interpolation (deviceCyclicFlux[Rot] is conservative) so the first momentum convection + continuity
         // see the correct periodic flux. (For a rest start U=0 this is 0 either way; it matters for a swirling init.)
-        if (hasCyclic_) {
+        if (hasCyclic_)
+        {
             if (cyc_.rotational) deviceCyclicFluxRot(cyc_, Uk_[0], Uk_[1], Uk_[2]);
             else                 deviceCyclicFlux   (cyc_, Uk_[0], Uk_[1], Uk_[2]);
         }
         if (hasAMI_) deviceAmiFlux(ami_, Uk_[0], Uk_[1], Uk_[2]);   // conservative initial AMI flux from U_init
-        { std::vector<scalar> o; for (std::size_t pi = 0; pi < fvp.size(); ++pi) { if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
-              o.insert(o.end(), phi.boundary[pi].begin(), phi.boundary[pi].end()); } phiBnd_.copyFrom(o); }
+        {
+            std::vector<scalar> o;
+            for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+            {
+                if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;
+                o.insert(o.end(), phi.boundary[pi].begin(), phi.boundary[pi].end());
+            }
+            phiBnd_.copyFrom(o);
+        }
         std::vector<scalar> nv(nC_, 0.0);
-        if (ctl_.turbulent) {
+        if (ctl_.turbulent)
+        {
             dbK_   = buildDeviceBoundary(*k, fvp, g);        // SA: the "k" slot holds nuTilda
             dk_.copyFrom(k->internal);
-            if (!ctl_.sa) { dbEps_ = buildDeviceBoundary(*eps, fvp, g); de_.copyFrom(eps->internal); }   // 2nd scalar (omega/eps); SA has none
+            if (!ctl_.sa)
+            {
+                dbEps_ = buildDeviceBoundary(*eps, fvp, g);
+                de_.copyFrom(eps->internal);   // 2nd scalar (omega/eps); SA has none
+            }
             nv = nut->internal;
             if (ctl_.sst || ctl_.sa) y_.copyFrom(cellWallDist(m, g, fvp));   // wall distance (SST F1/F2/F3; SA dTilda)
-            if (ctl_.lm && ReThetat && gammaInt) {   // kOmegaSSTLM transition fields
-                dbReThetat_ = buildDeviceBoundary(*ReThetat, fvp, g); ReThetat_.copyFrom(ReThetat->internal);
-                dbGammaInt_ = buildDeviceBoundary(*gammaInt, fvp, g); gammaInt_.copyFrom(gammaInt->internal);
+            if (ctl_.lm && ReThetat && gammaInt)   // kOmegaSSTLM transition fields
+            {
+                dbReThetat_ = buildDeviceBoundary(*ReThetat, fvp, g);
+                ReThetat_.copyFrom(ReThetat->internal);
+                dbGammaInt_ = buildDeviceBoundary(*gammaInt, fvp, g);
+                gammaInt_.copyFrom(gammaInt->internal);
                 gammaIntEff_.copyFrom(std::vector<scalar>(nC_, 0.0));   // OF kOmegaSSTLM ctor: gammaIntEff_ = Zero (no Pk on iter 1, before correctReThetatGammaInt updates it)
             }
         }
@@ -200,28 +293,39 @@ public:
     // iter 1. Without (2) the FIRST momentum predictor runs with nut straight from 0/nut, which is `uniform 0` in
     // motorBike AND pitzDaily, i.e. fully laminar; harmless on attached flows but the seed of divergence on high-Re
     // skewed meshes. kMin_/epsilonMin_/omegaMin_ default to SMALL (= 1e-15), matching the floors used in correct().
-    void validateTurbulence() {
+    void validateTurbulence()
+    {
         if (!ctl_.turbulent) return;
         const DeviceMesh& dm = dm_;
         deviceBoundField(dm, dk_, 1e-15);                              // bound(k_, kMin_)  [SA: bound(nuTilda_, 0)]
         if (!ctl_.sa) deviceBoundField(dm, de_, 1e-15);               // bound(omega_|epsilon_, ...Min_)
         // validate() -> correctNut(): recompute internal nut from the bounded fields + the initial U.
-        if (ctl_.sa) {
+        if (ctl_.sa)
+        {
             deviceNutSA(dk_, ctl_.nu, ctl_.saCoeffs.Cv1, dnut_);     // nut = nuTilda*fv1(nuTilda)
-        } else if (ctl_.sst) {
-            DeviceBuffer<scalar> gradU; deviceGradU(dm, dbU_, Uk_[0], Uk_[1], Uk_[2], gradU,
-                                                    hasAMI_ ? &ami_ : nullptr, hasCyclic_ ? &cyc_ : nullptr);
+        }
+        else if (ctl_.sst)
+        {
+            DeviceBuffer<scalar> gradU;
+            deviceGradU(dm, dbU_, Uk_[0], Uk_[1], Uk_[2], gradU,
+                        hasAMI_ ? &ami_ : nullptr, hasCyclic_ ? &cyc_ : nullptr);
             if (ctl_.gradULimitK > 0.0) deviceCellLimitGradU(dm, dbU_, Uk_[0], Uk_[1], Uk_[2], gradU, ctl_.gradULimitK);   // OF grad(U) cellLimited (validate correctNut)
-            DeviceBuffer<scalar> S2; deviceS2(gradU, nC_, S2);
-            DeviceBuffer<scalar> F2; deviceF2(dk_, de_, y_, ctl_.nu, ctl_.ksstCoeffs, F2);
+            DeviceBuffer<scalar> S2;
+            deviceS2(gradU, nC_, S2);
+            DeviceBuffer<scalar> F2;
+            deviceF2(dk_, de_, y_, ctl_.nu, ctl_.ksstCoeffs, F2);
             deviceNutSST(dk_, de_, F2, S2, ctl_.ksstCoeffs, dnut_);   // nut = a1*k/max(a1*omega, b1*F2*sqrt(S2))
-        } else {
+        }
+        else
+        {
             deviceNut(dk_, de_, dnut_, ctl_.keCoeffs);               // nut = Cmu*k^2/eps
         }
     }
 
-    DeviceSimpleResidual step() {
-        const DeviceMesh& dm = dm_; const scalar tol = ctl_.tolU;
+    DeviceSimpleResidual step()
+    {
+        const DeviceMesh& dm = dm_;
+        const scalar tol = ctl_.tolU;
         DeviceSimpleResidual res;
         // Non-orth pressure-correction limiter (OF fv::limitedSnGrad). The explicit corrVec.grad(p) correction in the
         // pressure equation is LAGGED by one outer iteration; on extreme-aspect-ratio + high-non-orth meshes (T3A:
@@ -237,101 +341,155 @@ public:
         // (OF updateCoeffs uses the prior corrector's phi). No-op when a boundary has no inletOutlet faces.
         deviceUpdateInletOutlet(dbU_, phiBnd_);
         deviceUpdateInletOutlet(dbP_, phiBnd_);
-        if (ctl_.turbulent) { deviceUpdateInletOutlet(dbK_, phiBnd_); deviceUpdateInletOutlet(dbEps_, phiBnd_);
-            if (ctl_.lm) { deviceUpdateInletOutlet(dbReThetat_, phiBnd_); deviceUpdateInletOutlet(dbGammaInt_, phiBnd_); } }
+        if (ctl_.turbulent)
+        {
+            deviceUpdateInletOutlet(dbK_, phiBnd_);
+            deviceUpdateInletOutlet(dbEps_, phiBnd_);
+            if (ctl_.lm)
+            {
+                deviceUpdateInletOutlet(dbReThetat_, phiBnd_);
+                deviceUpdateInletOutlet(dbGammaInt_, phiBnd_);
+            }
+        }
         // mixed freestreamVelocity/Pressure: recompute the per-face valueFraction from the (lagged) flow angle.
         if (hasMixed_) deviceUpdateMixedFreestream(dbU_, dbP_, phiBnd_, Uk_[0], Uk_[1], Uk_[2]);
         if (hasPiov_)  deviceUpdatePressureInletOutletVelocity(dbU_, phiBnd_, Uk_[0], Uk_[1], Uk_[2]);
         if (hasSym_)   deviceUpdateSymmetry(dbU_, Uk_[0], Uk_[1], Uk_[2]);
         // totalPressure p: recompute refValue = p0 - 0.5*neg(phi)|U_b|^2 from the boundary velocity (deviceBCValue
         // reflects the just-updated U BCs above, e.g. pressureInletOutletVelocity) + the boundary flux.
-        if (hasTotalP_) { DeviceBuffer<scalar> ubx, uby, ubz;
-            deviceBCValue(dbU_.comp[0], Uk_[0], ubx); deviceBCValue(dbU_.comp[1], Uk_[1], uby); deviceBCValue(dbU_.comp[2], Uk_[2], ubz);
-            deviceUpdateTotalPressure(dbP_, phiBnd_, ubx, uby, ubz); }
+        if (hasTotalP_)
+        {
+            DeviceBuffer<scalar> ubx, uby, ubz;
+            deviceBCValue(dbU_.comp[0], Uk_[0], ubx);
+            deviceBCValue(dbU_.comp[1], Uk_[1], uby);
+            deviceBCValue(dbU_.comp[2], Uk_[2], ubz);
+            deviceUpdateTotalPressure(dbP_, phiBnd_, ubx, uby, ubz);
+        }
 
-        DeviceBuffer<scalar> nuEff; deviceCopy(nuEff, dnut_); deviceAxpy(1.0, nuConst_, nuEff);   // nuEff = nu + nut
-        DeviceBuffer<scalar> nuEff_f; deviceInterpolate(dm, nuEff, nuEff_f);
+        DeviceBuffer<scalar> nuEff;
+        deviceCopy(nuEff, dnut_);
+        deviceAxpy(1.0, nuConst_, nuEff);   // nuEff = nu + nut
+        DeviceBuffer<scalar> nuEff_f;
+        deviceInterpolate(dm, nuEff, nuEff_f);
         // nuEff at boundary FACES: turbulent uses the TRUE wall nut (nutkWallFunction), not the cell value, so the
         // wall shear matches OpenFOAM; laminar/non-wall faces use the adjacent cell value.
         DeviceBuffer<scalar> nuEffBnd;
-        if (ctl_.turbulent) {
+        if (ctl_.turbulent)
+        {
             deviceCopy(nuEffBnd, nuBndConst_);
-            if (ctl_.sa) {   // SA wall nut via nutUSpaldingWallFunction (Newton uTau); other faces = adjacent cell nut
+            if (ctl_.sa)   // SA wall nut via nutUSpaldingWallFunction (Newton uTau); other faces = adjacent cell nut
+            {
                 deviceBoundaryNutSpalding(dbU_, bndIsWall_, bndY_, Uk_[0], Uk_[1], Uk_[2], dnut_, ctl_.nu, ctl_.saCoeffs, dnutBndWall_);
                 deviceAxpy(1.0, dnutBndWall_, nuEffBnd);
-            } else {         // k-eps / kOmegaSST: nutkWallFunction (k-based) at walls
-                DeviceBuffer<scalar> nutBnd; deviceBoundaryNut(dbU_.comp[0], bndIsWall_, bndY_, dk_, dnut_, ctl_.nu, nutBnd, ctl_.keCoeffs);
+            }
+            else   // k-eps / kOmegaSST: nutkWallFunction (k-based) at walls
+            {
+                DeviceBuffer<scalar> nutBnd;
+                deviceBoundaryNut(dbU_.comp[0], bndIsWall_, bndY_, dk_, dnut_, ctl_.nu, nutBnd, ctl_.keCoeffs);
                 deviceAxpy(1.0, nutBnd, nuEffBnd);
             }
         }
-        else deviceBCValue(dbExtrap_, nuEff, nuEffBnd);                                   // laminar: adjacent-cell value
+        else
+            deviceBCValue(dbExtrap_, nuEff, nuEffBnd);   // laminar: adjacent-cell value
         // explicit divDevReff stress (uses the incoming U; coupled across the 3 components)
-        DeviceBuffer<scalar> ddrX, ddrY, ddrZ; deviceDivDevReff(dm, dbU_, Uk_[0], Uk_[1], Uk_[2], nuEff, nuEffBnd, ddrX, ddrY, ddrZ, hasCyclic_ ? &cyc_ : nullptr, hasAMI_ ? &ami_ : nullptr);
+        DeviceBuffer<scalar> ddrX, ddrY, ddrZ;
+        deviceDivDevReff(dm, dbU_, Uk_[0], Uk_[1], Uk_[2], nuEff, nuEffBnd, ddrX, ddrY, ddrZ, hasCyclic_ ? &cyc_ : nullptr, hasAMI_ ? &ami_ : nullptr);
         DeviceBuffer<scalar>* ddr[3] = { &ddrX, &ddrY, &ddrZ };
 
-        DeviceBuffer<scalar> pbv; deviceBCValue(dbP_, dp_, pbv);
-        DeviceBuffer<scalar> gx, gy, gz; deviceGaussGrad(dm, dp_, pbv, gx, gy, gz);
+        DeviceBuffer<scalar> pbv;
+        deviceBCValue(dbP_, dp_, pbv);
+        DeviceBuffer<scalar> gx, gy, gz;
+        deviceGaussGrad(dm, dp_, pbv, gx, gy, gz);
         if (hasCyclic_) deviceCyclicAddGrad(cyc_, dp_, dm.V, gx, gy, gz);   // cyclic-face contribution to grad(p) in the momentum source
         if (hasAMI_)    deviceAmiAddGrad(ami_, dp_, dm.V, gx, gy, gz);       // AMI-face contribution to grad(p)
         DeviceBuffer<scalar> mDiag, mUp, mLo, lD, lU, lL;
-        deviceDivUpwindCoeffs(dm, phiInt_, mDiag, mUp, mLo); deviceLaplacianCoeffs(dm, nuEff_f, lD, lU, lL, ctl_.nonOrth);
-        deviceAxpy(-1.0,lD,mDiag); deviceAxpy(-1.0,lU,mUp); deviceAxpy(-1.0,lL,mLo);
+        deviceDivUpwindCoeffs(dm, phiInt_, mDiag, mUp, mLo);
+        deviceLaplacianCoeffs(dm, nuEff_f, lD, lU, lL, ctl_.nonOrth);
+        deviceAxpy(-1.0,lD,mDiag);
+        deviceAxpy(-1.0,lU,mUp);
+        deviceAxpy(-1.0,lL,mLo);
         // bounded Gauss upwind: - fvm::Sp(fvc::div(phi), U). mDiag -= V*div(phi). Stabilises the rest-start
         // transient (vanishes at convergence); matches OF's bounded scheme + the CPU simpleStep.
         // div(phi) MUST include the cyclic-face flux (OF's fvc::div sums ALL faces). Without it the cyclic cells
-        // see the un-cancelled cyclic flux ∓φ/V as a spurious divergence, so the bounded term injects ∓φ into the
-        // diagonal, asymmetric by 2φ between the inflow/outflow cyclic sides → asymmetric rAU/HbyA → non-axisym p.
-        if (ctl_.bounded) { DeviceBuffer<scalar> dphiM; deviceDiv(dm, phiInt_, phiBnd_, dphiM);
-          if (hasCyclic_) deviceCyclicAddDiv(cyc_, dm.V, dphiM);
-          if (hasAMI_)    deviceAmiAddDiv(ami_, dm.V, dphiM);
-          DeviceBuffer<scalar> bM; deviceHadamard(bM, dphiM, dm.V); deviceAxpy(-1.0, bM, mDiag); }
+        // see the un-cancelled cyclic flux -/+phi/V as a spurious divergence, so the bounded term injects -/+phi into the
+        // diagonal, asymmetric by 2phi between the inflow/outflow cyclic sides -> asymmetric rAU/HbyA -> non-axisym p.
+        if (ctl_.bounded)
+        {
+            DeviceBuffer<scalar> dphiM;
+            deviceDiv(dm, phiInt_, phiBnd_, dphiM);
+            if (hasCyclic_) deviceCyclicAddDiv(cyc_, dm.V, dphiM);
+            if (hasAMI_)    deviceAmiAddDiv(ami_, dm.V, dphiM);
+            DeviceBuffer<scalar> bM;
+            deviceHadamard(bM, dphiM, dm.V);
+            deviceAxpy(-1.0, bM, mDiag);
+        }
         // cyclic (periodic) momentum coupling M = div(phi,U) - laplacian(nuEff,U): folds the interface diagonal into
         // mDiag + builds cyc_.ifCoeff (off-diag) from the current cyclic flux; cycSumOff feeds the relax dominance.
         DeviceBuffer<scalar> cycSumOff;
-        if (hasCyclic_) { deviceCyclicAssembleMomentum(cyc_, nuEff, mDiag);
-            cycSumOff.copyFrom(std::vector<scalar>(nC_, 0.0)); deviceCyclicOffDiagSum(cyc_, cycSumOff);
-            if (cyc_.rotational) deviceCyclicScaleImplicit(cyc_); }   // per-component ifCoeffC[kk] = ifCoeff*forwardT[kk][kk]
+        if (hasCyclic_)
+        {
+            deviceCyclicAssembleMomentum(cyc_, nuEff, mDiag);
+            cycSumOff.copyFrom(std::vector<scalar>(nC_, 0.0));
+            deviceCyclicOffDiagSum(cyc_, cycSumOff);
+            if (cyc_.rotational) deviceCyclicScaleImplicit(cyc_);   // per-component ifCoeffC[kk] = ifCoeff*forwardT[kk][kk]
+        }
         DeviceBuffer<scalar> amiSumOff;                              // cyclicAMI momentum coupling (translational)
-        if (hasAMI_) { deviceAmiAssembleMomentum(ami_, nuEff, mDiag);
-            amiSumOff.copyFrom(std::vector<scalar>(nC_, 0.0)); deviceAmiOffDiagSum(ami_, amiSumOff);
-            if (ami_.rotational) deviceAmiScaleImplicit(ami_); }   // per-component ifCoeffC[kk] = ifCoeff*forwardT[kk][kk]
+        if (hasAMI_)
+        {
+            deviceAmiAssembleMomentum(ami_, nuEff, mDiag);
+            amiSumOff.copyFrom(std::vector<scalar>(nC_, 0.0));
+            deviceAmiOffDiagSum(ami_, amiSumOff);
+            if (ami_.rotational) deviceAmiScaleImplicit(ami_);   // per-component ifCoeffC[kk] = ifCoeff*forwardT[kk][kk]
+        }
         if (fvoMomSp_.size()) deviceAxpy(-1.0, fvoMomSp_, mDiag);   // fvOptions implicit momentum Sp: diag -= Sp*V (== fvm::Sp)
         // explicitPorositySource (DarcyForchheimer): isotropic resistance into the diagonal (mDiag += V*tr(Cd)); the
         // anisotropic remainder is added to relaxSrc per component below. Uses the LAMINAR nu (OF mu/rho, not nuEff).
         if (por_.active) deviceFvoPorosityDiag(por_, ctl_.nu, dm.V, Uk_[0], Uk_[1], Uk_[2], mDiag);
         DeviceBuffer<scalar>* gg[3] = { &gx, &gy, &gz };
-        DeviceBuffer<scalar> r0IC,r0BC,r0lIC,r0lBC; deviceBCDivCoeffs(dbU_.comp[0], phiBnd_, r0IC, r0BC);
-        deviceBCLaplacianCoeffsFace(dbU_.comp[0], nuEffBnd, r0lIC, r0lBC); deviceAxpy(-1.0,r0lIC,r0IC);
+        DeviceBuffer<scalar> r0IC,r0BC,r0lIC,r0lBC;
+        deviceBCDivCoeffs(dbU_.comp[0], phiBnd_, r0IC, r0BC);
+        deviceBCLaplacianCoeffsFace(dbU_.comp[0], nuEffBnd, r0lIC, r0lBC);
+        deviceAxpy(-1.0,r0lIC,r0IC);
         // slip/symmetry: the boundary diagonal differs per component (vf_k=|n_k|), so the SHARED relax/rAU diagonal
         // must use OF's cmptMax(cmptMag(iC0,iC1,iC2)), not comp[0] alone (== comp[0] when components are equal, so
         // every other BC is unaffected). Compute the per-component boundary iC and the per-face max magnitude.
         DeviceBuffer<scalar> iCmaxMag;
-        if (hasSym_) {
+        if (hasSym_)
+        {
             DeviceBuffer<scalar> r1IC,r1BC,r1lIC,r1lBC, r2IC,r2BC,r2lIC,r2lBC;
-            deviceBCDivCoeffs(dbU_.comp[1], phiBnd_, r1IC, r1BC); deviceBCLaplacianCoeffsFace(dbU_.comp[1], nuEffBnd, r1lIC, r1lBC); deviceAxpy(-1.0,r1lIC,r1IC);
-            deviceBCDivCoeffs(dbU_.comp[2], phiBnd_, r2IC, r2BC); deviceBCLaplacianCoeffsFace(dbU_.comp[2], nuEffBnd, r2lIC, r2lBC); deviceAxpy(-1.0,r2lIC,r2IC);
+            deviceBCDivCoeffs(dbU_.comp[1], phiBnd_, r1IC, r1BC);
+            deviceBCLaplacianCoeffsFace(dbU_.comp[1], nuEffBnd, r1lIC, r1lBC);
+            deviceAxpy(-1.0,r1lIC,r1IC);
+            deviceBCDivCoeffs(dbU_.comp[2], phiBnd_, r2IC, r2BC);
+            deviceBCLaplacianCoeffsFace(dbU_.comp[2], nuEffBnd, r2lIC, r2lBC);
+            deviceAxpy(-1.0,r2lIC,r2IC);
             deviceCmptMaxMag3(r0IC, r1IC, r2IC, iCmaxMag);   // OF fvMatrix::relax adds cmptMax(cmptMag(iC)) to the diagonal
         }
-        DeviceBuffer<scalar> mDiagR, delta; deviceRelaxDiag(deviceLduView(dm,mDiag,mUp,mLo), dm, r0IC, ctl_.relaxU, mDiagR, delta,
-                                                           hasCyclic_ ? cycSumOff.data() : (hasAMI_ ? amiSumOff.data() : nullptr),
-                                                           hasSym_ ? iCmaxMag.data() : nullptr);
+        DeviceBuffer<scalar> mDiagR, delta;
+        deviceRelaxDiag(deviceLduView(dm,mDiag,mUp,mLo), dm, r0IC, ctl_.relaxU, mDiagR, delta,
+                        hasCyclic_ ? cycSumOff.data() : (hasAMI_ ? amiSumOff.data() : nullptr),
+                        hasSym_ ? iCmaxMag.data() : nullptr);
         // velocityDampingConstraint: OF fvOptions.constrain(UEqn) runs AFTER UEqn.relax() and adds an implicit diagonal
         // sink (no source) where |U|>UMax. Add to the relaxed diagonal so it feeds the predictor AND rAU/HbyA (= OF A()).
         if (vdcActive_) deviceFvoVelocityDamping(vdcCells_, vdcUMax_, vdcC_, dm.V, Uk_[0], Uk_[1], Uk_[2], mDiagR);
         const DeviceLduView Uview = deviceLduView(dm, mDiagR, mUp, mLo);
         DeviceBuffer<scalar> iC[3], bCb[3], relaxSrc[3];
         // rotational cyclic: snapshot U_old so the deferred rotation MIXING is built from ONE consistent field for
-        // all three components. OF evaluates the cyclic patchNeighbourField (forwardT·U[nbr]) ONCE at UEqn assembly,
+        // all three components. OF evaluates the cyclic patchNeighbourField (forwardT.U[nbr]) ONCE at UEqn assembly,
         // from U_old, for the whole vector. cf solves the 3 components SEQUENTIALLY in place (Uk_[kk] is the solution
         // vector), so reading the live Uk_ inside the loop would feed component kk the freshly-solved earlier
-        // components -> the x↔y rotation mixing becomes asymmetric -> spurious cross-component coupling that breaks
+        // components -> the x<->y rotation mixing becomes asymmetric -> spurious cross-component coupling that breaks
         // the rotational (axi)symmetry and drifts the converged field. The snapshot makes it order-independent.
         DeviceBuffer<scalar> Usnap[3];
-        if ((hasCyclic_ && cyc_.rotational) || (hasAMI_ && ami_.rotational)) for (int kk = 0; kk < 3; ++kk) deviceCopy(Usnap[kk], Uk_[kk]);
+        if ((hasCyclic_ && cyc_.rotational) || (hasAMI_ && ami_.rotational))
+            for (int kk = 0; kk < 3; ++kk)
+                deviceCopy(Usnap[kk], Uk_[kk]);
         // rotational AMI deferred: the UN-rotated AMI-interpolated neighbour of the U_old snapshot (per src face),
         // consistent across components (the deferred mixing reads it, not the live Uk_).
         DeviceBuffer<scalar> Uint[3];
-        if (hasAMI_ && ami_.rotational) for (int l = 0; l < 3; ++l) deviceAmiInterpolate(ami_, Usnap[l], Uint[l]);
+        if (hasAMI_ && ami_.rotational)
+            for (int l = 0; l < 3; ++l)
+                deviceAmiInterpolate(ami_, Usnap[l], Uint[l]);
         // linearUpwind / non-orth need grad(U). Precompute ALL 3 component gradients HERE (Uk_ is still all-old at this
         // point, none solved yet), cyclic-inclusive: the cyclic linearUpwind reconstruction rotates gradU[nbr], so it
         // needs every component from a consistent field (computing per-kk inside the loop would read freshly-solved
@@ -340,22 +498,32 @@ public:
         DeviceBuffer<scalar> amiURot[3];   // rotated AMI-interp of the CURRENT U (gradient face value + linearUpwind/non-orth nbr)
         if ((ctl_.linearUpwind || ctl_.lust || ctl_.nonOrth) && hasAMI_ && ami_.rotational)
             deviceAmiInterpolateVec(ami_, Uk_[0], Uk_[1], Uk_[2], amiURot[0], amiURot[1], amiURot[2]);
-        if (ctl_.linearUpwind || ctl_.lust || ctl_.nonOrth) for (int l = 0; l < 3; ++l) {
-            DeviceBuffer<scalar> ubv; deviceBCValue(dbU_.comp[l], Uk_[l], ubv);
-            deviceGaussGrad(dm, Uk_[l], ubv, gUx[l], gUy[l], gUz[l]);
-            if (hasCyclic_) { if (cyc_.rotational) deviceCyclicAddGradRot(cyc_, Uk_[0], Uk_[1], Uk_[2], l, dm.V, gUx[l], gUy[l], gUz[l]);
-                              else deviceCyclicAddGrad(cyc_, Uk_[l], dm.V, gUx[l], gUy[l], gUz[l]); }
-            if (hasAMI_) { if (ami_.rotational) deviceAmiAddGradRot(ami_, Uk_[l], amiURot[l], dm.V, gUx[l], gUy[l], gUz[l]);
-                           else deviceAmiAddGrad(ami_, Uk_[l], dm.V, gUx[l], gUy[l], gUz[l]); }
-            // grad(U) cellLimited Gauss linear <k>: clamp this component's gradient so the linearUpwind/non-orth
-            // reconstruction stays bounded, OF's primary stabiliser on skewed (snappy) meshes. (min/max gather is
-            // over internal + non-cyclic boundary neighbours; interface neighbours not included, fine off-interface.)
-            if (ctl_.gradULimitK > 0.0) deviceCellLimitGrad(dm, Uk_[l], ubv, gUx[l], gUy[l], gUz[l], ctl_.gradULimitK);
-        }
+        if (ctl_.linearUpwind || ctl_.lust || ctl_.nonOrth)
+            for (int l = 0; l < 3; ++l)
+            {
+                DeviceBuffer<scalar> ubv;
+                deviceBCValue(dbU_.comp[l], Uk_[l], ubv);
+                deviceGaussGrad(dm, Uk_[l], ubv, gUx[l], gUy[l], gUz[l]);
+                if (hasCyclic_)
+                {
+                    if (cyc_.rotational) deviceCyclicAddGradRot(cyc_, Uk_[0], Uk_[1], Uk_[2], l, dm.V, gUx[l], gUy[l], gUz[l]);
+                    else deviceCyclicAddGrad(cyc_, Uk_[l], dm.V, gUx[l], gUy[l], gUz[l]);
+                }
+                if (hasAMI_)
+                {
+                    if (ami_.rotational) deviceAmiAddGradRot(ami_, Uk_[l], amiURot[l], dm.V, gUx[l], gUy[l], gUz[l]);
+                    else deviceAmiAddGrad(ami_, Uk_[l], dm.V, gUx[l], gUy[l], gUz[l]);
+                }
+                // grad(U) cellLimited Gauss linear <k>: clamp this component's gradient so the linearUpwind/non-orth
+                // reconstruction stays bounded, OF's primary stabiliser on skewed (snappy) meshes. (min/max gather is
+                // over internal + non-cyclic boundary neighbours; interface neighbours not included, fine off-interface.)
+                if (ctl_.gradULimitK > 0.0) deviceCellLimitGrad(dm, Uk_[l], ubv, gUx[l], gUy[l], gUz[l], ctl_.gradULimitK);
+            }
         // actuationDiskSource (Froude): T = 2*rho*A*(Uref.diskDir)^2*a*(1-a), Uref = mean U over the monitor cells
         // (lagged). Computed once per iter; distributed over the disk cells (V[c]/Vtot) into relaxSrc below.
         scalar adT = 0;
-        if (adActive_) {
+        if (adActive_)
+        {
             const scalar ud = (deviceDot(Uk_[0], adMonMask01_)*adDiskDir_.x + deviceDot(Uk_[1], adMonMask01_)*adDiskDir_.y
                              + deviceDot(Uk_[2], adMonMask01_)*adDiskDir_.z) / adNmon_;   // Uref . diskDir
             adT = 2.0 * adArea_ * ud*ud * adA_ * (1.0 - adA_);
@@ -367,30 +535,45 @@ public:
         // here (the plain per-component linearUpwind path stays inside the kk loop below).
         DeviceBuffer<scalar> corrV[3];
         if (ctl_.linearUpwindV) deviceLinearUpwindVCorr(dm, phiInt_, gUx, gUy, gUz, Uk_[0], Uk_[1], Uk_[2], corrV[0], corrV[1], corrV[2]);
-        for (int kk = 0; kk < 3; ++kk) {   // (#5 OpenMP-parallel momentum was tried + benchmarked -> 136× SLOWER, reverted)
-            DeviceBuffer<scalar> dIC,dBC,lIC,lBC; deviceBCDivCoeffs(dbU_.comp[kk],phiBnd_,dIC,dBC); deviceBCLaplacianCoeffsFace(dbU_.comp[kk],nuEffBnd,lIC,lBC);
-            deviceAxpy(-1.0,lIC,dIC); deviceAxpy(-1.0,lBC,dBC); iC[kk]=std::move(dIC); bCb[kk]=std::move(dBC);
+        for (int kk = 0; kk < 3; ++kk)   // (#5 OpenMP-parallel momentum was tried + benchmarked -> 136x SLOWER, reverted)
+        {
+            DeviceBuffer<scalar> dIC,dBC,lIC,lBC;
+            deviceBCDivCoeffs(dbU_.comp[kk],phiBnd_,dIC,dBC);
+            deviceBCLaplacianCoeffsFace(dbU_.comp[kk],nuEffBnd,lIC,lBC);
+            deviceAxpy(-1.0,lIC,dIC);
+            deviceAxpy(-1.0,lBC,dBC);
+            iC[kk]=std::move(dIC);
+            bCb[kk]=std::move(dBC);
             deviceHadamard(relaxSrc[kk], delta, Uk_[kk]);
             deviceAxpy(1.0, *ddr[kk], relaxSrc[kk]);                                  // += explicit divDevReff stress
             if (mrf_.active) deviceMrfCoriolis(mrf_, dm.V, Uk_[0], Uk_[1], Uk_[2], kk, relaxSrc[kk]);   // MRF Coriolis: -V*(Omega x U)_kk on zone cells
             // Explicit momentum corrections (linearUpwind deferred + non-orth laplacian) go into relaxSrc so they
             // feed BOTH the predictor solve AND H()/HbyA, OF's UEqn.H() includes them. Adding them only to the
             // predictor source leaves the corrector inconsistent and the U residual plateaus (does NOT reach 1e-6).
-            if (ctl_.linearUpwind || ctl_.lust) {   // deferred correction: source -= div(phi * grad(U_kk)_upwind.(Cf-C_up))
+            if (ctl_.linearUpwind || ctl_.lust)   // deferred correction: source -= div(phi * grad(U_kk)_upwind.(Cf-C_up))
+            {
                 DeviceBuffer<scalar> corr;
                 if (ctl_.linearUpwindV) corr = std::move(corrV[kk]);                          // vector-limited (computed once above)
                 else                    deviceLinearUpwindCorr(dm, phiInt_, gUx[kk], gUy[kk], gUz[kk], corr);
                 if (hasCyclic_) deviceCyclicAddLinUpwindCorr(cyc_, kk, gUx, gUy, gUz, corr);   // + cyclic-face linearUpwind (rotated nbr)
                 if (hasAMI_)    deviceAmiAddLinUpwindCorr(ami_, kk, gUx, gUy, gUz, corr);      // + AMI-face linearUpwind (rotated nbr stencil)
-                if (ctl_.lust) {   // OF LUST.H = 0.75*linear + 0.25*linearUpwind: scale the lU corr 0.25, add 0.75*linear corr
+                if (ctl_.lust)   // OF LUST.H = 0.75*linear + 0.25*linearUpwind: scale the lU corr 0.25, add 0.75*linear corr
+                {
                     deviceScale(corr, 0.25);
-                    DeviceBuffer<scalar> lc; deviceLinearCorr(dm, phiInt_, Uk_[kk], lc); deviceAxpy(0.75, lc, corr); }   // (cyclic linear part omitted; LUST cases are non-cyclic)
-                deviceAxpy(-1.0, corr, relaxSrc[kk]); }
-            if (ctl_.nonOrth) {        // -fvm::laplacian source correction: -= lapCorr(nuEff, grad(U_kk))
-                DeviceBuffer<scalar> lc; deviceLaplacianCorr(dm, nuEff_f, gUx[kk], gUy[kk], gUz[kk], lc);
+                    DeviceBuffer<scalar> lc;
+                    deviceLinearCorr(dm, phiInt_, Uk_[kk], lc);
+                    deviceAxpy(0.75, lc, corr);   // (cyclic linear part omitted; LUST cases are non-cyclic)
+                }
+                deviceAxpy(-1.0, corr, relaxSrc[kk]);
+            }
+            if (ctl_.nonOrth)   // -fvm::laplacian source correction: -= lapCorr(nuEff, grad(U_kk))
+            {
+                DeviceBuffer<scalar> lc;
+                deviceLaplacianCorr(dm, nuEff_f, gUx[kk], gUy[kk], gUz[kk], lc);
                 if (hasCyclic_) deviceCyclicAddLapCorr(cyc_, kk, nuEff, gUx, gUy, gUz, lc);   // + cyclic-face non-orth (rotated tensor)
                 if (hasAMI_)    deviceAmiAddLapCorr(ami_, kk, nuEff, gUx, gUy, gUz, lc);       // + AMI-face non-orth (rotated tensor stencil)
-                deviceAxpy(-nonOrthRelaxU, lc, relaxSrc[kk]); }
+                deviceAxpy(-nonOrthRelaxU, lc, relaxSrc[kk]);
+            }
             // constant body force (drives periodic channels) is an explicit momentum SOURCE: it must go into relaxSrc
             // so it feeds BOTH the predictor AND H()/HbyA (OF UEqn.H() includes fvOptions sources). Adding it only to
             // the predictor leaves HbyA short by rAU*g -> the corrector U = HbyA - rAU*grad(p) converges ~(1-relax) low.
@@ -403,15 +586,19 @@ public:
             // which mirrors meanVelocityForce's eqn += Su) -> relaxSrc -= (V/Vtot)*T*diskDir (a momentum sink/turbine).
             if (adActive_) deviceAxpy(-adT*(kk==0?adDiskDir_.x:kk==1?adDiskDir_.y:adDiskDir_.z)/adVtot_, adMaskVDisk_, relaxSrc[kk]);
             if (rotor_.active) deviceAxpy(-1.0, *rotorF[kk], relaxSrc[kk]);   // rotorDiskSource: relaxSrc -= force (OF eqn -= force)
-            DeviceBuffer<scalar> s; deviceHadamard(s, dm.V, *gg[kk]); deviceScale(s,-1.0); deviceAxpy(1.0,relaxSrc[kk],s);   // s = -V*grad(p) + relaxSrc (incl. body force)
-            // rotational cyclic deferred split (PREDICTOR only): the diag-implicit off-diagonal (ifCoeffC = ifCoeff·
-            // forwardT[kk][kk]) plus this off-diagonal MIXING term reconstructs the full-rotation coupling -ifCoeff·
-            // (forwardT·U[nbr])[kk] in the predictor RHS, but with a consistent (diagonal-dominant) matrix that
+            DeviceBuffer<scalar> s;
+            deviceHadamard(s, dm.V, *gg[kk]);
+            deviceScale(s,-1.0);
+            deviceAxpy(1.0,relaxSrc[kk],s);   // s = -V*grad(p) + relaxSrc (incl. body force)
+            // rotational cyclic deferred split (PREDICTOR only): the diag-implicit off-diagonal (ifCoeffC = ifCoeff.
+            // forwardT[kk][kk]) plus this off-diagonal MIXING term reconstructs the full-rotation coupling -ifCoeff.
+            // (forwardT.U[nbr])[kk] in the predictor RHS, but with a consistent (diagonal-dominant) matrix that
             // converges where OF's full-implicit limit-cycles in cf's segregated SIMPLE. Built from the U_old snapshot
             // (order-independent). H() below uses the FULL rotation on the post-solve U (OF-faithful), NOT this term.
             if (hasCyclic_ && cyc_.rotational) deviceCyclicAddDeferredRot(cyc_, Usnap[0], Usnap[1], Usnap[2], kk, s);
             if (hasAMI_ && ami_.rotational)    deviceAmiAddDeferredRot(ami_, Uint[0], Uint[1], Uint[2], kk, s);
-            DeviceBuffer<scalar> diagC,b; deviceFold(dm, mDiagR, s, iC[kk], bCb[kk], diagC, b);
+            DeviceBuffer<scalar> diagC,b;
+            deviceFold(dm, mDiagR, s, iC[kk], bCb[kk], diagC, b);
             // rotational: the implicit off-diagonal for component kk is scaled by forwardT[kk][kk] (OF transformCoupleField).
             const scalar* mIfc = !hasCyclic_ ? nullptr : (cyc_.rotational ? cyc_.ifCoeffC[kk].data() : cyc_.ifCoeff.data());
             const DeviceLduView mv = hasCyclic_
@@ -424,10 +611,12 @@ public:
             // OF fvVectorMatrix::solveSegregated solves each U component with the `U` lduMatrix solver (smoothSolver
             // /GaussSeidel for motorBike). Route through deviceSymGaussSeidel when fvSolution asks for it (robust on
             // anisotropic snappy cells where Jacobi-BiCGStab under-solves the loose relTol); interface LDUs keep BiCGStab.
-            scalar ur; DeviceSolverPerf uperf;
+            scalar ur;
+            DeviceSolverPerf uperf;
             if (ctl_.gsU && !hasCyclic_ && !hasAMI_)
                 ur = deviceSymGaussSeidel(mv, b, Uk_[kk], nf, tol, ctl_.relTolU, 5000, &uperf);
-            else {
+            else
+            {
                 uperf = deviceJacobiBiCGStab(mv, b, Uk_[kk], nf, tol, ctl_.relTolU, 5000, ctl_.bicgCheckEvery);
                 ur = uperf.initialResidual;
             }
@@ -442,88 +631,143 @@ public:
         // misses the constrained-component diagonal (bottom symmetry iC=(0,iC_v,0): iC[0]=0 but cmptAv=iC_v/3), which
         // on high-AR cells made rAU wildly too large -> catastrophic slip blowup. Reused below as the H() cmptAv term.
         DeviceBuffer<scalar> cmptAvIC;
-        if (hasSym_) { deviceCopy(cmptAvIC, iC[0]); deviceAxpy(1.0, iC[1], cmptAvIC); deviceAxpy(1.0, iC[2], cmptAvIC); deviceScale(cmptAvIC, 1.0/3.0); }
-        DeviceBuffer<scalar> diagA,dumb,rAU; deviceFold(dm,mDiagR,zeroSrc_, hasSym_ ? cmptAvIC : iC[0], zeroBndU_,diagA,dumb); deviceReciprocalV(dm,diagA,rAU);
+        if (hasSym_)
+        {
+            deviceCopy(cmptAvIC, iC[0]);
+            deviceAxpy(1.0, iC[1], cmptAvIC);
+            deviceAxpy(1.0, iC[2], cmptAvIC);
+            deviceScale(cmptAvIC, 1.0/3.0);
+        }
+        DeviceBuffer<scalar> diagA,dumb,rAU;
+        deviceFold(dm,mDiagR,zeroSrc_, hasSym_ ? cmptAvIC : iC[0], zeroBndU_,diagA,dumb);
+        deviceReciprocalV(dm,diagA,rAU);
         // SIMPLEC: rAtU = 1/(1/rAU - H1) = V/max(A*1, 0.1*diagA) (A*1 = row sum = deviceAmul with ones). drAtU = rAtU - rAU.
         DeviceBuffer<scalar> rAtU, drAtU;
-        if (ctl_.consistent) {
-            DeviceBuffer<scalar> rowSum; deviceAmul(hasCyclic_
+        if (ctl_.consistent)
+        {
+            DeviceBuffer<scalar> rowSum;
+            deviceAmul(hasCyclic_
                 ? deviceLduViewCyclic(dm, diagA, mUp, mLo, cyc_.n, cyc_.ownCell.data(), cyc_.nbrCell.data(), cyc_.ifCoeff.data())
                 : deviceLduView(dm, diagA, mUp, mLo), ones_, rowSum);
             deviceSimplecRAtU(dm, rowSum, diagA, rAtU);
-            deviceCopy(drAtU, rAtU); deviceAxpy(-1.0, rAU, drAtU);
-        } else deviceCopy(rAtU, rAU);
+            deviceCopy(drAtU, rAtU);
+            deviceAxpy(-1.0, rAU, drAtU);
+        }
+        else
+            deviceCopy(rAtU, rAU);
         // meanVelocityForce.correct (after the predictor, before H()/HbyA, like OF fvOptions.correct(U) in UEqn.H):
         // dGradP = relax*(|Ubar| - magUbarAve)/rAUave; accumulate gradP_; correct U += flowDir*rAU*dGradP. Reductions
         // and the body force/correction use maskV/mask01 so selectionMode all (whole field) and cellZone both work.
-        if (mvfActive_) {
+        if (mvfActive_)
+        {
             const scalar magUbarAve = (mvfFlowDir_.x*deviceDot(Uk_[0], mvfMaskV_) + mvfFlowDir_.y*deviceDot(Uk_[1], mvfMaskV_)
                                      + mvfFlowDir_.z*deviceDot(Uk_[2], mvfMaskV_)) / mvfVtot_;
             const scalar rAUave = deviceDot(rAU, mvfMaskV_) / mvfVtot_;
             const scalar dGradP = mvfRelax_ * (mvfUbarMag_ - magUbarAve) / rAUave;
             mvfGradP_ += dGradP;
             if (std::getenv("BRAE_MVF_DEBUG")) std::printf("    mvf: magUbarAve=%.6g rAUave=%.6g dGradP=%.6g gradP=%.6g\n", magUbarAve, rAUave, dGradP, mvfGradP_);
-            DeviceBuffer<scalar> rAUm; deviceHadamard(rAUm, rAU, mvfMask01_);              // rAU in the selection, 0 else
-            deviceAxpy(mvfFlowDir_.x*dGradP, rAUm, Uk_[0]); deviceAxpy(mvfFlowDir_.y*dGradP, rAUm, Uk_[1]); deviceAxpy(mvfFlowDir_.z*dGradP, rAUm, Uk_[2]);
+            DeviceBuffer<scalar> rAUm;
+            deviceHadamard(rAUm, rAU, mvfMask01_);              // rAU in the selection, 0 else
+            deviceAxpy(mvfFlowDir_.x*dGradP, rAUm, Uk_[0]);
+            deviceAxpy(mvfFlowDir_.y*dGradP, rAUm, Uk_[1]);
+            deviceAxpy(mvfFlowDir_.z*dGradP, rAUm, Uk_[2]);
         }
         if (limUActive_) deviceFvoLimitVelocity(limUCells_, limUMax_, Uk_[0], Uk_[1], Uk_[2]);   // limitVelocity on the predictor U (OF fvOptions.correct) -> feeds H()/HbyA
         // slip/symmetry H() consistency term: OF UEqn.H() adds (cmptAv(iC) - iC_cmpt)*psi_cmpt per component, where
         // cmptAv = mean of the 3 boundary internalCoeffs (fvMatrix::H + addCmptAvBoundaryDiag). Zero for every
         // component-independent BC (iC_cmpt == cmptAv), nonzero ONLY for slip (per-component vf=|n_k|), it supplies
-        // the HbyA↔rAU consistency that a single scalar rAU otherwise breaks at a non-axis-aligned wall.
+        // the HbyA<->rAU consistency that a single scalar rAU otherwise breaks at a non-axis-aligned wall.
         DeviceBuffer<scalar>& cmptAvH = cmptAvIC;   // same cmptAv(iC) already computed for the rAU diagonal above
         DeviceBuffer<scalar> HbyA[3];
-        { DeviceBuffer<scalar> Hk[3];
-          // cyclicAMI H: precompute the AMI-interpolated (rotated) neighbour U once for the vector, then H[own] -=
-          // ifCoeff*UNbr[kk]/V per component (= OF UEqn.H() with the AMI weighted stencil).
-          DeviceBuffer<scalar> UNx, UNy, UNz;
-          if (hasAMI_) deviceAmiInterpolateVec(ami_, Uk_[0], Uk_[1], Uk_[2], UNx, UNy, UNz);
-          DeviceBuffer<scalar>* UN[3] = { &UNx, &UNy, &UNz };
-          for (int kk = 0; kk < 3; ++kk) {
-              DeviceBuffer<scalar> bdH;   // slip: bdDiag = cmptAv(iC) - iC[kk] (OF H() term); else zero (bit-identical)
-              if (hasSym_) { deviceCopy(bdH, cmptAvH); deviceAxpy(-1.0, iC[kk], bdH); }
-              deviceMatrixH(Uview, dm, Uk_[kk], relaxSrc[kk], hasSym_ ? bdH : zeroBndU_, bCb[kk], Hk[kk]);
-              if (hasCyclic_ && !cyc_.rotational) deviceCyclicAddH(cyc_, Uk_[kk], dm.V, Hk[kk]);   // translational off-diag
-              if (hasAMI_) deviceAmiAddH(ami_, *UN[kk], dm.V, Hk[kk]); }
-          // rotational cyclic H: the FULL rotation -ifCoeff·(forwardT·U[nbr])[kk] on the POST-solve U, evaluated once
-          // for the whole vector (matches OF UEqn.H(), which re-evaluates patchNeighbourField from the new U). The
-          // deferred mixing fed only the PREDICTOR; H is the exact full-rotation explicit coupling, consistent across
-          // components, so HbyA/phiHbyA carry the true rotated neighbour momentum, not a per-component-stale value.
-          if (hasCyclic_ && cyc_.rotational) deviceCyclicAddHRot(cyc_, Uk_[0], Uk_[1], Uk_[2], dm.V, Hk[0], Hk[1], Hk[2]);
-          for (int kk = 0; kk < 3; ++kk) deviceHadamard(HbyA[kk], rAU, Hk[kk]); }
-        DeviceBuffer<scalar> phiHi; deviceVectorFlux(dm, HbyA[0], HbyA[1], HbyA[2], phiHi);   // flux of the ORIGINAL HbyA
-        if (hasCyclic_) { if (cyc_.rotational) deviceCyclicFluxRot(cyc_, HbyA[0], HbyA[1], HbyA[2]);   // rotate the neighbour HbyA
-                          else deviceCyclicFlux(cyc_, HbyA[0], HbyA[1], HbyA[2]); }   // cyclic-face phiHbyA = interp(HbyA).Sf -> cyc_.phi
-        if (hasAMI_) deviceAmiFlux(ami_, HbyA[0], HbyA[1], HbyA[2]);   // AMI-face phiHbyA = (w*HbyA[own]+(1-w)*interp(HbyA[nbr]))·Sf
-        DeviceBuffer<scalar> hxb,hyb,hzb; deviceBCValue(dbU_.comp[0],HbyA[0],hxb); deviceBCValue(dbU_.comp[1],HbyA[1],hyb); deviceBCValue(dbU_.comp[2],HbyA[2],hzb);
+        {
+            DeviceBuffer<scalar> Hk[3];
+            // cyclicAMI H: precompute the AMI-interpolated (rotated) neighbour U once for the vector, then H[own] -=
+            // ifCoeff*UNbr[kk]/V per component (= OF UEqn.H() with the AMI weighted stencil).
+            DeviceBuffer<scalar> UNx, UNy, UNz;
+            if (hasAMI_) deviceAmiInterpolateVec(ami_, Uk_[0], Uk_[1], Uk_[2], UNx, UNy, UNz);
+            DeviceBuffer<scalar>* UN[3] = { &UNx, &UNy, &UNz };
+            for (int kk = 0; kk < 3; ++kk)
+            {
+                DeviceBuffer<scalar> bdH;   // slip: bdDiag = cmptAv(iC) - iC[kk] (OF H() term); else zero (bit-identical)
+                if (hasSym_)
+                {
+                    deviceCopy(bdH, cmptAvH);
+                    deviceAxpy(-1.0, iC[kk], bdH);
+                }
+                deviceMatrixH(Uview, dm, Uk_[kk], relaxSrc[kk], hasSym_ ? bdH : zeroBndU_, bCb[kk], Hk[kk]);
+                if (hasCyclic_ && !cyc_.rotational) deviceCyclicAddH(cyc_, Uk_[kk], dm.V, Hk[kk]);   // translational off-diag
+                if (hasAMI_) deviceAmiAddH(ami_, *UN[kk], dm.V, Hk[kk]);
+            }
+            // rotational cyclic H: the FULL rotation -ifCoeff.(forwardT.U[nbr])[kk] on the POST-solve U, evaluated once
+            // for the whole vector (matches OF UEqn.H(), which re-evaluates patchNeighbourField from the new U). The
+            // deferred mixing fed only the PREDICTOR; H is the exact full-rotation explicit coupling, consistent across
+            // components, so HbyA/phiHbyA carry the true rotated neighbour momentum, not a per-component-stale value.
+            if (hasCyclic_ && cyc_.rotational) deviceCyclicAddHRot(cyc_, Uk_[0], Uk_[1], Uk_[2], dm.V, Hk[0], Hk[1], Hk[2]);
+            for (int kk = 0; kk < 3; ++kk)
+                deviceHadamard(HbyA[kk], rAU, Hk[kk]);
+        }
+        DeviceBuffer<scalar> phiHi;
+        deviceVectorFlux(dm, HbyA[0], HbyA[1], HbyA[2], phiHi);   // flux of the ORIGINAL HbyA
+        if (hasCyclic_)
+        {
+            if (cyc_.rotational) deviceCyclicFluxRot(cyc_, HbyA[0], HbyA[1], HbyA[2]);   // rotate the neighbour HbyA
+            else deviceCyclicFlux(cyc_, HbyA[0], HbyA[1], HbyA[2]);   // cyclic-face phiHbyA = interp(HbyA).Sf -> cyc_.phi
+        }
+        if (hasAMI_) deviceAmiFlux(ami_, HbyA[0], HbyA[1], HbyA[2]);   // AMI-face phiHbyA = (w*HbyA[own]+(1-w)*interp(HbyA[nbr])).Sf
+        DeviceBuffer<scalar> hxb,hyb,hzb;
+        deviceBCValue(dbU_.comp[0],HbyA[0],hxb);
+        deviceBCValue(dbU_.comp[1],HbyA[1],hyb);
+        deviceBCValue(dbU_.comp[2],HbyA[2],hzb);
         // constrainHbyA at mixed velocity faces (OF resets phiHbyA_b = U_b.Sf at fixesValue patches): use U_b not HbyA_b.
         if (hasMixed_) deviceConstrainMixedHbyA(dbU_, Uk_[0], Uk_[1], Uk_[2], hxb, hyb, hzb);
         // slip/symmetry: OF constrainHbyA sets HbyA_b = U_b (= U.boundaryField, the slipped velocity) at every
         // non-assignable patch, NOT the projected HbyA. Project the cell U (HbyA_b = U_c - n(n.U_c) = U_b), matching
         // OF byte-for-byte and the mixed path above (both use U_b). Wall flux is still exactly 0 (normal removed).
         if (hasSym_) deviceConstrainSymmetryHbyA(dbU_, Uk_[0], Uk_[1], Uk_[2], hxb, hyb, hzb);
-        DeviceBuffer<scalar> phiHb; deviceBoundaryFlux(dm,hxb,hyb,hzb,phiHb);
+        DeviceBuffer<scalar> phiHb;
+        deviceBoundaryFlux(dm,hxb,hyb,hzb,phiHb);
         if (mrf_.active) deviceMrfApplyFrameFlux(mrf_, +1.0, phiHi, phiHb);   // MRF.makeRelative(phiHbyA) before pressure
         // adjustPhi (OF order: after flux(HbyA), before the SIMPLEC correction): enforce global continuity by
         // scaling the adjustable outflow when there is no pressure reference (closed/all-velocity domains).
         if (ctl_.needRef) deviceAdjustPhi(adjustMask_, phiHb);
-        if (ctl_.consistent) {
+        if (ctl_.consistent)
+        {
             // phiHbyA += interpolate(rAtU-rAU)*snGrad(p)*magSf = laplacian(interp(drAtU), p).flux()  (NOT via HbyA flux)
-            DeviceBuffer<scalar> drAtUf; deviceInterpolate(dm, drAtU, drAtUf);
-            DeviceBuffer<scalar> ld, lu, ll; deviceLaplacianCoeffs(dm, drAtUf, ld, lu, ll, ctl_.nonOrth);   // over-relaxed nonOrthDeltaCoeffs to match OF's corrected snGrad(p) (was orthogonal dc -> cos(theta) too small on non-orth meshes)
-            DeviceBuffer<scalar> fInt; deviceMatrixFluxInternal(deviceLduView(dm, ld, lu, ll), dp_, fInt); deviceAxpy(1.0, fInt, phiHi);
+            DeviceBuffer<scalar> drAtUf;
+            deviceInterpolate(dm, drAtU, drAtUf);
+            DeviceBuffer<scalar> ld, lu, ll;
+            deviceLaplacianCoeffs(dm, drAtUf, ld, lu, ll, ctl_.nonOrth);   // over-relaxed nonOrthDeltaCoeffs to match OF's corrected snGrad(p) (was orthogonal dc -> cos(theta) too small on non-orth meshes)
+            DeviceBuffer<scalar> fInt;
+            deviceMatrixFluxInternal(deviceLduView(dm, ld, lu, ll), dp_, fInt);
+            deviceAxpy(1.0, fInt, phiHi);
             // OF's term is interp(rAtU-rAU)*fvc::snGrad(p)*magSf, and snGrad(p) is the CORRECTED snGrad (orth + non-orth).
-            // The orth part is the laplacian flux above; add the non-orth part interp(drAtU)*(corrVec·grad(p)_f)*magSf so
-            // the SIMPLEC flux correction is complete on non-orthogonal meshes (no-op when orthogonal: corrVec≈0).
-            if (ctl_.nonOrth) { DeviceBuffer<scalar> ffcS; deviceLaplacianCorrFlux(dm, drAtUf, gx, gy, gz, ffcS); deviceAxpy(1.0, ffcS, phiHi); }
-            DeviceBuffer<scalar> dIC, dBC; deviceBCLaplacianCoeffs(dbP_, drAtU, dIC, dBC);
-            DeviceBuffer<scalar> fBnd; deviceMatrixFluxBoundary(dbP_, dIC, dBC, dp_, fBnd); deviceAxpy(1.0, fBnd, phiHb);
+            // The orth part is the laplacian flux above; add the non-orth part interp(drAtU)*(corrVec.grad(p)_f)*magSf so
+            // the SIMPLEC flux correction is complete on non-orthogonal meshes (no-op when orthogonal: corrVec~=0).
+            if (ctl_.nonOrth)
+            {
+                DeviceBuffer<scalar> ffcS;
+                deviceLaplacianCorrFlux(dm, drAtUf, gx, gy, gz, ffcS);
+                deviceAxpy(1.0, ffcS, phiHi);
+            }
+            DeviceBuffer<scalar> dIC, dBC;
+            deviceBCLaplacianCoeffs(dbP_, drAtU, dIC, dBC);
+            DeviceBuffer<scalar> fBnd;
+            deviceMatrixFluxBoundary(dbP_, dIC, dBC, dp_, fBnd);
+            deviceAxpy(1.0, fBnd, phiHb);
             // HbyA adjustment AFTER the flux (feeds the velocity corrector only): HbyA -= (rAU-rAtU)*grad(p)
-            for (int kk = 0; kk < 3; ++kk) { DeviceBuffer<scalar> t; deviceHadamard(t, drAtU, *gg[kk]); deviceAxpy(1.0, t, HbyA[kk]); } }
-        DeviceBuffer<scalar> rAUf; deviceInterpolate(dm,rAtU,rAUf);
+            for (int kk = 0; kk < 3; ++kk)
+            {
+                DeviceBuffer<scalar> t;
+                deviceHadamard(t, drAtU, *gg[kk]);
+                deviceAxpy(1.0, t, HbyA[kk]);
+            }
+        }
+        DeviceBuffer<scalar> rAUf;
+        deviceInterpolate(dm,rAtU,rAUf);
         // pressure matrix buffers are PERSISTENT members: their addresses stay fixed across SIMPLE steps (only the
         // values change), so the V-cycle CUDA graph (keyed on diagCp_) is captured once and replayed every step.
-        DeviceBuffer<scalar> pPrev; deviceCopy(pPrev, dp_);   // p entering the pressure step (for relaxation), captured once
+        DeviceBuffer<scalar> pPrev;
+        deviceCopy(pPrev, dp_);   // p entering the pressure step (for relaxation), captured once
         // nNonOrthogonalCorrectors (OF SIMPLE, pEqn.H `while (simple.correctNonOrthogonal())`): re-solve
         // laplacian(rAtU,p) == div(phiHbyA) (nNonOrth+1) times, recomputing the EXPLICIT non-orthogonal correction
         // (corrVec.grad(p)) from the UPDATED p each pass; the conservative flux is committed only on the final pass.
@@ -535,16 +779,20 @@ public:
         const int nPass = (ctl_.nonOrth ? ctl_.nNonOrth : 0) + 1;
         DeviceBuffer<scalar> pIC, pBC, ffcP, ffcPcyc, ffcPami;
         DeviceSolverPerf pp, pp0;
-        for (int nonOrthPass = 0; nonOrthPass < nPass; ++nonOrthPass) {
-            if (nonOrthPass > 0) {   // recompute grad(p) from the just-solved p (pass 0 uses the entry grad in gx/gy/gz)
-                DeviceBuffer<scalar> pbvN; deviceBCValue(dbP_, dp_, pbvN);
+        for (int nonOrthPass = 0; nonOrthPass < nPass; ++nonOrthPass)
+        {
+            if (nonOrthPass > 0)   // recompute grad(p) from the just-solved p (pass 0 uses the entry grad in gx/gy/gz)
+            {
+                DeviceBuffer<scalar> pbvN;
+                deviceBCValue(dbP_, dp_, pbvN);
                 deviceGaussGrad(dm, dp_, pbvN, gx, gy, gz);
                 if (hasCyclic_) deviceCyclicAddGrad(cyc_, dp_, dm.V, gx, gy, gz);
                 if (hasAMI_)    deviceAmiAddGrad(ami_, dp_, dm.V, gx, gy, gz);
             }
             deviceLaplacianCoeffs(dm, rAUf, pD_, pU_, pL_, ctl_.nonOrth);
             deviceBCLaplacianCoeffs(dbP_, rAtU, pIC, pBC);
-            DeviceBuffer<scalar> divPhiH; deviceDiv(dm, phiHi, phiHb, divPhiH);
+            DeviceBuffer<scalar> divPhiH;
+            deviceDiv(dm, phiHi, phiHb, divPhiH);
             if (hasCyclic_) deviceCyclicAddDiv(cyc_, dm.V, divPhiH);            // + cyclic-face flux into continuity div(phiHbyA)
             if (hasAMI_)    deviceAmiAddDiv(ami_, dm.V, divPhiH);               // + AMI-face flux into continuity div(phiHbyA)
             deviceFoldPressure(dm, pD_, divPhiH, pIC, pBC, diagCp_, bp_);
@@ -553,18 +801,31 @@ public:
             if (hasAMI_)    deviceAmiAssembleLaplacian(ami_, rAtU, diagCp_, /*addToDiag*/true);   // AMI pressure laplacian
             // explicit non-orth correction: faceFluxCorr from grad(p) for THIS pass; add -V*div(ffc) to b, and subtract
             // ffc from the reconstructed flux below (so div(phi)=0 on non-orth faces). gx/gy/gz = grad(p) this pass.
-            ffcP = DeviceBuffer<scalar>(); ffcPcyc = DeviceBuffer<scalar>(); ffcPami = DeviceBuffer<scalar>();
-            if (ctl_.nonOrth) { deviceLaplacianCorrFluxLimited(dm, rAUf, dp_, gx, gy, gz, nonOrthLimitP, ffcP);
-                DeviceBuffer<scalar> sc; deviceFaceDivSource(dm, ffcP, sc); deviceAxpy(1.0, sc, bp_);
+            ffcP = DeviceBuffer<scalar>();
+            ffcPcyc = DeviceBuffer<scalar>();
+            ffcPami = DeviceBuffer<scalar>();
+            if (ctl_.nonOrth)
+            {
+                deviceLaplacianCorrFluxLimited(dm, rAUf, dp_, gx, gy, gz, nonOrthLimitP, ffcP);
+                DeviceBuffer<scalar> sc;
+                deviceFaceDivSource(dm, ffcP, sc);
+                deviceAxpy(1.0, sc, bp_);
                 if (hasCyclic_) deviceCyclicLapCorrP(cyc_, rAtU, gx, gy, gz, bp_, ffcPcyc);
-                if (hasAMI_)    deviceAmiLapCorrP(ami_, rAtU, gx, gy, gz, bp_, ffcPami); }
+                if (hasAMI_)    deviceAmiLapCorrP(ami_, rAtU, gx, gy, gz, bp_, ffcPami);
+            }
             // No fixedValue-p patch -> singular all-Neumann pressure. cyclic/AMI use a tiny SYMMETRIC diagonal shift
             // (the periodic RHS is zero-mean); non-cyclic keeps the OF single-cell setReference (doubles a fresh diag).
-            if (ctl_.needRef) {
-                if (hasCyclic_ || hasAMI_) { const scalar eps = -1e-10 * (deviceSumMag(diagCp_) / nC_); deviceAxpy(eps, ones_, diagCp_); }
+            if (ctl_.needRef)
+            {
+                if (hasCyclic_ || hasAMI_)
+                {
+                    const scalar eps = -1e-10 * (deviceSumMag(diagCp_) / nC_);
+                    deviceAxpy(eps, ones_, diagCp_);
+                }
                 else deviceSetReference(diagCp_, bp_, ctl_.pRefCell, ctl_.pRefValue);
             }
-            if (hasCyclic_ || hasAMI_) {
+            if (hasCyclic_ || hasAMI_)
+            {
                 // Periodic/AMI: interface-coupled operator solved with Jacobi-PCG (no AMG; the internal-face Galerkin
                 // coarse operator cannot represent the interface edges).
                 const DeviceLduView pvc = hasCyclic_
@@ -572,43 +833,63 @@ public:
                     : deviceLduViewAmi(dm,diagCp_,pU_,pL_, ami_.n, ami_.ownCell.data(), ami_.off.data(), ami_.nbrCell.data(), ami_.weight.data(), ami_.ifCoeff.data());
                 const scalar nfp = deviceNormFactor(pvc, dp_, bp_, ones_);
                 pp = deviceJacobiPCG(pvc, bp_, dp_, nfp, ctl_.tolP, ctl_.relTolP, 3000);
-            } else {
+            }
+            else
+            {
                 const scalar nfp = deviceNormFactor(deviceLduView(dm,diagCp_,pU_,pL_), dp_, bp_, ones_);
                 amgGalerkin(amg_, diagCp_, pU_, pL_);                                      // re-coarsen the pressure matrix
                 pp = deviceAMGPCG(deviceLduView(dm,diagCp_,pU_,pL_), amg_, bp_, dp_, nfp, ctl_.tolP, ctl_.relTolP, 3000, ctl_.useGraph, ctl_.pcgCheckEvery, ctl_.corrScaling);
             }
             if (nonOrthPass == 0) pp0 = pp;   // SIMPLE residualControl uses the FIRST pass's initial residual (OF convention)
         }
-        res.p = pp0.initialResidual; res.pFinal = pp.finalResidual; res.pIters = pp.nIterations;
+        res.p = pp0.initialResidual;
+        res.pFinal = pp.finalResidual;
+        res.pIters = pp.nIterations;
         if (std::getenv("BRAE_SOLVER_DEBUG")) std::printf("    p %s iters=%d  init=%.2e final=%.2e\n",
                                                         (hasCyclic_||hasAMI_)?"Jacobi-PCG":"AMG-PCG", pp.nIterations, pp.initialResidual, pp.finalResidual);
         const DeviceLduView pview = deviceLduView(dm,diagCp_,pU_,pL_);
-        DeviceBuffer<scalar> pfi; deviceMatrixFluxInternal(pview, dp_, pfi); deviceCopy(phiInt_, phiHi); deviceAxpy(-1.0, pfi, phiInt_);
+        DeviceBuffer<scalar> pfi;
+        deviceMatrixFluxInternal(pview, dp_, pfi);
+        deviceCopy(phiInt_, phiHi);
+        deviceAxpy(-1.0, pfi, phiInt_);
         if (ctl_.nonOrth) deviceAxpy(-1.0, ffcP, phiInt_);   // phi -= faceFluxCorrection (continuity on non-orth faces)
-        DeviceBuffer<scalar> pfb; deviceMatrixFluxBoundary(dbP_, pIC, pBC, dp_, pfb); deviceCopy(phiBnd_, phiHb); deviceAxpy(-1.0, pfb, phiBnd_);
+        DeviceBuffer<scalar> pfb;
+        deviceMatrixFluxBoundary(dbP_, pIC, pBC, dp_, pfb);
+        deviceCopy(phiBnd_, phiHb);
+        deviceAxpy(-1.0, pfb, phiBnd_);
         if (hasCyclic_) deviceCyclicCorrectFlux(cyc_, dp_);   // cyc_.phi -= ifCoeff*(p_nbr - p_own) : conservative periodic flux (pre-relax dp_)
         if (hasAMI_)    deviceAmiCorrectFlux(ami_, dp_);       // ami_.phi -= ifCoeff*(interp(p_nbr) - p_own)
         if (hasCyclic_ && ctl_.nonOrth && ffcPcyc.size()) deviceAxpy(-1.0, ffcPcyc, cyc_.phi);   // cyclic-face non-orth flux correction (matches phiInt_ -= ffcP)
         if (hasAMI_ && ctl_.nonOrth && ffcPami.size()) deviceAxpy(-1.0, ffcPami, ami_.phi);       // AMI-face non-orth flux correction
-        deviceScale(dp_, ctl_.relaxP); deviceAxpy(1.0 - ctl_.relaxP, pPrev, dp_);
-        DeviceBuffer<scalar> pbv2; deviceBCValue(dbP_, dp_, pbv2);
-        DeviceBuffer<scalar> gnx,gny,gnz; deviceGaussGrad(dm, dp_, pbv2, gnx,gny,gnz);
+        deviceScale(dp_, ctl_.relaxP);
+        deviceAxpy(1.0 - ctl_.relaxP, pPrev, dp_);
+        DeviceBuffer<scalar> pbv2;
+        deviceBCValue(dbP_, dp_, pbv2);
+        DeviceBuffer<scalar> gnx,gny,gnz;
+        deviceGaussGrad(dm, dp_, pbv2, gnx,gny,gnz);
         if (hasCyclic_) deviceCyclicAddGrad(cyc_, dp_, dm.V, gnx,gny,gnz);   // + cyclic-face contribution to grad(p)
         if (hasAMI_)    deviceAmiAddGrad(ami_, dp_, dm.V, gnx,gny,gnz);       // + AMI-face contribution to grad(p)
         DeviceBuffer<scalar>* gn[3]={&gnx,&gny,&gnz};
-        for (int kk = 0; kk < 3; ++kk) { DeviceBuffer<scalar> Un; deviceCorrector(HbyA[kk], rAtU, *gn[kk], Un); Uk_[kk]=std::move(Un); }   // SIMPLEC: rAtU
+        for (int kk = 0; kk < 3; ++kk)   // SIMPLEC: rAtU
+        {
+            DeviceBuffer<scalar> Un;
+            deviceCorrector(HbyA[kk], rAtU, *gn[kk], Un);
+            Uk_[kk]=std::move(Un);
+        }
         // limitVelocity (fvOptions.correct): clamp |U| <= max on the corrected (output) velocity. OF clamps after the
         // momentum predictor; cf clamps the post-corrector U so the WRITTEN field is bounded (matches OF's output).
         if (limUActive_) deviceFvoLimitVelocity(limUCells_, limUMax_, Uk_[0], Uk_[1], Uk_[2]);
 
         clearTurbulenceReport();   // OF-style report: collect this step's turbulence solves (Solving for k/omega/...)
-        if (ctl_.turbulent) {
+        if (ctl_.turbulent)
+        {
             if (ctl_.sa)    // one-equation: dk_ slot holds nuTilda; relaxK/limitedK/twoBykK carry the nuTilda settings
                 deviceSpalartAllmarasCorrect(dm, dbU_, dbK_, Uk_[0], Uk_[1], Uk_[2], dk_, dnut_, y_, phiInt_, phiBnd_,
                                              ctl_.nu, ctl_.relaxK, ctl_.tolKE, ctl_.bounded, ctl_.limitedK, ctl_.twoBykK,
                                              ctl_.saCoeffs, ctl_.relTolKE, ctl_.bicgCheckEvery, ctl_.luK, ctl_.nonOrth,
                                              ctl_.gsK, hasAMI_ ? &ami_ : nullptr, hasCyclic_ ? &cyc_ : nullptr);
-            else if (ctl_.sst) {   // de_ slot holds omega; relaxEps/limitedEps/twoBykEps carry the omega-equation settings
+            else if (ctl_.sst)   // de_ slot holds omega; relaxEps/limitedEps/twoBykEps carry the omega-equation settings
+            {
                 deviceKOmegaSSTCorrect(dm, wall_, dbEps_, dbK_, dbU_, Uk_[0], Uk_[1], Uk_[2], dk_, de_, dnut_, y_,
                                        phiInt_, phiBnd_, ctl_.nu, ctl_.relaxEps, ctl_.relaxK, ctl_.tolKE, ctl_.bounded,
                                        ctl_.limitedK, ctl_.limitedEps, ctl_.twoBykK, ctl_.twoBykEps, ctl_.ksstCoeffs, ctl_.relTolKE, ctl_.bicgCheckEvery,
@@ -629,8 +910,10 @@ public:
         // OF continuityErrs.H: contErr = fvc::div(phi) on the CORRECTED flux; sum local = sum(V|contErr|)/sumV,
         // global = sum(V contErr)/sumV. deviceDiv gives Sum(phi)/V per cell, so R = V*div = the cell flux balance.
         {
-            DeviceBuffer<scalar> divPhi; deviceDiv(dm, phiInt_, phiBnd_, divPhi);
-            DeviceBuffer<scalar> R; deviceHadamard(R, divPhi, dm.V);
+            DeviceBuffer<scalar> divPhi;
+            deviceDiv(dm, phiInt_, phiBnd_, divPhi);
+            DeviceBuffer<scalar> R;
+            deviceHadamard(R, divPhi, dm.V);
             const scalar sumV = deviceDot(dm.V, ones_) + 1e-300;
             res.contLocal  = deviceSumMag(R) / sumV;
             res.contGlobal = deviceDot(R, ones_) / sumV;
@@ -640,71 +923,126 @@ public:
 
     // Enable an MRF rotating zone: builds the device frame data + makes the resident flux RELATIVE (so the
     // momentum/pressure are solved in the rotating frame). Call once after construction, before stepping.
-    void setMRF(const MRFZone& z, const PrimitiveMesh& m, const FvGeometry& g,
-                const std::vector<std::string>& nonRotating = {}) {
+    void setMRF(
+        const MRFZone& z,
+        const PrimitiveMesh& m,
+        const FvGeometry& g,
+        const std::vector<std::string>& nonRotating = {})
+    {
         mrf_ = buildDeviceMRF(z, m, g, fvp_, nonRotating);
         deviceMrfApplyFrameFlux(mrf_, +1.0, phiInt_, phiBnd_);     // initial phi -> relative (OF createFields)
         // NOTE: MRF is NOT applied to the cyclic/cyclicAMI interface flux. Ground truth: OF never combines MRF with
         // cyclicAMI (0/12 MRF tutorials use AMI, all use conformal multi-zone meshes; rotating AMI is done by a
-        // MOVING MESH in transient solvers, not MRF). So there is no MRF×AMI pattern to support here.
+        // MOVING MESH in transient solvers, not MRF). So there is no MRF x AMI pattern to support here.
     }
 
     // Enable fvOptions (system/fvOptions). Empty data -> every hook below stays a no-op (bit-identical to no file),
     // exactly like fv::options::New on a case without the dict. Copies the precomputed per-cell source terms to the
     // device. Call once after construction. The momentum source feeds relaxSrc (so it reaches BOTH the predictor and
     // H()/HbyA, like the body force / OF UEqn.H fvOptions(U)); the implicit Sp lowers the momentum diagonal.
-    void setFvOptions(const FvOptionsData& fo) {
+    void setFvOptions(const FvOptionsData& fo)
+    {
         hasFvoMom_ = fo.hasMomentum;
-        if (fo.hasMomentum) {
-            for (int c = 0; c < 3; ++c) fvoMomSu_[c].copyFrom(fo.momSu[c]);
+        if (fo.hasMomentum)
+        {
+            for (int c = 0; c < 3; ++c)
+                fvoMomSu_[c].copyFrom(fo.momSu[c]);
             if (!fo.momSp.empty()) fvoMomSp_.copyFrom(fo.momSp);
         }
-        for (const auto& s : fo.scaSu) fvoScaSu_[s.first].copyFrom(s.second);   // scalar (k/epsilon/…) sources
-        for (const auto& s : fo.scaSp) fvoScaSp_[s.first].copyFrom(s.second);
-        if (fo.porActive) { por_.active = true; por_.d = fo.porD; por_.f = fo.porF; por_.cells.copyFrom(fo.porCells); }
-        if (fo.mvfActive) {
-            mvfActive_ = true; mvfRelax_ = fo.mvfRelax;
+        for (const auto& s : fo.scaSu)
+            fvoScaSu_[s.first].copyFrom(s.second);   // scalar (k/epsilon/...) sources
+        for (const auto& s : fo.scaSp)
+            fvoScaSp_[s.first].copyFrom(s.second);
+        if (fo.porActive)
+        {
+            por_.active = true;
+            por_.d = fo.porD;
+            por_.f = fo.porF;
+            por_.cells.copyFrom(fo.porCells);
+        }
+        if (fo.mvfActive)
+        {
+            mvfActive_ = true;
+            mvfRelax_ = fo.mvfRelax;
             const scalar m = std::sqrt(fo.mvfUbar.x*fo.mvfUbar.x + fo.mvfUbar.y*fo.mvfUbar.y + fo.mvfUbar.z*fo.mvfUbar.z);
-            mvfUbarMag_ = m; mvfFlowDir_ = m > 0 ? vector{fo.mvfUbar.x/m, fo.mvfUbar.y/m, fo.mvfUbar.z/m} : vector{1,0,0};
+            mvfUbarMag_ = m;
+            mvfFlowDir_ = m > 0 ? vector{fo.mvfUbar.x/m, fo.mvfUbar.y/m, fo.mvfUbar.z/m} : vector{1,0,0};
             std::vector<scalar> m01(nC_, fo.mvfCells.empty() ? 1.0 : 0.0);   // selectionMode all -> ones; cellZone -> 1 in zone
-            for (label c : fo.mvfCells) if (c >= 0 && c < nC_) m01[c] = 1.0;
+            for (label c : fo.mvfCells)
+                if (c >= 0 && c < nC_) m01[c] = 1.0;
             mvfMask01_.copyFrom(m01);
             deviceHadamard(mvfMaskV_, dm_.V, mvfMask01_);                     // maskV = V in the selection (0 else)
             mvfVtot_ = deviceSumMag(mvfMaskV_);                               // total selection volume
         }
-        if (fo.limUActive) {
-            limUActive_ = true; limUMax_ = fo.limUMax;
+        if (fo.limUActive)
+        {
+            limUActive_ = true;
+            limUMax_ = fo.limUMax;
             std::vector<label> lc = fo.limUCells;
-            if (lc.empty()) { lc.resize(nC_); for (label c = 0; c < nC_; ++c) lc[c] = c; }   // selectionMode all
+            if (lc.empty())   // selectionMode all
+            {
+                lc.resize(nC_);
+                for (label c = 0; c < nC_; ++c)
+                    lc[c] = c;
+            }
             limUCells_.copyFrom(lc);
         }
-        if (fo.vdcActive) {
-            vdcActive_ = true; vdcUMax_ = fo.vdcUMax; vdcC_ = fo.vdcC;
+        if (fo.vdcActive)
+        {
+            vdcActive_ = true;
+            vdcUMax_ = fo.vdcUMax;
+            vdcC_ = fo.vdcC;
             std::vector<label> vc = fo.vdcCells;
-            if (vc.empty()) { vc.resize(nC_); for (label c = 0; c < nC_; ++c) vc[c] = c; }   // selectionMode all
+            if (vc.empty())   // selectionMode all
+            {
+                vc.resize(nC_);
+                for (label c = 0; c < nC_; ++c)
+                    vc[c] = c;
+            }
             vdcCells_.copyFrom(vc);
         }
-        if (fo.adActive) {
-            adActive_ = true; adDiskDir_ = fo.adDiskDir; adArea_ = fo.adArea; adA_ = fo.adA;
-            std::vector<scalar> dm01(nC_, 0.0); for (label c : fo.adDiskCells) if (c>=0 && c<nC_) dm01[c] = 1.0;
-            DeviceBuffer<scalar> dmask; dmask.copyFrom(dm01);
-            deviceHadamard(adMaskVDisk_, dm_.V, dmask); adVtot_ = deviceSumMag(adMaskVDisk_);   // V in disk / total disk volume
-            std::vector<scalar> mon(nC_, 0.0); for (label c : fo.adMonitorCells) if (c>=0 && c<nC_) mon[c] = 1.0;
-            adMonMask01_.copyFrom(mon); adNmon_ = (scalar)fo.adMonitorCells.size();
+        if (fo.adActive)
+        {
+            adActive_ = true;
+            adDiskDir_ = fo.adDiskDir;
+            adArea_ = fo.adArea;
+            adA_ = fo.adA;
+            std::vector<scalar> dm01(nC_, 0.0);
+            for (label c : fo.adDiskCells)
+                if (c>=0 && c<nC_) dm01[c] = 1.0;
+            DeviceBuffer<scalar> dmask;
+            dmask.copyFrom(dm01);
+            deviceHadamard(adMaskVDisk_, dm_.V, dmask);
+            adVtot_ = deviceSumMag(adMaskVDisk_);   // V in disk / total disk volume
+            std::vector<scalar> mon(nC_, 0.0);
+            for (label c : fo.adMonitorCells)
+                if (c>=0 && c<nC_) mon[c] = 1.0;
+            adMonMask01_.copyFrom(mon);
+            adNmon_ = (scalar)fo.adMonitorCells.size();
         }
         fvoCount_ = fo.count;
     }
     // rotorDiskSource (BEM): the device rotor is built from the mesh in gpuSimpleFoam and handed over here.
     void setRotorDisk(DeviceRotorDisk r) { rotor_ = std::move(r); }
-    // fvOptions scalar source for a transported scalar field (k/epsilon/…): src += Su, diag -= Sp.  No-op when absent.
-    void fvOptionsAddSupScalar(const std::string& field, DeviceBuffer<scalar>* src, DeviceBuffer<scalar>* diag) {
+    // fvOptions scalar source for a transported scalar field (k/epsilon/...): src += Su, diag -= Sp.  No-op when absent.
+    void fvOptionsAddSupScalar(
+        const std::string& field,
+        DeviceBuffer<scalar>* src,
+        DeviceBuffer<scalar>* diag)
+    {
         if (auto it = fvoScaSu_.find(field); it != fvoScaSu_.end() && src) deviceAxpy(1.0, it->second, *src);
         if (auto it = fvoScaSp_.find(field); it != fvoScaSp_.end() && diag) deviceAxpy(-1.0, it->second, *diag);
     }
 
     // pull device fields back to host (reconstruct for output / validation).
-    std::vector<vector> U() const { const auto x=Uk_[0].host(), y=Uk_[1].host(), z=Uk_[2].host();
-        std::vector<vector> u(nC_); for (label c=0;c<nC_;++c) u[c]={x[c],y[c],z[c]}; return u; }
+    std::vector<vector> U() const
+    {
+        const auto x=Uk_[0].host(), y=Uk_[1].host(), z=Uk_[2].host();
+        std::vector<vector> u(nC_);
+        for (label c=0;c<nC_;++c)
+            u[c]={x[c],y[c],z[c]};
+        return u;
+    }
     std::vector<scalar> p()   const { return dp_.host(); }
     std::vector<scalar> k()   const { return dk_.host(); }
     std::vector<scalar> eps() const { return de_.host(); }
@@ -729,17 +1067,26 @@ private:
     DeviceMRF mrf_;                       // optional rotating zone (inactive by default)
     // fvOptions (empty by default -> no-op). Momentum source per component (relaxSrc) + implicit Sp (diagonal);
     // scalar sources keyed by field name. See setFvOptions / the unconditional hooks in step().
-    bool   hasFvoMom_ = false; int fvoCount_ = 0;
+    bool   hasFvoMom_ = false;
+    int fvoCount_ = 0;
     DeviceBuffer<scalar> fvoMomSu_[3], fvoMomSp_;
     std::map<std::string, DeviceBuffer<scalar>> fvoScaSu_, fvoScaSp_;
     DevicePorosity por_;                  // explicitPorositySource (DarcyForchheimer), evaluated each iter
     // meanVelocityForce: accumulated pressure gradient gradP_ driving the mean velocity to Ubar (channel flow).
-    bool   mvfActive_ = false; vector mvfFlowDir_{0,0,0}; scalar mvfUbarMag_ = 0, mvfRelax_ = 1.0, mvfGradP_ = 0, mvfVtot_ = 0;
+    bool   mvfActive_ = false;
+    vector mvfFlowDir_{0,0,0};
+    scalar mvfUbarMag_ = 0, mvfRelax_ = 1.0, mvfGradP_ = 0, mvfVtot_ = 0;
     DeviceBuffer<scalar> mvfMaskV_, mvfMask01_;   // V (and 1) in the zone, 0 else (= V / ones for selectionMode all)
-    bool   limUActive_ = false; scalar limUMax_ = 0; DeviceBuffer<label> limUCells_;   // limitVelocity clamp
-    bool   vdcActive_ = false; scalar vdcUMax_ = 0, vdcC_ = 1; DeviceBuffer<label> vdcCells_;   // velocityDampingConstraint
+    bool   limUActive_ = false;
+    scalar limUMax_ = 0;
+    DeviceBuffer<label> limUCells_;   // limitVelocity clamp
+    bool   vdcActive_ = false;
+    scalar vdcUMax_ = 0, vdcC_ = 1;
+    DeviceBuffer<label> vdcCells_;   // velocityDampingConstraint
     // actuationDiskSource (Froude): thrust over a disk cellZone, computed each iter from the monitored upstream U.
-    bool   adActive_ = false; vector adDiskDir_{1,0,0}; scalar adArea_ = 0, adA_ = 0, adVtot_ = 0, adNmon_ = 0;
+    bool   adActive_ = false;
+    vector adDiskDir_{1,0,0};
+    scalar adArea_ = 0, adA_ = 0, adVtot_ = 0, adNmon_ = 0;
     DeviceBuffer<scalar> adMaskVDisk_, adMonMask01_;   // V in disk cells / 1 in monitor cells
     DeviceRotorDisk rotor_;                            // rotorDiskSource (BEM); per-cell force recomputed each iter
     DeviceBuffer<scalar> rotorFx_, rotorFy_, rotorFz_;

--- a/src/applications/solvers/simpleFoam/gpuSimpleFoam.cu
+++ b/src/applications/solvers/simpleFoam/gpuSimpleFoam.cu
@@ -37,7 +37,8 @@
 
 using namespace brae;
 
-static void printUsage() {
+static void printUsage()
+{
     std::printf(
 "brae, a GPU-native, OpenFOAM-compatible CFD solver (steady incompressible, simpleFoam).\n"
 "The whole SIMPLE loop runs on one GPU; reads a standard OpenFOAM case and writes standard time dirs.\n\n"
@@ -56,27 +57,46 @@ static void printUsage() {
 "Docs and benchmarks: https://github.com/simd-ai/brae\n");
 }
 
-int main(int argc, char** argv) {
-    try {
-        for (int i = 1; i < argc; ++i) { const std::string h = argv[i]; if (h == "--help" || h == "-h") { printUsage(); return 0; } }
+int main(int argc, char** argv)
+{
+    try
+    {
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string h = argv[i];
+            if (h == "--help" || h == "-h")
+            {
+                printUsage();
+                return 0;
+            }
+        }
         // -cases c1 c2 ... : run several cases at once, one per GPU (mesh/parameter study). The parent
         // orchestrates (forks one child `brae -case cX` per GPU, no CUDA here); a plain -case is unaffected.
-        for (int i = 1; i < argc; ++i) if (std::string(argv[i]) == "-cases") {
-            std::vector<std::string> sweep;
-            for (int j = i + 1; j < argc && argv[j][0] != '-'; ++j) sweep.push_back(argv[j]);
-            if (!sweep.empty()) return braesweep::runSweepCases(sweep);
-        }
+        for (int i = 1; i < argc; ++i)
+            if (std::string(argv[i]) == "-cases")
+            {
+                std::vector<std::string> sweep;
+                for (int j = i + 1; j < argc && argv[j][0] != '-'; ++j)
+                    sweep.push_back(argv[j]);
+                if (!sweep.empty()) return braesweep::runSweepCases(sweep);
+            }
         std::string caseDir = ".";
         bool partition = false;                              // -partition: build mesh + AMG caches, then exit (no solve)
-        for (int i = 1; i < argc; ++i) { const std::string a = argv[i];
-            if (a == "-case" && i + 1 < argc) caseDir = argv[++i];
-            else if (a == "-partition") partition = true;
-            else if (a[0] != '-') caseDir = a; }
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string a = argv[i];
+            if (a == "-case" && i + 1 < argc)
+                caseDir = argv[++i];
+            else if (a == "-partition")
+                partition = true;
+            else if (a[0] != '-')
+                caseDir = a;
+        }
         // -partition is cf's analogue of OF decomposePar: do the one-time prep (parse mesh + build AMG hierarchy) and
         // persist it to constant/polyMesh/.brae_mesh|amgcache, so the actual run reloads it warm. Forces the cache write.
         if (partition) setenv("BRAE_MESH_CACHE", "1", 1);
 
-        // ---- controls from the case dictionaries ----
+        // controls from the case dictionaries
         const FoamDict controlDict = readDict(caseDir + "/system/controlDict");
         const FoamDict fvSolution  = readDict(caseDir + "/system/fvSolution");
         const FoamDict transport   = readDict(caseDir + "/constant/transportProperties");
@@ -85,13 +105,16 @@ int main(int argc, char** argv) {
         const std::string startStr = controlDict.wordOr("startTime", "0");
         // OF `restore0Dir` convention (NOT a solver fallback): tutorials needing a mesh-prep step (snappyHexMesh /
         // setFields / changeDictionary, e.g. motorBike) ship the flow fields in <startTime>.orig, because
-        // snappyHexMesh writes mesh-level fields (cellLevel/pointLevel/…) INTO <startTime>. OpenFOAM's Allrun copies
+        // snappyHexMesh writes mesh-level fields (cellLevel/pointLevel/...) INTO <startTime>. OpenFOAM's Allrun copies
         // 0.orig -> 0 before solving; cf does exactly the same SETUP step here (only when <startTime> has no U), so the
         // solver then reads <startTime> identically to OF, behaviour unchanged vs OF, no read-from-.orig special case.
-        {   namespace fs = std::filesystem; std::error_code ec;
+        {
+            namespace fs = std::filesystem;
+            std::error_code ec;
             const std::string d0 = caseDir + "/" + startStr, dOrig = d0 + ".orig";
             const bool haveU = fs::exists(d0 + "/U") || fs::exists(d0 + "/U.gz");
-            if (!haveU && (fs::exists(dOrig + "/U") || fs::exists(dOrig + "/U.gz"))) {
+            if (!haveU && (fs::exists(dOrig + "/U") || fs::exists(dOrig + "/U.gz")))
+            {
                 std::fprintf(stderr, "brae: %s/U not found -> restoring %s/* into %s (OpenFOAM restore0Dir convention)\n",
                              d0.c_str(), dOrig.c_str(), d0.c_str());
                 fs::create_directories(d0, ec);
@@ -110,83 +133,130 @@ int main(int argc, char** argv) {
         ctl.nu = transport.scalarOr("nu", 1e-5);
         // read schemes: div(phi,U) "bounded" -> -Sp(div(phi),.); "linearUpwind" -> deferred gradient correction;
         // laplacian/snGrad "corrected" -> non-orthogonal correction (nonOrthDeltaCoeffs implicit + corrVec.grad explicit).
-        { std::istringstream fsch(readFileExpanded(caseDir + "/system/fvSchemes")); std::string ln;  // $var expanded ($turbulence)
-          auto hasWord = [](const std::string& s, const std::string& w) {     // whole-word match (so "uncorrected" != "corrected")
-              for (std::size_t p = s.find(w); p != std::string::npos; p = s.find(w, p + 1)) {
-                  const bool lb = (p == 0 || !std::isalpha((unsigned char)s[p-1]));
-                  const bool rb = (p + w.size() >= s.size() || !std::isalpha((unsigned char)s[p+w.size()]));
-                  if (lb && rb) return true; }
-              return false; };
-          // "limitedLinear <k_>" on a div line -> twoByk = 2/max(k_,SMALL); returns 0 if the scheme is absent.
-          auto limitedTwoByk = [](const std::string& s) -> scalar {
-              const std::size_t p = s.find("limitedLinear");
-              if (p == std::string::npos) return 0.0;
-              scalar kc = 1.0; std::sscanf(s.c_str() + p + 13, "%lf", &kc);   // coefficient after "limitedLinear"
-              return 2.0 / std::max(kc, (scalar)1e-30); };
-          // the interpolation-scheme word after "Gauss" on a div(phi,*) line (OF: "[bounded] Gauss <scheme> [args]").
-          auto divSchemeWord = [](const std::string& s) -> std::string {
-              const std::size_t g = s.find("Gauss");
-              if (g == std::string::npos) return std::string();
-              const char* p = s.c_str() + g + 5; while (*p && std::isspace((unsigned char)*p)) ++p;
-              std::string w; while (*p && !std::isspace((unsigned char)*p) && *p != ';') { w += *p; ++p; }
-              return w; };
-          // OF-faithful fail-fast (mirrors surfaceInterpolationScheme::New "Unknown discretisation scheme ... Valid
-          // schemes are : (...)" + exit(FatalIOError)): throw on a scheme cf models nothing close to; warn loudly on
-          // one cf only APPROXIMATES (so the route is detected, never silently covered). `ok` = exact; `approx` = warned.
-          auto checkDiv = [&](const std::string& s, const char* field,
-                              std::initializer_list<const char*> ok, std::initializer_list<const char*> approx) {
-              const std::string w = divSchemeWord(s);
-              for (const char* o : ok)     if (w == o) return;
-              for (const char* o : approx) if (w == o) {
-                  std::fprintf(stderr, "brae WARNING: div(phi,%s) 'Gauss %s' has no exact cf kernel -- run as a near-equivalent "
-                               "(NOT OF-bit-identical). Set the scheme to an exact one to avoid this.\n", field, w.c_str());
-                  return; }
-              std::string valid; for (const char* o : ok) (valid += " ") += o; for (const char* o : approx) (valid += " ") += o;
-              throw std::runtime_error(std::string("brae: unknown/unsupported div(phi,") + field +
-                  ") scheme 'Gauss " + w + "'; cf supports : (" + valid + " )"); };
-          while (std::getline(fsch, ln)) {
-              if (ln.find("div(phi,U)") != std::string::npos) {
-                  checkDiv(ln, "U", {"upwind", "linearUpwind", "linearUpwindV", "LUST"}, {"limitedLinear", "limitedLinearV"});
-                  if (ln.find("bounded") != std::string::npos)      ctl.bounded = true;
-                  if (ln.find("linearUpwind") != std::string::npos) ctl.linearUpwind = true;   // linearUpwindV contains this -> upwind matrix + gradients
-                  if (ln.find("linearUpwindV") != std::string::npos) ctl.linearUpwindV = true; // + OF vector direction limiter
-                  if (ln.find("LUST") != std::string::npos)         ctl.lust = true; }   // 0.75 linear + 0.25 linearUpwind
-              // grad(U) cellLimited Gauss linear <k> (OF cellLimitedGrad<minmod>): k is the first number after
-              // "cellLimited" (the basicScheme between has no digits). 0 = unlimited. cellMDLimited not yet handled.
-              if (ln.find("grad(U)") != std::string::npos && hasWord(ln, "cellLimited")) {
-                  ctl.gradULimitK = 1.0;
-                  const char* s = ln.c_str() + ln.find("cellLimited") + 11;
-                  while (*s && !(std::isdigit((unsigned char)*s) || *s == '.')) ++s;
-                  scalar kc; if (std::sscanf(s, "%lf", &kc) == 1) ctl.gradULimitK = kc; }
-              if (std::getenv("BRAE_SCHEME_DEBUG") && ln.find("div(phi,") != std::string::npos) std::fprintf(stderr, "[scheme] %s\n", ln.c_str());
-              if (ln.find("div(phi,k)") != std::string::npos) {
-                  checkDiv(ln, "k", {"upwind", "linearUpwind", "limitedLinear"}, {});
-                  const scalar t = limitedTwoByk(ln); if (t > 0.0) { ctl.limitedK = true; ctl.twoBykK = t; }
-                  if (ln.find("linearUpwind") != std::string::npos) ctl.luK = true; }
-              if (ln.find("div(phi,epsilon)") != std::string::npos || ln.find("div(phi,omega)") != std::string::npos) {
-                  checkDiv(ln, "epsilon|omega", {"upwind", "linearUpwind", "limitedLinear"}, {});
-                  const scalar t = limitedTwoByk(ln); if (t > 0.0) { ctl.limitedEps = true; ctl.twoBykEps = t; }   // 2nd turb scalar (eps|omega)
-                  if (ln.find("linearUpwind") != std::string::npos) ctl.luEps = true; }
-              if (ln.find("div(phi,nuTilda)") != std::string::npos) {   // SA: nuTilda uses the k-slot scheme flags
-                  checkDiv(ln, "nuTilda", {"upwind", "linearUpwind", "limitedLinear"}, {});
-                  const scalar t = limitedTwoByk(ln); if (t > 0.0) { ctl.limitedK = true; ctl.twoBykK = t; }
-                  if (ln.find("linearUpwind") != std::string::npos) ctl.luK = true; }
-              if (ln.find("Gauss") != std::string::npos || ln.find("snGrad") != std::string::npos ||
-                  ln.find("laplacian") != std::string::npos || ln.find("default") != std::string::npos) {
-                  if (hasWord(ln, "corrected")) ctl.nonOrth = true;     // unlimited non-orth correction (psi = 1)
-                  // OF fv::limitedSnGrad "limited [<correctedScheme>] <psi>" (psi in [0,1]): non-orth correction
-                  // capped per-face. hasWord avoids matching "unlimited" and "limitedLinear" (a div scheme); the coeff
-                  // is the next numeric token after "limited" (skip an optional scheme word like "corrected").
-                  if (hasWord(ln, "limited")) {
-                      ctl.nonOrth = true; scalar psi = 1.0;
-                      const char* s = ln.c_str() + ln.find("limited") + 7;
-                      while (*s && !(std::isdigit((unsigned char)*s) || *s == '.')) ++s;   // skip to the coefficient
-                      if (std::sscanf(s, "%lf", &psi) == 1) ctl.nonOrthLimit = psi; } } } }
+        {
+            std::istringstream fsch(readFileExpanded(caseDir + "/system/fvSchemes"));   // $var expanded ($turbulence)
+            std::string ln;
+            auto hasWord = [](const std::string& s, const std::string& w)   // whole-word match (so "uncorrected" != "corrected")
+            {
+                for (std::size_t p = s.find(w); p != std::string::npos; p = s.find(w, p + 1))
+                {
+                    const bool lb = (p == 0 || !std::isalpha((unsigned char)s[p-1]));
+                    const bool rb = (p + w.size() >= s.size() || !std::isalpha((unsigned char)s[p+w.size()]));
+                    if (lb && rb) return true;
+                }
+                return false;
+            };
+            // "limitedLinear <k_>" on a div line -> twoByk = 2/max(k_,SMALL); returns 0 if the scheme is absent.
+            auto limitedTwoByk = [](const std::string& s) -> scalar
+            {
+                const std::size_t p = s.find("limitedLinear");
+                if (p == std::string::npos) return 0.0;
+                scalar kc = 1.0;
+                std::sscanf(s.c_str() + p + 13, "%lf", &kc);   // coefficient after "limitedLinear"
+                return 2.0 / std::max(kc, (scalar)1e-30);
+            };
+            // the interpolation-scheme word after "Gauss" on a div(phi,*) line (OF: "[bounded] Gauss <scheme> [args]").
+            auto divSchemeWord = [](const std::string& s) -> std::string
+            {
+                const std::size_t g = s.find("Gauss");
+                if (g == std::string::npos) return std::string();
+                const char* p = s.c_str() + g + 5;
+                while (*p && std::isspace((unsigned char)*p)) ++p;
+                std::string w;
+                while (*p && !std::isspace((unsigned char)*p) && *p != ';') { w += *p; ++p; }
+                return w;
+            };
+            // OF-faithful fail-fast (mirrors surfaceInterpolationScheme::New "Unknown discretisation scheme ... Valid
+            // schemes are : (...)" + exit(FatalIOError)): throw on a scheme cf models nothing close to; warn loudly on
+            // one cf only APPROXIMATES (so the route is detected, never silently covered). `ok` = exact; `approx` = warned.
+            auto checkDiv = [&](
+                const std::string& s,
+                const char* field,
+                std::initializer_list<const char*> ok,
+                std::initializer_list<const char*> approx)
+            {
+                const std::string w = divSchemeWord(s);
+                for (const char* o : ok)
+                    if (w == o) return;
+                for (const char* o : approx)
+                    if (w == o)
+                    {
+                        std::fprintf(stderr, "brae WARNING: div(phi,%s) 'Gauss %s' has no exact cf kernel -- run as a near-equivalent "
+                                     "(NOT OF-bit-identical). Set the scheme to an exact one to avoid this.\n", field, w.c_str());
+                        return;
+                    }
+                std::string valid;
+                for (const char* o : ok)     (valid += " ") += o;
+                for (const char* o : approx) (valid += " ") += o;
+                throw std::runtime_error(std::string("brae: unknown/unsupported div(phi,") + field +
+                    ") scheme 'Gauss " + w + "'; cf supports : (" + valid + " )");
+            };
+            while (std::getline(fsch, ln))
+            {
+                if (ln.find("div(phi,U)") != std::string::npos)
+                {
+                    checkDiv(ln, "U", {"upwind", "linearUpwind", "linearUpwindV", "LUST"}, {"limitedLinear", "limitedLinearV"});
+                    if (ln.find("bounded") != std::string::npos)      ctl.bounded = true;
+                    if (ln.find("linearUpwind") != std::string::npos) ctl.linearUpwind = true;   // linearUpwindV contains this -> upwind matrix + gradients
+                    if (ln.find("linearUpwindV") != std::string::npos) ctl.linearUpwindV = true; // + OF vector direction limiter
+                    if (ln.find("LUST") != std::string::npos)         ctl.lust = true;   // 0.75 linear + 0.25 linearUpwind
+                }
+                // grad(U) cellLimited Gauss linear <k> (OF cellLimitedGrad<minmod>): k is the first number after
+                // "cellLimited" (the basicScheme between has no digits). 0 = unlimited. cellMDLimited not yet handled.
+                if (ln.find("grad(U)") != std::string::npos && hasWord(ln, "cellLimited"))
+                {
+                    ctl.gradULimitK = 1.0;
+                    const char* s = ln.c_str() + ln.find("cellLimited") + 11;
+                    while (*s && !(std::isdigit((unsigned char)*s) || *s == '.')) ++s;
+                    scalar kc;
+                    if (std::sscanf(s, "%lf", &kc) == 1) ctl.gradULimitK = kc;
+                }
+                if (std::getenv("BRAE_SCHEME_DEBUG") && ln.find("div(phi,") != std::string::npos) std::fprintf(stderr, "[scheme] %s\n", ln.c_str());
+                if (ln.find("div(phi,k)") != std::string::npos)
+                {
+                    checkDiv(ln, "k", {"upwind", "linearUpwind", "limitedLinear"}, {});
+                    const scalar t = limitedTwoByk(ln);
+                    if (t > 0.0) { ctl.limitedK = true; ctl.twoBykK = t; }
+                    if (ln.find("linearUpwind") != std::string::npos) ctl.luK = true;
+                }
+                if (ln.find("div(phi,epsilon)") != std::string::npos || ln.find("div(phi,omega)") != std::string::npos)
+                {
+                    checkDiv(ln, "epsilon|omega", {"upwind", "linearUpwind", "limitedLinear"}, {});
+                    const scalar t = limitedTwoByk(ln);
+                    if (t > 0.0) { ctl.limitedEps = true; ctl.twoBykEps = t; }   // 2nd turb scalar (eps|omega)
+                    if (ln.find("linearUpwind") != std::string::npos) ctl.luEps = true;
+                }
+                if (ln.find("div(phi,nuTilda)") != std::string::npos)   // SA: nuTilda uses the k-slot scheme flags
+                {
+                    checkDiv(ln, "nuTilda", {"upwind", "linearUpwind", "limitedLinear"}, {});
+                    const scalar t = limitedTwoByk(ln);
+                    if (t > 0.0) { ctl.limitedK = true; ctl.twoBykK = t; }
+                    if (ln.find("linearUpwind") != std::string::npos) ctl.luK = true;
+                }
+                if (ln.find("Gauss") != std::string::npos || ln.find("snGrad") != std::string::npos ||
+                    ln.find("laplacian") != std::string::npos || ln.find("default") != std::string::npos)
+                {
+                    if (hasWord(ln, "corrected")) ctl.nonOrth = true;     // unlimited non-orth correction (psi = 1)
+                    // OF fv::limitedSnGrad "limited [<correctedScheme>] <psi>" (psi in [0,1]): non-orth correction
+                    // capped per-face. hasWord avoids matching "unlimited" and "limitedLinear" (a div scheme); the coeff
+                    // is the next numeric token after "limited" (skip an optional scheme word like "corrected").
+                    if (hasWord(ln, "limited"))
+                    {
+                        ctl.nonOrth = true;
+                        scalar psi = 1.0;
+                        const char* s = ln.c_str() + ln.find("limited") + 7;
+                        while (*s && !(std::isdigit((unsigned char)*s) || *s == '.')) ++s;   // skip to the coefficient
+                        if (std::sscanf(s, "%lf", &psi) == 1) ctl.nonOrthLimit = psi;
+                    }
+                }
+            }
+        }
         const std::string simType = turbProps.wordOr("simulationType", "laminar");
         ctl.turbulent = (simType == "RAS");
         if (simType != "RAS" && simType != "laminar")
             throw std::runtime_error("brae: unsupported simulationType '" + simType + "' (RAS or laminar)");
-        if (ctl.turbulent) {
+        if (ctl.turbulent)
+        {
             const FoamDict* ras = turbProps.subDict("RAS");
             const std::string model = ras ? ras->wordOr("RASModel", "") : "";
             ctl.lm  = (model == "kOmegaSSTLM");                 // Langtry-Menter transition = kOmegaSST + gamma-ReThetat
@@ -195,48 +265,70 @@ int main(int argc, char** argv) {
             const bool rke = (model == "realizableKE");
             if (model != "kEpsilon" && !rke && !ctl.sst && !ctl.sa)
                 throw std::runtime_error("brae: unsupported RASModel '" + model + "' (kEpsilon, realizableKE, kOmegaSST, kOmegaSSTLM or SpalartAllmaras)");
-            if (ctl.sa) {
+            if (ctl.sa)
+            {
                 // Spalart-Allmaras: OF defaults (coeffs read from RAS.SpalartAllmarasCoeffs would override; not needed here).
                 const SpalartAllmarasCoeffs& c = ctl.saCoeffs;
                 std::printf("  SpalartAllmaras (OF defaults): sigmaNut=%.4g kappa=%.4g Cb1=%.4g Cb2=%.4g Cw1=%.4g Cw2=%.3g Cw3=%.3g Cv1=%.3g Cs=%.3g\n",
                             c.sigmaNut, c.kappa, c.Cb1, c.Cb2, c.Cw1(), c.Cw2, c.Cw3, c.Cv1, c.Cs);
-            } else if (ctl.sst) {
+            }
+            else if (ctl.sst)
+            {
                 // kOmegaSST coefficients: OF turbulenceProperties RAS.kOmegaSSTCoeffs (absent keys keep OF defaults).
                 readKOmegaSSTCoeffs(ras, ctl.ksstCoeffs);
                 const KOmegaSSTCoeffs& c = ctl.ksstCoeffs;
                 std::printf("  kOmegaSSTCoeffs: a1=%.4g betaStar=%.4g alphaK1=%.4g alphaOmega1=%.4g gamma1=%.4g beta1=%.4g\n",
                             c.a1, c.betaStar, c.alphaK1, c.alphaOmega1, c.gamma1, c.beta1);
-            } else {
+            }
+            else
+            {
                 // k-eps coefficients: RAS.kEpsilonCoeffs (kappa/E wall-function coeffs accepted if present).
                 KEpsilonCoeffs& c = ctl.keCoeffs;
-                if (rke) {   // realizableKE: variable Cmu + strain production; OF defaults A0=4, C2=1.9, sigmak=1, sigmaEps=1.2
-                    c.realizable = true; c.A0 = 4.0; c.C2 = 1.9; c.sigmaK = 1.0; c.sigmaEps = 1.2;
-                    if (const FoamDict* rkc = ras ? ras->subDict("realizableKECoeffs") : nullptr) {
-                        c.A0 = rkc->scalarOr("A0", c.A0); c.C2 = rkc->scalarOr("C2", c.C2);
-                        c.sigmaK = rkc->scalarOr("sigmak", c.sigmaK); c.sigmaEps = rkc->scalarOr("sigmaEps", c.sigmaEps);
-                        c.kappa = rkc->scalarOr("kappa", c.kappa); c.E = rkc->scalarOr("E", c.E);
+                if (rke)   // realizableKE: variable Cmu + strain production; OF defaults A0=4, C2=1.9, sigmak=1, sigmaEps=1.2
+                {
+                    c.realizable = true;
+                    c.A0 = 4.0;
+                    c.C2 = 1.9;
+                    c.sigmaK = 1.0;
+                    c.sigmaEps = 1.2;
+                    if (const FoamDict* rkc = ras ? ras->subDict("realizableKECoeffs") : nullptr)
+                    {
+                        c.A0 = rkc->scalarOr("A0", c.A0);
+                        c.C2 = rkc->scalarOr("C2", c.C2);
+                        c.sigmaK = rkc->scalarOr("sigmak", c.sigmaK);
+                        c.sigmaEps = rkc->scalarOr("sigmaEps", c.sigmaEps);
+                        c.kappa = rkc->scalarOr("kappa", c.kappa);
+                        c.E = rkc->scalarOr("E", c.E);
                     }
                     std::printf("  realizableKECoeffs: A0=%.4g C2=%.4g sigmak=%.4g sigmaEps=%.4g kappa=%.4g E=%.4g (variable Cmu)\n",
                                 c.A0, c.C2, c.sigmaK, c.sigmaEps, c.kappa, c.E);
-                } else {
-                const FoamDict* kec = ras ? ras->subDict("kEpsilonCoeffs") : nullptr;
-                if (kec) {
-                    c.Cmu = kec->scalarOr("Cmu", c.Cmu); c.C1 = kec->scalarOr("C1", c.C1); c.C2 = kec->scalarOr("C2", c.C2);
-                    c.C3 = kec->scalarOr("C3", c.C3); c.sigmaK = kec->scalarOr("sigmak", c.sigmaK);
-                    c.sigmaEps = kec->scalarOr("sigmaEps", c.sigmaEps); c.kappa = kec->scalarOr("kappa", c.kappa);
-                    c.E = kec->scalarOr("E", c.E);
                 }
-                std::printf("  kEpsilonCoeffs%s: Cmu=%.4g C1=%.4g C2=%.4g C3=%.4g sigmak=%.4g sigmaEps=%.4g kappa=%.4g E=%.4g\n",
-                            kec ? " (from dict)" : " (OF defaults)", c.Cmu, c.C1, c.C2, c.C3, c.sigmaK, c.sigmaEps, c.kappa, c.E);
+                else
+                {
+                    const FoamDict* kec = ras ? ras->subDict("kEpsilonCoeffs") : nullptr;
+                    if (kec)
+                    {
+                        c.Cmu = kec->scalarOr("Cmu", c.Cmu);
+                        c.C1 = kec->scalarOr("C1", c.C1);
+                        c.C2 = kec->scalarOr("C2", c.C2);
+                        c.C3 = kec->scalarOr("C3", c.C3);
+                        c.sigmaK = kec->scalarOr("sigmak", c.sigmaK);
+                        c.sigmaEps = kec->scalarOr("sigmaEps", c.sigmaEps);
+                        c.kappa = kec->scalarOr("kappa", c.kappa);
+                        c.E = kec->scalarOr("E", c.E);
+                    }
+                    std::printf("  kEpsilonCoeffs%s: Cmu=%.4g C1=%.4g C2=%.4g C3=%.4g sigmak=%.4g sigmaEps=%.4g kappa=%.4g E=%.4g\n",
+                                kec ? " (from dict)" : " (OF defaults)", c.Cmu, c.C1, c.C2, c.C3, c.sigmaK, c.sigmaEps, c.kappa, c.E);
                 }
             }
         }
 
         // Scalar linearUpwind (deferred correction) is implemented in the scalar scaffold but currently DEGRADES
         // turbulence accuracy (explicit lagged correction + loose under-relaxed turb solve + steep near-wall
-        // gradients): airFoil2D SA overshoots ν̃ (Cd worse), pitzDaily SST k/p worse than the upwind baseline.
+        // gradients): airFoil2D SA overshoots nuTilda (Cd worse), pitzDaily SST k/p worse than the upwind baseline.
         // Default OFF -> scalars use upwind (the validated behavior). BRAE_SCALAR_LINEARUPWIND=1 honours the scheme (A/B).
-        if (!std::getenv("BRAE_SCALAR_LINEARUPWIND")) {
+        if (!std::getenv("BRAE_SCALAR_LINEARUPWIND"))
+        {
             // Detect-the-route: if fvSchemes ASKED for linearUpwind on a turbulence scalar, say loudly that cf is
             // running upwind instead (do not silently honour-then-ignore). The gating is deliberate (accuracy), but
             // the user must see that the requested scheme is not the one being applied.
@@ -244,7 +336,8 @@ int main(int argc, char** argv) {
                 std::fprintf(stderr, "brae WARNING: div(phi,<turbulence scalar>) requested 'linearUpwind' but cf is running "
                              "UPWIND (default: the scalar linearUpwind deferred correction degrades turbulence accuracy vs "
                              "OF). Set BRAE_SCALAR_LINEARUPWIND=1 to honour the requested scheme.\n");
-            ctl.luK = false; ctl.luEps = false;
+            ctl.luK = false;
+            ctl.luEps = false;
         }
 
         const FoamDict* rf  = fvSolution.subDict("relaxationFactors");
@@ -256,14 +349,22 @@ int main(int argc, char** argv) {
         ctl.relaxP   = fld ? fld->scalarOr("p", 1.0) : 1.0;
 
         const FoamDict* solvers = fvSolution.subDict("solvers");
-        auto solverTol = [&](const std::string& f, scalar def) {
-            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr; return s ? s->scalarOr("tolerance", def) : def; };
-        auto solverRelTol = [&](const std::string& f) {           // SIMPLE only needs a loose per-step solve
-            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr; return s ? s->scalarOr("relTol", 0.0) : 0.0; };
-        ctl.tolP = solverTol("p", 1e-6); ctl.tolU = solverTol("U", 1e-8);
+        auto solverTol = [&](const std::string& f, scalar def)
+        {
+            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr;
+            return s ? s->scalarOr("tolerance", def) : def;
+        };
+        auto solverRelTol = [&](const std::string& f)   // SIMPLE only needs a loose per-step solve
+        {
+            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr;
+            return s ? s->scalarOr("relTol", 0.0) : 0.0;
+        };
+        ctl.tolP = solverTol("p", 1e-6);
+        ctl.tolU = solverTol("U", 1e-8);
         const std::string second = ctl.sst ? "omega" : "epsilon";
         ctl.tolKE = ctl.sa ? solverTol("nuTilda", 1e-8) : std::fmin(solverTol("k", 1e-8), solverTol(second, 1e-8));
-        ctl.relTolP = solverRelTol("p"); ctl.relTolU = solverRelTol("U");
+        ctl.relTolP = solverRelTol("p");
+        ctl.relTolU = solverRelTol("U");
         ctl.relTolKE = ctl.sa ? solverRelTol("nuTilda")                     // SA: single nuTilda solve
                               : std::fmin(solverRelTol("k"), solverRelTol(second));   // OF solves k/(eps|omega) loosely per SIMPLE step
         // Per-field scalar linear solver from fvSolution, EXACTLY as OF selects it: solver smoothSolver +
@@ -271,11 +372,13 @@ int main(int argc, char** argv) {
         // OF smoothSolver with a GaussSeidel-family smoother (GaussSeidel = forward sweep, symGaussSeidel = fwd+bwd);
         // cf maps BOTH to its symmetric multicolor deviceSymGaussSeidel (a superset of forward GaussSeidel). Other
         // solvers (PBiCG[Stab]/GAMG/...) keep BiCGStab. motorBike uses "GaussSeidel" for U/k/omega; pitzDaily "symGaussSeidel".
-        auto useSymGS = [&](const std::string& f) {
+        auto useSymGS = [&](const std::string& f)
+        {
             const FoamDict* s = solvers ? solvers->subDict(f) : nullptr;
             if (!s || s->wordOr("solver", "") != "smoothSolver") return false;
             const std::string sm = s->wordOr("smoother", "");
-            return sm == "symGaussSeidel" || sm == "GaussSeidel"; };
+            return sm == "symGaussSeidel" || sm == "GaussSeidel";
+        };
         ctl.gsK   = useSymGS(ctl.sa ? "nuTilda" : "k");
         ctl.gsEps = ctl.sa ? false : useSymGS(second);
         // Momentum solver READ FROM fvSolution exactly like OF (fvVectorMatrix::solveSegregated solves each U component
@@ -289,9 +392,17 @@ int main(int argc, char** argv) {
         // BiCGStab batched convergence DEFAULT OFF: measured net-NEGATIVE once relTol makes the solves few-iter
         // (overshoot to the K-boundary costs more than the saved syncs). Kept behind the env for tight-tol cases
         // (many inner iters), where it would help like the pressure pcgCheckEvery does.
-        if (const char* be = std::getenv("BRAE_BICG_CHECK_EVERY")) { const int k = std::atoi(be); if (k >= 1) ctl.bicgCheckEvery = k; }
+        if (const char* be = std::getenv("BRAE_BICG_CHECK_EVERY"))
+        {
+            const int k = std::atoi(be);
+            if (k >= 1) ctl.bicgCheckEvery = k;
+        }
         ctl.pcgCheckEvery = 4;   // application default: batched PCG residual read (1.30x; OF-validated identical to K=1).
-        if (const char* ce = std::getenv("BRAE_PCG_CHECK_EVERY")) { const int k = std::atoi(ce); if (k >= 1) ctl.pcgCheckEvery = k; }   // override (1 = exact)
+        if (const char* ce = std::getenv("BRAE_PCG_CHECK_EVERY"))
+        {
+            const int k = std::atoi(ce);
+            if (k >= 1) ctl.pcgCheckEvery = k;   // override (1 = exact)
+        }
         if (const char* cs = std::getenv("BRAE_CORR_SCALING")) ctl.corrScaling = (std::atoi(cs) != 0);   // AMG corr-scaling + flexible CG
         if (const char* ug = std::getenv("BRAE_USE_GRAPH")) ctl.useGraph = (std::atoi(ug) != 0);          // V-cycle graph replay toggle (debug)
 
@@ -299,11 +410,15 @@ int main(int argc, char** argv) {
         const FoamDict* resCtl = simple ? simple->subDict("residualControl") : nullptr;
         const bool hasRC = (resCtl != nullptr);
         const scalar rcP = resCtl ? resCtl->scalarOr("p", -1) : -1, rcU = resCtl ? resCtl->scalarOr("U", -1) : -1;
-        { const std::string cons = simple ? simple->wordOr("consistent", "no") : "no";
-          ctl.consistent = (cons == "yes" || cons == "true" || cons == "on" || cons == "1"); }   // SIMPLEC
+        {
+            const std::string cons = simple ? simple->wordOr("consistent", "no") : "no";
+            ctl.consistent = (cons == "yes" || cons == "true" || cons == "on" || cons == "1");   // SIMPLEC
+        }
         ctl.nNonOrth = simple ? simple->intOr("nNonOrthogonalCorrectors", 0) : 0;   // extra pressure passes on non-orthogonal meshes
-        { const std::vector<scalar> bf = simple ? simple->scalarListOr("bodyForce", {}) : std::vector<scalar>{};
-          if (bf.size() >= 3) ctl.bodyForce = vector{bf[0], bf[1], bf[2]}; }   // constant momentum source (drives cyclic/periodic channels)
+        {
+            const std::vector<scalar> bf = simple ? simple->scalarListOr("bodyForce", {}) : std::vector<scalar>{};
+            if (bf.size() >= 3) ctl.bodyForce = vector{bf[0], bf[1], bf[2]};   // constant momentum source (drives cyclic/periodic channels)
+        }
 
         std::printf("brae (device-resident) | case=%s | %s%s | nu=%.3g\n", caseDir.c_str(),
                     simType.c_str(), ctl.turbulent ? (ctl.sst ? " (kOmegaSST)" : " (kEpsilon)") : "", ctl.nu);
@@ -314,24 +429,43 @@ int main(int argc, char** argv) {
         std::printf("  grad(U) cellLimited k=%.3g (0=unlimited)\n", ctl.gradULimitK);
         std::printf("  linear solver (GaussSeidel from fvSolution; else BiCGStab): U=%d k|nuTilda=%d eps|omega=%d\n", ctl.gsU, ctl.gsK, ctl.gsEps);
 
-        // ---- mesh + start fields (single GPU: read directly, no decomposition) ----
+        // mesh + start fields (single GPU: read directly, no decomposition)
         const bool timeStartup = std::getenv("BRAE_TIME_STARTUP") != nullptr;
         auto _tsClk = std::chrono::high_resolution_clock::now();
-        auto _tsLap = [&](const char* what){ if (timeStartup) { auto n = std::chrono::high_resolution_clock::now();
-            std::fprintf(stderr, "[startup] %-22s %6.2f s\n", what, std::chrono::duration<double>(n-_tsClk).count()); _tsClk = n; } };
-        PrimitiveMesh m; m.read(caseDir + "/constant/polyMesh");                    _tsLap("mesh read");
-        FvGeometry g; g.build(m);                                                   _tsLap("geometry build");
+        auto _tsLap = [&](const char* what)
+        {
+            if (timeStartup)
+            {
+                auto n = std::chrono::high_resolution_clock::now();
+                std::fprintf(stderr, "[startup] %-22s %6.2f s\n", what, std::chrono::duration<double>(n-_tsClk).count());
+                _tsClk = n;
+            }
+        };
+        PrimitiveMesh m;
+        m.read(caseDir + "/constant/polyMesh");
+        _tsLap("mesh read");
+        FvGeometry g;
+        g.build(m);
+        _tsLap("geometry build");
         const std::vector<FvPatch> fvp = buildPatches(m, g);
         const label nC = m.nCells();
 
-        GeometricField<vector> U = buildField<vector>(readField<vector>(fieldDir + "/U"), fvp, nC); U.evaluateBoundary();
-        GeometricField<scalar> p = buildField<scalar>(readField<scalar>(fieldDir + "/p"), fvp, nC); p.evaluateBoundary();
+        GeometricField<vector> U = buildField<vector>(readField<vector>(fieldDir + "/U"), fvp, nC);
+        U.evaluateBoundary();
+        GeometricField<scalar> p = buildField<scalar>(readField<scalar>(fieldDir + "/p"), fvp, nC);
+        p.evaluateBoundary();
         // pressure needs a reference iff NO p patch fixes the value (singular all-Neumann system, e.g. closed
         // lid-driven cavity / fixedFluxPressure-walled domains). Then adjustPhi + pEqn.setReference (OF needReference).
         ctl.needRef = true;
         // a fixedValue-p OR a freestreamPressure (outletInlet, cat 4: fixedValue at outflow) references the pressure.
-        for (const auto& bf : p.boundary) if (bf->fixesValue() || bf->bcCategory() == 4) { ctl.needRef = false; break; }
-        if (ctl.needRef) {
+        for (const auto& bf : p.boundary)
+            if (bf->fixesValue() || bf->bcCategory() == 4)
+            {
+                ctl.needRef = false;
+                break;
+            }
+        if (ctl.needRef)
+        {
             ctl.pRefCell  = simple ? (label)simple->intOr("pRefCell", 0) : 0;
             ctl.pRefValue = simple ? simple->scalarOr("pRefValue", 0.0) : 0.0;
             std::printf("  pressure needs reference (no fixedValue-p): pRefCell=%d pRefValue=%.4g\n",
@@ -341,18 +475,29 @@ int main(int argc, char** argv) {
 
         const std::string secondName = ctl.sst ? "omega" : "epsilon";   // the 2nd turbulence scalar
         GeometricField<scalar> k, eps, nut, ReThetat, gammaInt;   // ReThetat/gammaInt: kOmegaSSTLM transition
-        if (ctl.sa) {   // Spalart-Allmaras (one-equation): nuTilda -> the "k" slot, nut. BCs (freestream + fixedValue-0 wall) need no inlet calc.
-            k   = buildField<scalar>(readField<scalar>(fieldDir + "/nuTilda"), fvp, nC); k.evaluateBoundary();
-            nut = buildField<scalar>(readField<scalar>(fieldDir + "/nut"), fvp, nC);     nut.evaluateBoundary();
-        } else if (ctl.turbulent) {
+        if (ctl.sa)   // Spalart-Allmaras (one-equation): nuTilda -> the "k" slot, nut. BCs (freestream + fixedValue-0 wall) need no inlet calc.
+        {
+            k   = buildField<scalar>(readField<scalar>(fieldDir + "/nuTilda"), fvp, nC);
+            k.evaluateBoundary();
+            nut = buildField<scalar>(readField<scalar>(fieldDir + "/nut"), fvp, nC);
+            nut.evaluateBoundary();
+        }
+        else if (ctl.turbulent)
+        {
             const FieldData<scalar> kFD = readField<scalar>(fieldDir + "/k");
             const FieldData<scalar> sFD = readField<scalar>(fieldDir + "/" + secondName);
-            k   = buildField<scalar>(kFD, fvp, nC);                                                k.evaluateBoundary();
-            eps = buildField<scalar>(sFD, fvp, nC);                                                eps.evaluateBoundary();
-            nut = buildField<scalar>(readField<scalar>(fieldDir + "/nut"), fvp, nC); nut.evaluateBoundary();
-            if (ctl.lm) {   // kOmegaSSTLM transition fields
-                ReThetat = buildField<scalar>(readField<scalar>(fieldDir + "/ReThetat"), fvp, nC); ReThetat.evaluateBoundary();
-                gammaInt = buildField<scalar>(readField<scalar>(fieldDir + "/gammaInt"), fvp, nC); gammaInt.evaluateBoundary();
+            k   = buildField<scalar>(kFD, fvp, nC);
+            k.evaluateBoundary();
+            eps = buildField<scalar>(sFD, fvp, nC);
+            eps.evaluateBoundary();
+            nut = buildField<scalar>(readField<scalar>(fieldDir + "/nut"), fvp, nC);
+            nut.evaluateBoundary();
+            if (ctl.lm)   // kOmegaSSTLM transition fields
+            {
+                ReThetat = buildField<scalar>(readField<scalar>(fieldDir + "/ReThetat"), fvp, nC);
+                ReThetat.evaluateBoundary();
+                gammaInt = buildField<scalar>(readField<scalar>(fieldDir + "/gammaInt"), fvp, nC);
+                gammaInt.evaluateBoundary();
                 std::printf("  kOmegaSSTLM (Langtry-Menter transition): + ReThetat + gammaInt transport\n");
             }
             // turbulent-inlet BCs: inflow value computed from U (k) then from k (epsilon/omega).
@@ -361,14 +506,20 @@ int main(int argc, char** argv) {
             applyTurbulentInletSecond(eps, sFD, k, wCmu, fvp);
         }
 
-        // ---- MRF rotating zone (constant/MRFProperties + polyMesh/cellZones), if present ----
+        // MRF rotating zone (constant/MRFProperties + polyMesh/cellZones), if present
         const MRFConfig mrfCfg = readMRFProperties(caseDir + "/constant");
         MRFZone mrfZone;
-        if (mrfCfg.active) {
+        if (mrfCfg.active)
+        {
             const auto zones = readCellZones(caseDir + "/constant/polyMesh");
             const auto it = zones.find(mrfCfg.cellZone);
             std::vector<label> zoneCells = (it != zones.end()) ? it->second : std::vector<label>{};
-            if (zoneCells.empty()) { zoneCells.resize(nC); for (label c = 0; c < nC; ++c) zoneCells[c] = c; }   // whole-mesh fallback
+            if (zoneCells.empty())   // whole-mesh fallback
+            {
+                zoneCells.resize(nC);
+                for (label c = 0; c < nC; ++c)
+                    zoneCells[c] = c;
+            }
             mrfZone = buildMRFZone(m, zoneCells, mrfCfg.axis, mrfCfg.omega, mrfCfg.origin);
             mrfCorrectBoundaryVelocity(U, mrfZone, g, fvp, mrfCfg.nonRotatingPatches);   // in-zone walls -> Omega x r
             phi = fvc::flux(U, m, g, fvp);                                               // re-flux (absolute; setMRF makes it relative)
@@ -377,27 +528,31 @@ int main(int argc, char** argv) {
                         mrfCfg.origin.x, mrfCfg.origin.y, mrfCfg.origin.z, mrfCfg.nonRotatingPatches.size(), zoneCells.size());
         }
 
-        // ---- device-resident SIMPLE loop ----
+        // device-resident SIMPLE loop
         _tsLap("fields + patches");
         DeviceSimpleSolver solver(m, g, fvp, U, p, phi, ctl,
                                   ctl.turbulent ? &k : nullptr, (ctl.turbulent && !ctl.sa) ? &eps : nullptr, ctl.turbulent ? &nut : nullptr,
                                   ctl.lm ? &ReThetat : nullptr, ctl.lm ? &gammaInt : nullptr);
         _tsLap("solver ctor (incl AMG)");
-        if (partition) {   // caches written by the mesh read + the AMG build above; done, like decomposePar finishing.
+        if (partition)   // caches written by the mesh read + the AMG build above; done, like decomposePar finishing.
+        {
             std::printf("brae -partition: mesh + AMG hierarchy cached to %s/constant/polyMesh/ (.brae_meshcache + .brae_amgcache).\n"
                         "  Run the solve normally; it will reload them warm.\n", caseDir.c_str());
             return 0;
         }
         if (mrfCfg.active) solver.setMRF(mrfZone, m, g, mrfCfg.nonRotatingPatches);
 
-        // ---- fvOptions (system/fvOptions or constant/fvOptions), if present (else an empty no-op list) ----
-        // Read cellZones only when an fvOptions file exists (avoids touching cellZones on cases that have none ,
+        // fvOptions (system/fvOptions or constant/fvOptions), if present (else an empty no-op list)
+        // Read cellZones only when an fvOptions file exists (avoids touching cellZones on cases that have none,
         // and a binary cellZones, which readCellZones does not parse).
         std::map<std::string, std::vector<label>> fvoZones;
-        { std::ifstream a(caseDir + "/system/fvOptions"), b(caseDir + "/constant/fvOptions");
-          if (a.good() || b.good()) fvoZones = readCellZones(caseDir + "/constant/polyMesh"); }
+        {
+            std::ifstream a(caseDir + "/system/fvOptions"), b(caseDir + "/constant/fvOptions");
+            if (a.good() || b.good()) fvoZones = readCellZones(caseDir + "/constant/polyMesh");
+        }
         const FvOptionsData fvo = readFvOptions(caseDir, fvoZones, g.V(), nC, g.C());
-        if (!fvo.empty()) {
+        if (!fvo.empty())
+        {
             solver.setFvOptions(fvo);
             if (fvo.rotor.active)   // build the BEM rotor geometry from the mesh (cell centres + face areas) and hand it over
                 solver.setRotorDisk(buildDeviceRotorDisk(fvo.rotor, g.C(), g.Sf(), m.owner(), m.neighbour(), m.nInternalFaces()));
@@ -406,71 +561,98 @@ int main(int argc, char** argv) {
                         fvo.limUActive ? " limitVelocity" : "", fvo.adActive ? " actuationDiskSource" : "",
                         fvo.rotor.active ? " rotorDiskSource" : "", fvo.vdcActive ? " velocityDampingConstraint" : "",
                         (!fvo.scaSu.empty() || !fvo.scaSp.empty()) ? " scalar(WARN: turbulence-field sources read but not yet applied per-model)" : "");
-        } else {
+        }
+        else
+        {
             std::printf("  No finite volume options present\n");   // OF createFvOptions.H message
         }
         auto ok = [](scalar res, scalar ctlv) { return ctlv < 0 || res < ctlv; };
-        // ---- OF controlDict write cadence: writeControl / writeInterval / purgeWrite (ported from Foam::Time) ----
+        // OF controlDict write cadence: writeControl / writeInterval / purgeWrite (ported from Foam::Time)
         const std::string writeControl = controlDict.wordOr("writeControl", "timeStep");
         const scalar writeInterval = controlDict.scalarOr("writeInterval", 1e30);   // OF default GREAT -> only the final state
         const int    purgeWrite    = std::max(0, controlDict.intOr("purgeWrite", 0));
         const scalar deltaT        = controlDict.scalarOr("deltaT", 1.0);
         const scalar startTimeVal  = controlDict.scalarOr("startTime", 0.0);
         long writeTimeIndex = 0;
-        auto timeName = [](scalar t) -> std::string {                               // integer name for whole times (deltaT=1), else %g
+        auto timeName = [](scalar t) -> std::string   // integer name for whole times (deltaT=1), else %g
+        {
             if (t == std::floor(t) && std::fabs((double)t) < 1e15) return std::to_string((long long)std::llround((double)t));
-            char b[64]; std::snprintf(b, sizeof b, "%g", (double)t); return std::string(b); };
-        auto isWriteTime = [&](int it, scalar tval) -> bool {                       // Foam::Time::operator++ write switch
+            char b[64];
+            std::snprintf(b, sizeof b, "%g", (double)t);
+            return std::string(b);
+        };
+        auto isWriteTime = [&](int it, scalar tval) -> bool   // Foam::Time::operator++ write switch
+        {
             if (writeControl == "timeStep")
                 return writeInterval >= 1 && (it % (long)writeInterval) == 0;       // Time.C: !(timeIndex % writeInterval)
-            if (writeControl == "runTime" || writeControl == "adjustable" || writeControl == "adjustableRunTime") {
+            if (writeControl == "runTime" || writeControl == "adjustable" || writeControl == "adjustableRunTime")
+            {
                 const long wi = (long)(((tval - startTimeVal) + 0.5 * deltaT) / writeInterval);
-                if (wi > writeTimeIndex) { writeTimeIndex = wi; return true; }
-                return false; }
+                if (wi > writeTimeIndex)
+                {
+                    writeTimeIndex = wi;
+                    return true;
+                }
+                return false;
+            }
             return false;   // none / clockTime / cpuTime: only the final state (written after the loop)
         };
         std::deque<std::string> writtenTimes;                                       // purgeWrite FIFO (keep the last N)
         const std::string wsrc = fieldDir + "/";
-        auto writeTimeDir = [&](const std::string& tname) {                         // reconstruct + write one time directory
+        auto writeTimeDir = [&](const std::string& tname)   // reconstruct + write one time directory
+        {
             const std::string outDir = caseDir + "/" + tname;
             std::filesystem::create_directories(outDir);
             // The written fields keep the source field's `#include "include/..."` directives (resolved relative to the
             // time dir). Copy the startTime include/ dir alongside so OpenFOAM readers (paraFoam, postProcess, foamToVTK)
             // resolve them, otherwise the field points at a nonexistent <time>/include/ and fails to load.
-            { std::error_code ec2; if (std::filesystem::exists(fieldDir + "/include"))
-                std::filesystem::copy(fieldDir + "/include", outDir + "/include",
-                    std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing, ec2); }
+            {
+                std::error_code ec2;
+                if (std::filesystem::exists(fieldDir + "/include"))
+                    std::filesystem::copy(fieldDir + "/include", outDir + "/include",
+                        std::filesystem::copy_options::recursive | std::filesystem::copy_options::overwrite_existing, ec2);
+            }
             writeVolField(wsrc + "U", outDir + "/U", solver.U(), fvp, precision);
             writeVolField(wsrc + "p", outDir + "/p", solver.p(), fvp, precision);
-            if (ctl.sa) {                                                           // one-equation: the k slot holds nuTilda
+            if (ctl.sa)   // one-equation: the k slot holds nuTilda
+            {
                 writeVolField(wsrc + "nuTilda", outDir + "/nuTilda", solver.k(),   fvp, precision);
                 writeVolField(wsrc + "nut",     outDir + "/nut",     solver.nut(), fvp, precision);
-            } else if (ctl.turbulent) {
+            }
+            else if (ctl.turbulent)
+            {
                 writeVolField(wsrc + "k", outDir + "/k", solver.k(), fvp, precision);
                 writeVolField(wsrc + secondName, outDir + "/" + secondName, solver.eps(), fvp, precision);
                 writeVolField(wsrc + "nut", outDir + "/nut", solver.nut(), fvp, precision);
-                if (ctl.lm) {                                                       // kOmegaSSTLM transition fields
+                if (ctl.lm)   // kOmegaSSTLM transition fields
+                {
                     writeVolField(wsrc + "ReThetat", outDir + "/ReThetat", solver.ReThetat(), fvp, precision);
                     writeVolField(wsrc + "gammaInt", outDir + "/gammaInt", solver.gammaInt(), fvp, precision);
                 }
             }
             std::printf("written %s/{U,p%s}\n", outDir.c_str(),
                         ctl.turbulent ? (ctl.sa ? ",nuTilda,nut" : ctl.sst ? ",k,omega,nut" : ",k,epsilon,nut") : "");
-            if (purgeWrite > 0) {                                                   // Foam::Time TimeIO: keep only the last purgeWrite dirs
+            if (purgeWrite > 0)   // Foam::Time TimeIO: keep only the last purgeWrite dirs
+            {
                 if (writtenTimes.empty() || writtenTimes.back() != tname) writtenTimes.push_back(tname);
-                while ((int)writtenTimes.size() > purgeWrite) {
-                    std::error_code pec; std::filesystem::remove_all(caseDir + "/" + writtenTimes.front(), pec);
+                while ((int)writtenTimes.size() > purgeWrite)
+                {
+                    std::error_code pec;
+                    std::filesystem::remove_all(caseDir + "/" + writtenTimes.front(), pec);
                     writtenTimes.pop_front();
                 }
             }
         };
 
-        int iter = 0; bool converged = false;
+        int iter = 0;
+        bool converged = false;
         const auto _runStart = std::chrono::high_resolution_clock::now();          // for OpenFOAM-style ExecutionTime
         double _cumCont = 0.0;                                                     // cumulative continuity error (OF continuityErrs.H)
-        for (iter = 1; iter <= endTime && !converged; ++iter) {
+        for (iter = 1; iter <= endTime && !converged; ++iter)
+        {
             const DeviceSimpleResidual r = solver.step();
-            {   // OpenFOAM-style per-iteration report: Time, per-field solver residuals, continuity, turbulence, ExecutionTime.
+            {
+                // OpenFOAM-style per-iteration report: Time, per-field solver residuals, continuity, turbulence, ExecutionTime.
                 const double _et = std::chrono::duration<double>(std::chrono::high_resolution_clock::now() - _runStart).count();
                 const double cl = (double)deltaT * r.contLocal, cg = (double)deltaT * r.contGlobal;
                 _cumCont += cg;
@@ -497,45 +679,91 @@ int main(int argc, char** argv) {
 
         // BRAE_DUMP_CONTINUITY: localise the per-cell continuity imbalance R[c]=sum_f phi_f and bucket sum|R| by
         // region (wall-adjacent / farfield-adjacent / interior) to find WHERE continuity fails to close.
-        if (std::getenv("BRAE_DUMP_CONTINUITY")) {
+        if (std::getenv("BRAE_DUMP_CONTINUITY"))
+        {
             const std::vector<scalar> phiI = solver.phiInternal(), phiB = solver.phiBoundary();
             std::vector<scalar> R(nC, 0.0);
-            for (label f = 0; f < m.nInternalFaces(); ++f) { R[m.owner()[f]] += phiI[f]; R[m.neighbour()[f]] -= phiI[f]; }
-            { label bi = 0; for (const auto& pp : fvp) for (label i = 0; i < pp.size; ++i) R[pp.faceCells[i]] += phiB[bi++]; }
+            for (label f = 0; f < m.nInternalFaces(); ++f)
+            {
+                R[m.owner()[f]] += phiI[f];
+                R[m.neighbour()[f]] -= phiI[f];
+            }
+            {
+                label bi = 0;
+                for (const auto& pp : fvp)
+                    for (label i = 0; i < pp.size; ++i)
+                        R[pp.faceCells[i]] += phiB[bi++];
+            }
             std::vector<int> tag(nC, 0);   // 0=interior 1=wall-adjacent 2=farfield(patch)-adjacent
-            for (const auto& pp : fvp) { const int t = (pp.type == "wall") ? 1 : (pp.type == "patch" ? 2 : 0);
-                if (t) for (label i = 0; i < pp.size; ++i) tag[pp.faceCells[i]] = std::max(tag[pp.faceCells[i]], t); }
-            double sAll = 0, sW = 0, sF = 0, sI = 0, mx = 0; label mxc = 0;
-            for (label c = 0; c < nC; ++c) { const double a = std::fabs(R[c]); sAll += a;
-                if (tag[c] == 1) sW += a; else if (tag[c] == 2) sF += a; else sI += a; if (a > mx) { mx = a; mxc = c; } }
+            for (const auto& pp : fvp)
+            {
+                const int t = (pp.type == "wall") ? 1 : (pp.type == "patch" ? 2 : 0);
+                if (t)
+                    for (label i = 0; i < pp.size; ++i)
+                        tag[pp.faceCells[i]] = std::max(tag[pp.faceCells[i]], t);
+            }
+            double sAll = 0, sW = 0, sF = 0, sI = 0, mx = 0;
+            label mxc = 0;
+            for (label c = 0; c < nC; ++c)
+            {
+                const double a = std::fabs(R[c]);
+                sAll += a;
+                if (tag[c] == 1) sW += a;
+                else if (tag[c] == 2) sF += a;
+                else sI += a;
+                if (a > mx) { mx = a; mxc = c; }
+            }
             const double inv = sAll > 0 ? 100.0 / sAll : 0.0;
             std::printf("CONTINUITY: sum|div phi|=%.4e  max=%.4e @cell %d  | region share: wall=%.1f%% farfield=%.1f%% interior=%.1f%%\n",
                         sAll, mx, (int)mxc, sW * inv, sF * inv, sI * inv);
-            std::vector<label> idx(nC); for (label c = 0; c < nC; ++c) idx[c] = c;
+            std::vector<label> idx(nC);
+            for (label c = 0; c < nC; ++c)
+                idx[c] = c;
             const label topN = std::min<label>(12, nC);
             std::partial_sort(idx.begin(), idx.begin() + topN, idx.end(), [&](label a, label b){ return std::fabs(R[a]) > std::fabs(R[b]); });
             std::printf("  top cells (|imbalance|, tag, centroid):\n");
-            for (label q = 0; q < topN; ++q) { const label c = idx[q]; const vector cc = g.C()[c];
-                std::printf("    cell %6d  |R|=%.3e  tag=%d  C=(%.4f %.4f %.4f)\n", (int)c, std::fabs(R[c]), tag[c], cc.x, cc.y, cc.z); }
+            for (label q = 0; q < topN; ++q)
+            {
+                const label c = idx[q];
+                const vector cc = g.C()[c];
+                std::printf("    cell %6d  |R|=%.3e  tag=%d  C=(%.4f %.4f %.4f)\n", (int)c, std::fabs(R[c]), tag[c], cc.x, cc.y, cc.z);
+            }
         }
 
-        if (std::getenv("BRAE_DUMP_Y") && ctl.turbulent) {   // cell wall distance stats vs OF wallDist (SA destruction ~ 1/y^2)
+        if (std::getenv("BRAE_DUMP_Y") && ctl.turbulent)   // cell wall distance stats vs OF wallDist (SA destruction ~ 1/y^2)
+        {
             const std::vector<scalar> yv = solver.cellY();
-            if (!yv.empty()) { double mn = 1e300, mx = 0, sm = 0; for (scalar v : yv) { mn = std::min(mn, (double)v); mx = std::max(mx, (double)v); sm += v; }
-                std::printf("cellY: min=%.4e max=%.4e mean=%.4e (n=%zu)\n", mn, mx, sm / yv.size(), yv.size()); } }
+            if (!yv.empty())
+            {
+                double mn = 1e300, mx = 0, sm = 0;
+                for (scalar v : yv)
+                {
+                    mn = std::min(mn, (double)v);
+                    mx = std::max(mx, (double)v);
+                    sm += v;
+                }
+                std::printf("cellY: min=%.4e max=%.4e mean=%.4e (n=%zu)\n", mn, mx, sm / yv.size(), yv.size());
+            }
+        }
 
-        // ---- always write the final (converged / endTime) state; matches OF's writeAndEnd, and feeds purgeWrite ----
+        // always write the final (converged / endTime) state; matches OF's writeAndEnd, and feeds purgeWrite
         writeTimeDir(timeName(startTimeVal + (scalar)nIter * deltaT));
         const std::vector<vector> Ug = solver.U();   // converged fields, reused by the force calculation below
         const std::vector<scalar> pg = solver.p();
 
         // forces on wall patches (OF functionObjects::forces; kinematic, rhoInf=1). Validated vs OF (ctest forces).
-        if (ctl.turbulent) {
+        if (ctl.turbulent)
+        {
             std::vector<std::string> walls;
-            for (const auto& q : fvp) if (q.type == "wall") walls.push_back(q.name);
-            if (!walls.empty()) {
-                for (label c = 0; c < nC; ++c) U.internal[c] = Ug[c];   // converged fields -> evaluate wall BCs
-                p.internal = pg; U.evaluateBoundary(); p.evaluateBoundary();
+            for (const auto& q : fvp)
+                if (q.type == "wall") walls.push_back(q.name);
+            if (!walls.empty())
+            {
+                for (label c = 0; c < nC; ++c)
+                    U.internal[c] = Ug[c];   // converged fields -> evaluate wall BCs
+                p.internal = pg;
+                U.evaluateBoundary();
+                p.evaluateBoundary();
                 const scalar wCmu   = ctl.sst ? ctl.ksstCoeffs.betaStar : ctl.keCoeffs.Cmu;
                 const scalar wKappa = ctl.sst ? ctl.ksstCoeffs.kappa    : ctl.keCoeffs.kappa;
                 const scalar wE     = ctl.sst ? ctl.ksstCoeffs.E        : ctl.keCoeffs.E;
@@ -549,8 +777,15 @@ int main(int argc, char** argv) {
                 // forceCoeffs (Cd/Cl/Cm) if the case defines a forceCoeffs functionObject (controlDict.functions).
                 const FoamDict* funcs = controlDict.subDict("functions");
                 const FoamDict* fcd = nullptr;
-                if (funcs) for (const auto& s : funcs->subs) if (s.second.wordOr("type", "") == "forceCoeffs") { fcd = &s.second; break; }
-                if (fcd) {
+                if (funcs)
+                    for (const auto& s : funcs->subs)
+                        if (s.second.wordOr("type", "") == "forceCoeffs")
+                        {
+                            fcd = &s.second;
+                            break;
+                        }
+                if (fcd)
+                {
                     auto toV = [](const std::vector<scalar>& a, vector d){ return a.size() >= 3 ? vector{a[0],a[1],a[2]} : d; };
                     const std::vector<std::string> fcP = fcd->wordListOr("patches", walls);
                     const scalar rhoInf = fcd->scalarOr("rhoInf", 1.0), magUInf = fcd->scalarOr("magUInf", 1.0);
@@ -566,7 +801,9 @@ int main(int argc, char** argv) {
                 }
             }
         }
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         std::fprintf(stderr, "brae ERROR: %s\n", e.what());
         return 1;
     }

--- a/src/applications/solvers/simpleFoam/mrf_simple.cuh
+++ b/src/applications/solvers/simpleFoam/mrf_simple.cuh
@@ -20,49 +20,83 @@
 namespace brae {
 
 // constrainHbyA: HbyA boundary = U's fixed value at fixedValue patches, zeroGradient/empty elsewhere.
-inline GeometricField<vector> mrfConstrainHbyA(const std::vector<vector>& Hcell, const GeometricField<vector>& U,
-                                               const std::vector<FvPatch>& fvp) {
-    GeometricField<vector> HbyA; HbyA.internal = Hcell;
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) {
-        if (fvp[pi].type == "empty") HbyA.boundary.push_back(std::make_unique<EmptyPatchField<vector>>(fvp[pi]));
+inline GeometricField<vector> mrfConstrainHbyA(
+    const std::vector<vector>& Hcell,
+    const GeometricField<vector>& U,
+    const std::vector<FvPatch>& fvp)
+{
+    GeometricField<vector> HbyA;
+    HbyA.internal = Hcell;
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+    {
+        if (fvp[pi].type == "empty")
+            HbyA.boundary.push_back(std::make_unique<EmptyPatchField<vector>>(fvp[pi]));
         else if (U.boundary[pi]->fixesValue())
             HbyA.boundary.push_back(std::make_unique<FixedValuePatchField<vector>>(fvp[pi], false, vector{}, U.boundary[pi]->value()));
-        else HbyA.boundary.push_back(std::make_unique<ZeroGradientPatchField<vector>>(fvp[pi]));
+        else
+            HbyA.boundary.push_back(std::make_unique<ZeroGradientPatchField<vector>>(fvp[pi]));
     }
     return HbyA;
 }
 
-inline void mrfSimpleStep(const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& fvp,
-                          const MRFZone& z, GeometricField<vector>& U, GeometricField<scalar>& p,
-                          SurfaceScalarField& phi,
-                          scalar nu, scalar relaxU, scalar relaxP, scalar tolU, scalar tolP) {
+inline void mrfSimpleStep(
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp,
+    const MRFZone& z,
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    scalar nu,
+    scalar relaxU,
+    scalar relaxP,
+    scalar tolU,
+    scalar tolP)
+{
     const label nC = m.nCells(), nIf = m.nInternalFaces();
     const std::vector<scalar>& V = g.V();
 
     // momentum: div(phi_rel,U) - laplacian(nu,U) - div(nu dev2(T(grad U))) + Coriolis.
     FvVectorMatrix UEqn = fvm::div(phi.internal, phi.boundary, U, m, fvp);
     addEqual(UEqn, fvm::laplacian(U, nu, m, g, fvp), -1.0);
-    { const std::vector<tensor> gC = fvc::gaussGrad(U, m, g, fvp);
-      const std::vector<std::vector<tensor>> gB = fvc::gradUBoundary(U, gC, m, g, fvp);
-      std::vector<tensor> sC(nC); for (label c = 0; c < nC; ++c) sC[c] = nu * dev2(transpose(gC[c]));
-      std::vector<std::vector<tensor>> sB(fvp.size());
-      for (std::size_t pi = 0; pi < fvp.size(); ++pi) { sB[pi].resize(fvp[pi].size);
-          for (label i = 0; i < fvp[pi].size; ++i) sB[pi][i] = nu * dev2(transpose(gB[pi][i])); }
-      const std::vector<vector> dS = fvc::div(sC, sB, m, g, fvp);
-      for (label c = 0; c < nC; ++c) UEqn.source[c] += V[c] * dS[c]; }
+    {
+        const std::vector<tensor> gC = fvc::gaussGrad(U, m, g, fvp);
+        const std::vector<std::vector<tensor>> gB = fvc::gradUBoundary(U, gC, m, g, fvp);
+        std::vector<tensor> sC(nC);
+        for (label c = 0; c < nC; ++c)
+            sC[c] = nu * dev2(transpose(gC[c]));
+        std::vector<std::vector<tensor>> sB(fvp.size());
+        for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        {
+            sB[pi].resize(fvp[pi].size);
+            for (label i = 0; i < fvp[pi].size; ++i)
+                sB[pi][i] = nu * dev2(transpose(gB[pi][i]));
+        }
+        const std::vector<vector> dS = fvc::div(sC, sB, m, g, fvp);
+        for (label c = 0; c < nC; ++c)
+            UEqn.source[c] += V[c] * dS[c];
+    }
     addCoriolis(UEqn.source, U.internal, V, z);                 // MRF.DDt(U)
     relaxMatrix(UEqn, U, m, fvp, relaxU);
 
     // momentum predictor.
-    { const std::vector<vector> gP = fvc::gaussGrad(p, m, g, fvp);
-      FvVectorMatrix Mp = UEqn; for (label c = 0; c < nC; ++c) Mp.source[c] += (-V[c]) * gP[c];
-      solveVector(Mp, U, m, fvp, tolU, 0.0, 2000); }
+    {
+        const std::vector<vector> gP = fvc::gaussGrad(p, m, g, fvp);
+        FvVectorMatrix Mp = UEqn;
+        for (label c = 0; c < nC; ++c)
+            Mp.source[c] += (-V[c]) * gP[c];
+        solveVector(Mp, U, m, fvp, tolU, 0.0, 2000);
+    }
 
     // rAU, HbyA, phiHbyA (relative).
     const std::vector<scalar> A = matrixA(UEqn, m, g, fvp);
-    std::vector<scalar> rAU(nC); for (label c = 0; c < nC; ++c) rAU[c] = 1.0 / A[c];
+    std::vector<scalar> rAU(nC);
+    for (label c = 0; c < nC; ++c)
+        rAU[c] = 1.0 / A[c];
     const std::vector<vector> H = matrixH(UEqn, U, m, g, fvp);
-    std::vector<vector> Hcell(nC); for (label c = 0; c < nC; ++c) Hcell[c] = rAU[c] * H[c];
+    std::vector<vector> Hcell(nC);
+    for (label c = 0; c < nC; ++c)
+        Hcell[c] = rAU[c] * H[c];
     GeometricField<vector> HbyA = mrfConstrainHbyA(Hcell, U, fvp);
     HbyA.evaluateBoundary();
     SurfaceScalarField phiHbyA = fvc::flux(HbyA, m, g, fvp);
@@ -72,23 +106,31 @@ inline void mrfSimpleStep(const PrimitiveMesh& m, const FvGeometry& g, const std
     const SurfaceScalarField rAUf = fvc::interpolate(rAU, m, g, fvp);
     FvScalarMatrix pEqn = fvm::laplacian(rAUf, p, m, g, fvp);
     const std::vector<scalar> dphi = fvc::div(phiHbyA, m, g, fvp);
-    for (label c = 0; c < nC; ++c) pEqn.source[c] += V[c] * dphi[c];
-    scalar dsum = 0; for (scalar d : pEqn.diag) dsum += std::fabs(d);
+    for (label c = 0; c < nC; ++c)
+        pEqn.source[c] += V[c] * dphi[c];
+    scalar dsum = 0;
+    for (scalar d : pEqn.diag)
+        dsum += std::fabs(d);
     const scalar eps = 1e-10 * (dsum / nC);
-    for (label c = 0; c < nC; ++c) pEqn.diag[c] -= eps;        // remove the constant nullspace symmetrically
+    for (label c = 0; c < nC; ++c)
+        pEqn.diag[c] -= eps;        // remove the constant nullspace symmetrically
     const std::vector<scalar> pPrev = p.internal;
     pcg(pEqn, p.internal, m, fvp, tolP, 0.0, 4000);
     p.evaluateBoundary();
 
     // conservative relative flux + relax + corrector.
     const SurfaceScalarField pflux = matrixFlux(pEqn, p, m, fvp);
-    for (label f = 0; f < nIf; ++f) phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) for (label i = 0; i < fvp[pi].size; ++i)
-        phi.boundary[pi][i] = phiHbyA.boundary[pi][i] - pflux.boundary[pi][i];
-    for (label c = 0; c < nC; ++c) p.internal[c] = pPrev[c] + relaxP * (p.internal[c] - pPrev[c]);
+    for (label f = 0; f < nIf; ++f)
+        phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        for (label i = 0; i < fvp[pi].size; ++i)
+            phi.boundary[pi][i] = phiHbyA.boundary[pi][i] - pflux.boundary[pi][i];
+    for (label c = 0; c < nC; ++c)
+        p.internal[c] = pPrev[c] + relaxP * (p.internal[c] - pPrev[c]);
     p.evaluateBoundary();
     const std::vector<vector> gPn = fvc::gaussGrad(p, m, g, fvp);
-    for (label c = 0; c < nC; ++c) U.internal[c] = HbyA.internal[c] - rAU[c] * gPn[c];
+    for (label c = 0; c < nC; ++c)
+        U.internal[c] = HbyA.internal[c] - rAU[c] * gPn[c];
     U.evaluateBoundary();
 }
 

--- a/src/applications/solvers/simpleFoam/parallel_simple.cuh
+++ b/src/applications/solvers/simpleFoam/parallel_simple.cuh
@@ -29,7 +29,8 @@ inline scalar pcmp(const vector& v, int c) { return c == 0 ? v.x : (c == 1 ? v.y
 inline void   pset(vector& v, int c, scalar s) { if (c == 0) v.x = s; else if (c == 1) v.y = s; else v.z = s; }
 
 // One rank's decomposed view. globalNCells is needed for the parallel solvers' normFactor.
-struct Partition {
+struct Partition
+{
     int rank = 0; label globalNCells = 0;
     std::vector<PatchInfo> gPatches;
     LocalMesh Lm; FvGeometry lg; std::vector<FvPatch> lp;
@@ -37,12 +38,17 @@ struct Partition {
     std::vector<ProcessorInterface> ifs;
 
     Partition(const PrimitiveMesh& gm, const std::vector<label>& cellToPart, int myRank)
-        : rank(myRank), globalNCells(gm.nCells()), gPatches(gm.patches()), Lm(buildLocalMesh(gm, cellToPart, myRank)) {
+        : rank(myRank),
+          globalNCells(gm.nCells()),
+          gPatches(gm.patches()),
+          Lm(buildLocalMesh(gm, cellToPart, myRank))
+    {
         lg.build(Lm.mesh);
         lp = buildPatches(Lm.mesh, lg);
         procDelta = computeProcDeltaCoeffs(Lm, lg, lp);
         procW     = computeProcWeights(Lm, lg, lp);
-        for (std::size_t j = 0; j < Lm.procNbr.size(); ++j) ifs.emplace_back(myRank, Lm.procNbr[j], Lm.procFaceCells[j]);
+        for (std::size_t j = 0; j < Lm.procNbr.size(); ++j)
+            ifs.emplace_back(myRank, Lm.procNbr[j], Lm.procFaceCells[j]);
     }
     label nCells() const { return Lm.mesh.nCells(); }
 };
@@ -51,12 +57,22 @@ struct Partition {
 // patches interpolating (w*local + (1-w)*halo) so value() gives the coupled face value. Works for
 // scalar (gamma fields) and tensor (the divDevReff stress sigma).
 template <typename T>
-inline GeometricField<T> distributeFromCells(const std::vector<T>& cells, const Partition& P) {
-    GeometricField<T> gf; gf.internal = cells;
+inline GeometricField<T> distributeFromCells(const std::vector<T>& cells, const Partition& P)
+{
+    GeometricField<T> gf;
+    gf.internal = cells;
     std::size_t pj = 0;
-    for (const FvPatch& p : P.lp) {
-        if (p.type == "processor") { auto pf = std::make_unique<ProcessorFvPatchField<T>>(p, P.Lm.procNbr[pj], 0); pf->setWeights(P.procW[pj]); gf.boundary.push_back(std::move(pf)); ++pj; }
-        else gf.boundary.push_back(std::make_unique<ZeroGradientPatchField<T>>(p));
+    for (const FvPatch& p : P.lp)
+    {
+        if (p.type == "processor")
+        {
+            auto pf = std::make_unique<ProcessorFvPatchField<T>>(p, P.Lm.procNbr[pj], 0);
+            pf->setWeights(P.procW[pj]);
+            gf.boundary.push_back(std::move(pf));
+            ++pj;
+        }
+        else
+            gf.boundary.push_back(std::make_unique<ZeroGradientPatchField<T>>(p));
     }
     gf.evaluateBoundary();
     return gf;
@@ -65,30 +81,45 @@ inline GeometricField<T> distributeFromCells(const std::vector<T>& cells, const 
 // Explicit divDevReff stress term fvc::div(nuEff*dev2(T(grad U))) on the distributed mesh. The cell
 // gradient is the processor-aware gaussGrad; processor FACES use the INTERPOLATED cell sigma (coupled
 // face, via a distributed tensor field), real faces use the snGrad-corrected boundary gradient.
-inline std::vector<vector> parallelDivDevReff(const Partition& P, const GeometricField<vector>& U,
-                                              const std::vector<scalar>& nuEffCell,
-                                              const std::vector<std::vector<scalar>>& nuEffBnd) {
-    const PrimitiveMesh& m = P.Lm.mesh; const FvGeometry& g = P.lg; const std::vector<FvPatch>& lp = P.lp;
+inline std::vector<vector> parallelDivDevReff(
+    const Partition& P,
+    const GeometricField<vector>& U,
+    const std::vector<scalar>& nuEffCell,
+    const std::vector<std::vector<scalar>>& nuEffBnd)
+{
+    const PrimitiveMesh& m = P.Lm.mesh;
+    const FvGeometry& g = P.lg;
+    const std::vector<FvPatch>& lp = P.lp;
     const std::vector<tensor> gradC = fvc::gaussGrad(U, m, g, lp);
     std::vector<tensor> sigC(m.nCells());
-    for (label c = 0; c < m.nCells(); ++c) sigC[c] = nuEffCell[c] * dev2(transpose(gradC[c]));
+    for (label c = 0; c < m.nCells(); ++c)
+        sigC[c] = nuEffCell[c] * dev2(transpose(gradC[c]));
     GeometricField<tensor> sigFld = distributeFromCells<tensor>(sigC, P);            // processor-interpolated sigma
     const std::vector<std::vector<tensor>> gradB = fvc::gradUBoundary(U, gradC, m, g, lp);
     std::vector<std::vector<tensor>> sigB(lp.size());
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) {
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+    {
         sigB[pi].resize(lp[pi].size);
-        if (lp[pi].type == "processor") for (label i = 0; i < lp[pi].size; ++i) sigB[pi][i] = sigFld.boundary[pi]->value()[i];
-        else                            for (label i = 0; i < lp[pi].size; ++i) sigB[pi][i] = nuEffBnd[pi][i] * dev2(transpose(gradB[pi][i]));
+        if (lp[pi].type == "processor")
+            for (label i = 0; i < lp[pi].size; ++i)
+                sigB[pi][i] = sigFld.boundary[pi]->value()[i];
+        else
+            for (label i = 0; i < lp[pi].size; ++i)
+                sigB[pi][i] = nuEffBnd[pi][i] * dev2(transpose(gradB[pi][i]));
     }
     return fvc::div(sigC, sigB, m, g, lp);
 }
 
 // outward flux per LOCAL face from the maintained phi (internal + boundary). Processor faces carry
 // the conservative interface flux; real-boundary entries are the patch flux (used by fvm::div).
-inline std::vector<scalar> outwardFlux(const Partition& P, const SurfaceScalarField& phi) {
+inline std::vector<scalar> outwardFlux(const Partition& P, const SurfaceScalarField& phi)
+{
     std::vector<scalar> o(P.Lm.mesh.nFaces(), 0.0);
-    for (label f = 0; f < P.Lm.mesh.nInternalFaces(); ++f) o[f] = phi.internal[f];
-    for (std::size_t pi = 0; pi < P.lp.size(); ++pi) for (label i = 0; i < P.lp[pi].size; ++i) o[P.lp[pi].start + i] = phi.boundary[pi][i];
+    for (label f = 0; f < P.Lm.mesh.nInternalFaces(); ++f)
+        o[f] = phi.internal[f];
+    for (std::size_t pi = 0; pi < P.lp.size(); ++pi)
+        for (label i = 0; i < P.lp[pi].size; ++i)
+            o[P.lp[pi].start + i] = phi.boundary[pi][i];
     return o;
 }
 
@@ -97,32 +128,55 @@ struct ParStepResidual { scalar p = 0.0, Ux = 0.0; };
 
 // One laminar/simplified SIMPLE iteration on the distributed fields; updates U, p, phi in place.
 // Returns the momentum-predictor and pressure initial residuals (OF SIMPLE convergence measure).
-inline ParStepResidual parallelSimpleStepLaminar(const Partition& P, GeometricField<vector>& U, GeometricField<scalar>& p,
-                                      SurfaceScalarField& phi, const std::vector<scalar>& nuEffCell,
-                                      const std::vector<std::vector<scalar>>& nuEffBnd,
-                                      const FieldData<vector>& UbcShape, scalar relaxU, scalar relaxP,
-                                      scalar tolU, scalar tolP, bool bounded = false) {
+inline ParStepResidual parallelSimpleStepLaminar(
+    const Partition& P,
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    const std::vector<scalar>& nuEffCell,
+    const std::vector<std::vector<scalar>>& nuEffBnd,
+    const FieldData<vector>& UbcShape,
+    scalar relaxU,
+    scalar relaxP,
+    scalar tolU,
+    scalar tolP,
+    bool bounded = false)
+{
     ParStepResidual res;
-    const PrimitiveMesh& m = P.Lm.mesh; const FvGeometry& lg = P.lg; const std::vector<FvPatch>& lp = P.lp;
+    const PrimitiveMesh& m = P.Lm.mesh;
+    const FvGeometry& lg = P.lg;
+    const std::vector<FvPatch>& lp = P.lp;
     const label lnC = m.nCells(), nIf = m.nInternalFaces();
     std::vector<ProcessorInterface> ifs = P.ifs;   // local copy (mutable exchange buffers)
 
     // validComponents (fvMesh::validComponents): an empty-patch direction is not solved, so it must
     // not pollute the U residualControl measure. Mirror OF, exclude empty directions from res.Ux.
     bool validC[3] = {true, true, true};
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) if (lp[pi].type == "empty" && lp[pi].size > 0) {
-        scalar ax = 0, ay = 0, az = 0;
-        for (label i = 0; i < lp[pi].size; ++i) { const vector& n = lg.Sf()[lp[pi].start + i]; ax += std::fabs(n.x); ay += std::fabs(n.y); az += std::fabs(n.z); }
-        validC[(ax >= ay && ax >= az) ? 0 : (ay >= az ? 1 : 2)] = false;
-    }
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        if (lp[pi].type == "empty" && lp[pi].size > 0)
+        {
+            scalar ax = 0, ay = 0, az = 0;
+            for (label i = 0; i < lp[pi].size; ++i)
+            {
+                const vector& n = lg.Sf()[lp[pi].start + i];
+                ax += std::fabs(n.x);
+                ay += std::fabs(n.y);
+                az += std::fabs(n.z);
+            }
+            validC[(ax >= ay && ax >= az) ? 0 : (ay >= az ? 1 : 2)] = false;
+        }
 
     // nuEff at faces: interpolate internal; real boundary = nuEffBnd (= nu+nut_b); processor = interpolated.
     GeometricField<scalar> nuEffFld = distributeFromCells<scalar>(nuEffCell, P);
     SurfaceScalarField nuEfff0 = fvc::interpolate(nuEffCell, m, lg, lp);
     nuEfff0.boundary = nuEffBnd;
     std::vector<scalar> nuF(m.nFaces(), 0.0);
-    for (label f = 0; f < nIf; ++f) nuF[f] = nuEfff0.internal[f];
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) if (lp[pi].type == "processor") for (label i = 0; i < lp[pi].size; ++i) nuF[lp[pi].start + i] = nuEffFld.boundary[pi]->value()[i];
+    for (label f = 0; f < nIf; ++f)
+        nuF[f] = nuEfff0.internal[f];
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        if (lp[pi].type == "processor")
+            for (label i = 0; i < lp[pi].size; ++i)
+                nuF[lp[pi].start + i] = nuEffFld.boundary[pi]->value()[i];
 
     const std::vector<scalar> outPhi = outwardFlux(P, phi);
 
@@ -130,37 +184,71 @@ inline ParStepResidual parallelSimpleStepLaminar(const Partition& P, GeometricFi
     FvVectorMatrix Ml = fvm::div(phi.internal, phi.boundary, U, m, lp);
     addEqual(Ml, fvm::laplacian(nuEfff0, U, m, lg, lp), -1.0);
     const std::vector<vector> divSig = parallelDivDevReff(P, U, nuEffCell, nuEffBnd);
-    for (label c = 0; c < lnC; ++c) Ml.source[c] += lg.V()[c] * divSig[c];
+    for (label c = 0; c < lnC; ++c)
+        Ml.source[c] += lg.V()[c] * divSig[c];
     // bounded Gauss upwind: - fvm::Sp(fvc::div(phi), U). Diagonal gets -V*div(phi), stabilises the transient
     // (a rest-start inlet cell where div(phi)!=0 at low nu blows up otherwise); vanishes at convergence.
-    if (bounded) { const std::vector<scalar> divPhi = fvc::div(phi, m, lg, lp);
-        for (label c = 0; c < lnC; ++c) Ml.diag[c] -= divPhi[c] * lg.V()[c]; }
+    if (bounded)
+    {
+        const std::vector<scalar> divPhi = fvc::div(phi, m, lg, lp);
+        for (label c = 0; c < lnC; ++c)
+            Ml.diag[c] -= divPhi[c] * lg.V()[c];
+    }
     DistributedMatrix L = momentumDistributed(Ml, P.Lm, lg, lp, outPhi, nuF, P.procDelta);
     parallelRelaxMatrix(L, Ml, U.internal, P.Lm, lp, relaxU);
-    { const std::vector<vector> gP = fvc::gaussGrad(p, m, lg, lp);
-      for (int k = 0; k < 3; ++k) {
-        DistributedMatrix Lc = L; Lc.diagC = L.diag; Lc.b.assign(lnC, 0.0);
-        for (label c = 0; c < lnC; ++c) Lc.b[c] = pcmp(Ml.source[c], k) - lg.V()[c] * pcmp(gP[c], k);
-        for (std::size_t pi = 0; pi < lp.size(); ++pi) for (label i = 0; i < lp[pi].size; ++i) { Lc.diagC[lp[pi].faceCells[i]] += pcmp(Ml.internalCoeffs[pi][i], k); Lc.b[lp[pi].faceCells[i]] += pcmp(Ml.boundaryCoeffs[pi][i], k); }
-        std::vector<scalar> x(lnC); for (label c = 0; c < lnC; ++c) x[c] = pcmp(U.internal[c], k);
-        const SolverPerformance up = parallelPBiCGStab(Lc, x, ifs, P.globalNCells, tolU, 0.0, 2000);
-        if (validC[k] && up.initialResidual > res.Ux) res.Ux = up.initialResidual;   // max over solved components
-        for (label c = 0; c < lnC; ++c) pset(U.internal[c], k, x[c]);
-      } }
+    {
+        const std::vector<vector> gP = fvc::gaussGrad(p, m, lg, lp);
+        for (int k = 0; k < 3; ++k)
+        {
+            DistributedMatrix Lc = L;
+            Lc.diagC = L.diag;
+            Lc.b.assign(lnC, 0.0);
+            for (label c = 0; c < lnC; ++c)
+                Lc.b[c] = pcmp(Ml.source[c], k) - lg.V()[c] * pcmp(gP[c], k);
+            for (std::size_t pi = 0; pi < lp.size(); ++pi)
+                for (label i = 0; i < lp[pi].size; ++i)
+                {
+                    Lc.diagC[lp[pi].faceCells[i]] += pcmp(Ml.internalCoeffs[pi][i], k);
+                    Lc.b[lp[pi].faceCells[i]] += pcmp(Ml.boundaryCoeffs[pi][i], k);
+                }
+            std::vector<scalar> x(lnC);
+            for (label c = 0; c < lnC; ++c)
+                x[c] = pcmp(U.internal[c], k);
+            const SolverPerformance up = parallelPBiCGStab(Lc, x, ifs, P.globalNCells, tolU, 0.0, 2000);
+            if (validC[k] && up.initialResidual > res.Ux) res.Ux = up.initialResidual;   // max over solved components
+            for (label c = 0; c < lnC; ++c)
+                pset(U.internal[c], k, x[c]);
+        }
+    }
 
     // rAU, HbyA, phiHbyA
     L.diagC = L.diag;
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) for (label i = 0; i < lp[pi].size; ++i) L.diagC[lp[pi].faceCells[i]] += cmptAv(Ml.internalCoeffs[pi][i]);
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        for (label i = 0; i < lp[pi].size; ++i)
+            L.diagC[lp[pi].faceCells[i]] += cmptAv(Ml.internalCoeffs[pi][i]);
     const std::vector<scalar> A = parallelMatrixA(L, lg.V());
-    std::vector<scalar> rAU(lnC); for (label c = 0; c < lnC; ++c) rAU[c] = 1.0 / A[c];
+    std::vector<scalar> rAU(lnC);
+    for (label c = 0; c < lnC; ++c)
+        rAU[c] = 1.0 / A[c];
     GeometricField<vector> HbyA = distributeField<vector>(UbcShape, P.gPatches, P.Lm, lp, P.procW, P.rank);
-    for (int k = 0; k < 3; ++k) {
-        std::vector<scalar> Uk(lnC); for (label c = 0; c < lnC; ++c) Uk[c] = pcmp(U.internal[c], k);
+    for (int k = 0; k < 3; ++k)
+    {
+        std::vector<scalar> Uk(lnC);
+        for (label c = 0; c < lnC; ++c)
+            Uk[c] = pcmp(U.internal[c], k);
         const std::vector<scalar> Apsi = parallelAmul(L, Uk, ifs);
         std::vector<scalar> Hk(lnC);
-        for (label c = 0; c < lnC; ++c) Hk[c] = L.diag[c] * Uk[c] - Apsi[c] + pcmp(Ml.source[c], k);
-        for (std::size_t pi = 0; pi < lp.size(); ++pi) for (label i = 0; i < lp[pi].size; ++i) { const vector ic = Ml.internalCoeffs[pi][i]; const label fc = lp[pi].faceCells[i]; Hk[fc] += (cmptAv(ic) - pcmp(ic, k)) * Uk[fc] + pcmp(Ml.boundaryCoeffs[pi][i], k); }
-        for (label c = 0; c < lnC; ++c) pset(HbyA.internal[c], k, rAU[c] * Hk[c] / lg.V()[c]);
+        for (label c = 0; c < lnC; ++c)
+            Hk[c] = L.diag[c] * Uk[c] - Apsi[c] + pcmp(Ml.source[c], k);
+        for (std::size_t pi = 0; pi < lp.size(); ++pi)
+            for (label i = 0; i < lp[pi].size; ++i)
+            {
+                const vector ic = Ml.internalCoeffs[pi][i];
+                const label fc = lp[pi].faceCells[i];
+                Hk[fc] += (cmptAv(ic) - pcmp(ic, k)) * Uk[fc] + pcmp(Ml.boundaryCoeffs[pi][i], k);
+            }
+        for (label c = 0; c < lnC; ++c)
+            pset(HbyA.internal[c], k, rAU[c] * Hk[c] / lg.V()[c]);
     }
     HbyA.evaluateBoundary();
     const SurfaceScalarField phiHbyA = fvc::flux(HbyA, m, lg, lp);
@@ -169,29 +257,57 @@ inline ParStepResidual parallelSimpleStepLaminar(const Partition& P, GeometricFi
     GeometricField<scalar> rAUfld = distributeFromCells(rAU, P);
     const SurfaceScalarField rAUf = fvc::interpolate(rAU, m, lg, lp);
     std::vector<scalar> rAUFf(m.nFaces(), 0.0);
-    for (label f = 0; f < nIf; ++f) rAUFf[f] = rAUf.internal[f];
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) if (lp[pi].type == "processor") for (label i = 0; i < lp[pi].size; ++i) rAUFf[lp[pi].start + i] = rAUfld.boundary[pi]->value()[i];
+    for (label f = 0; f < nIf; ++f)
+        rAUFf[f] = rAUf.internal[f];
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        if (lp[pi].type == "processor")
+            for (label i = 0; i < lp[pi].size; ++i)
+                rAUFf[lp[pi].start + i] = rAUfld.boundary[pi]->value()[i];
     FvScalarMatrix Mpl = fvm::laplacian(rAUf, p, m, lg, lp);
     const std::vector<scalar> dphi = fvc::div(phiHbyA, m, lg, lp);
-    for (label c = 0; c < lnC; ++c) Mpl.source[c] += lg.V()[c] * dphi[c];
+    for (label c = 0; c < lnC; ++c)
+        Mpl.source[c] += lg.V()[c] * dphi[c];
     DistributedMatrix Lp = assembleLocalLaplacianF(P.Lm, lg, lp, P.procDelta, rAUFf);
-    Lp.diag = Mpl.diag; Lp.upper = Mpl.upper; Lp.lower = Mpl.lower;
-    { std::size_t pj = 0; for (std::size_t pi = 0; pi < lp.size(); ++pi) { if (lp[pi].type != "processor") continue; for (label i = 0; i < lp[pi].size; ++i) Lp.diag[lp[pi].faceCells[i]] -= rAUFf[lp[pi].start + i] * lg.magSf()[lp[pi].start + i] * P.procDelta[pj][i]; ++pj; } }
-    Lp.diagC = Lp.diag; Lp.b.resize(lnC);
-    for (label c = 0; c < lnC; ++c) Lp.b[c] = Mpl.source[c];
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) for (label i = 0; i < lp[pi].size; ++i) { Lp.diagC[lp[pi].faceCells[i]] += Mpl.internalCoeffs[pi][i]; Lp.b[lp[pi].faceCells[i]] += Mpl.boundaryCoeffs[pi][i]; }
+    Lp.diag = Mpl.diag;
+    Lp.upper = Mpl.upper;
+    Lp.lower = Mpl.lower;
+    {
+        std::size_t pj = 0;
+        for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        {
+            if (lp[pi].type != "processor") continue;
+            for (label i = 0; i < lp[pi].size; ++i)
+                Lp.diag[lp[pi].faceCells[i]] -= rAUFf[lp[pi].start + i] * lg.magSf()[lp[pi].start + i] * P.procDelta[pj][i];
+            ++pj;
+        }
+    }
+    Lp.diagC = Lp.diag;
+    Lp.b.resize(lnC);
+    for (label c = 0; c < lnC; ++c)
+        Lp.b[c] = Mpl.source[c];
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        for (label i = 0; i < lp[pi].size; ++i)
+        {
+            Lp.diagC[lp[pi].faceCells[i]] += Mpl.internalCoeffs[pi][i];
+            Lp.b[lp[pi].faceCells[i]] += Mpl.boundaryCoeffs[pi][i];
+        }
     const std::vector<scalar> pPrev = p.internal;
     res.p = parallelPCG(Lp, p.internal, ifs, P.globalNCells, tolP, 0.0, 2000).initialResidual;
     p.evaluateBoundary();
     const SurfaceScalarField pflux = parallelMatrixFlux(Mpl, Lp, p, m, lp);
 
     // conservative phi + relax + corrector
-    for (label f = 0; f < nIf; ++f) phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
-    for (std::size_t pi = 0; pi < lp.size(); ++pi) for (label i = 0; i < lp[pi].size; ++i) phi.boundary[pi][i] = phiHbyA.boundary[pi][i] - pflux.boundary[pi][i];
-    for (label c = 0; c < lnC; ++c) p.internal[c] = pPrev[c] + relaxP * (p.internal[c] - pPrev[c]);
+    for (label f = 0; f < nIf; ++f)
+        phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
+    for (std::size_t pi = 0; pi < lp.size(); ++pi)
+        for (label i = 0; i < lp[pi].size; ++i)
+            phi.boundary[pi][i] = phiHbyA.boundary[pi][i] - pflux.boundary[pi][i];
+    for (label c = 0; c < lnC; ++c)
+        p.internal[c] = pPrev[c] + relaxP * (p.internal[c] - pPrev[c]);
     p.evaluateBoundary();
     const std::vector<vector> gPn = fvc::gaussGrad(p, m, lg, lp);
-    for (label c = 0; c < lnC; ++c) U.internal[c] = HbyA.internal[c] - rAU[c] * gPn[c];
+    for (label c = 0; c < lnC; ++c)
+        U.internal[c] = HbyA.internal[c] - rAU[c] * gPn[c];
     U.evaluateBoundary();
     return res;
 }

--- a/src/applications/solvers/simpleFoam/simpleFoam.cu
+++ b/src/applications/solvers/simpleFoam/simpleFoam.cu
@@ -31,40 +31,63 @@
 using namespace brae;
 
 // Gather a partitioned internal field to the global cell ordering (disjoint cells -> sum reduce).
-static std::vector<scalar> gather(const Partition& P, const std::vector<scalar>& loc) {
+static std::vector<scalar> gather(const Partition& P, const std::vector<scalar>& loc)
+{
     std::vector<scalar> g(P.globalNCells, 0.0);
-    for (label c = 0; c < P.nCells(); ++c) g[P.Lm.cellProcAddr[c]] = loc[c];
+    for (label c = 0; c < P.nCells(); ++c)
+        g[P.Lm.cellProcAddr[c]] = loc[c];
     Pstream::allReduce(g.data(), (int)g.size(), ReduceOp::Sum);
     return g;
 }
-static std::vector<vector> gather(const Partition& P, const std::vector<vector>& loc) {
+
+static std::vector<vector> gather(const Partition& P, const std::vector<vector>& loc)
+{
     std::vector<scalar> g(3 * P.globalNCells, 0.0);
-    for (label c = 0; c < P.nCells(); ++c) { const label gc = P.Lm.cellProcAddr[c]; g[3*gc]=loc[c].x; g[3*gc+1]=loc[c].y; g[3*gc+2]=loc[c].z; }
+    for (label c = 0; c < P.nCells(); ++c)
+    {
+        const label gc = P.Lm.cellProcAddr[c];
+        g[3*gc]=loc[c].x;
+        g[3*gc+1]=loc[c].y;
+        g[3*gc+2]=loc[c].z;
+    }
     Pstream::allReduce(g.data(), (int)g.size(), ReduceOp::Sum);
     std::vector<vector> out(P.globalNCells);
-    for (label c = 0; c < P.globalNCells; ++c) out[c] = {g[3*c], g[3*c+1], g[3*c+2]};
+    for (label c = 0; c < P.globalNCells; ++c)
+        out[c] = {g[3*c], g[3*c+1], g[3*c+2]};
     return out;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
     Pstream::init(argc, argv);
     const bool master = Pstream::master();
     const int nproc = Pstream::nProcs(), rank = Pstream::myProcNo();
-    try {
+    try
+    {
         std::string caseDir = ".";
-        for (int i = 1; i < argc; ++i) { const std::string a = argv[i];
-            if (a == "-case" && i + 1 < argc) caseDir = argv[++i];
-            else if (a[0] != '-') caseDir = a; }
+        for (int i = 1; i < argc; ++i)
+        {
+            const std::string a = argv[i];
+            if (a == "-case" && i + 1 < argc)
+                caseDir = argv[++i];
+            else if (a[0] != '-')
+                caseDir = a;
+        }
 
-        // ---- controls from the case dictionaries ----
+        // controls from the case dictionaries
         const FoamDict controlDict = readDict(caseDir + "/system/controlDict");
         const FoamDict fvSolution  = readDict(caseDir + "/system/fvSolution");
         const FoamDict transport   = readDict(caseDir + "/constant/transportProperties");
         const FoamDict turbProps   = readDict(caseDir + "/constant/turbulenceProperties");
         // "bounded Gauss upwind" for div(phi,U)? -> add the -Sp(div(phi),.) term to momentum + k/eps (OF scheme).
         bool boundedDiv = false;
-        { std::istringstream fsch(readFileExpanded(caseDir + "/system/fvSchemes")); std::string ln;  // $var expanded
-          while (std::getline(fsch, ln)) if (ln.find("div(phi,U)") != std::string::npos && ln.find("bounded") != std::string::npos) boundedDiv = true; }
+        {
+            std::istringstream fsch(readFileExpanded(caseDir + "/system/fvSchemes"));   // $var expanded
+            std::string ln;
+            while (std::getline(fsch, ln))
+                if (ln.find("div(phi,U)") != std::string::npos && ln.find("bounded") != std::string::npos)
+                    boundedDiv = true;
+        }
 
         const std::string startStr = controlDict.wordOr("startTime", "0");
         const int   endTime   = controlDict.intOr("endTime", 1000);
@@ -76,7 +99,8 @@ int main(int argc, char** argv) {
         if (simType != "RAS" && simType != "laminar")
             throw std::runtime_error("brae_simpleFoam: unsupported simulationType '" + simType + "' (RAS or laminar)");
         KEpsilonCoeffs keCoeffs;
-        if (turbulent) {
+        if (turbulent)
+        {
             const FoamDict* ras = turbProps.subDict("RAS");
             const std::string model = ras ? ras->wordOr("RASModel", "") : "";
             if (model != "kEpsilon")
@@ -84,10 +108,15 @@ int main(int argc, char** argv) {
             // model coefficients: OF turbulenceProperties RAS.kEpsilonCoeffs (optional; absent keys keep OF defaults).
             KEpsilonCoeffs& c = keCoeffs;
             const FoamDict* kec = ras ? ras->subDict("kEpsilonCoeffs") : nullptr;
-            if (kec) {
-                c.Cmu = kec->scalarOr("Cmu", c.Cmu); c.C1 = kec->scalarOr("C1", c.C1); c.C2 = kec->scalarOr("C2", c.C2);
-                c.C3 = kec->scalarOr("C3", c.C3); c.sigmaK = kec->scalarOr("sigmak", c.sigmaK);
-                c.sigmaEps = kec->scalarOr("sigmaEps", c.sigmaEps); c.kappa = kec->scalarOr("kappa", c.kappa);
+            if (kec)
+            {
+                c.Cmu = kec->scalarOr("Cmu", c.Cmu);
+                c.C1 = kec->scalarOr("C1", c.C1);
+                c.C2 = kec->scalarOr("C2", c.C2);
+                c.C3 = kec->scalarOr("C3", c.C3);
+                c.sigmaK = kec->scalarOr("sigmak", c.sigmaK);
+                c.sigmaEps = kec->scalarOr("sigmaEps", c.sigmaEps);
+                c.kappa = kec->scalarOr("kappa", c.kappa);
                 c.E = kec->scalarOr("E", c.E);
             }
             std::printf("  kEpsilonCoeffs%s: Cmu=%.4g C1=%.4g C2=%.4g C3=%.4g sigmak=%.4g sigmaEps=%.4g kappa=%.4g E=%.4g\n",
@@ -105,8 +134,11 @@ int main(int argc, char** argv) {
 
         // linear-solver tolerances (per equation).
         const FoamDict* solvers = fvSolution.subDict("solvers");
-        auto solverTol = [&](const std::string& f, scalar def) {
-            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr; return s ? s->scalarOr("tolerance", def) : def; };
+        auto solverTol = [&](const std::string& f, scalar def)
+        {
+            const FoamDict* s = solvers ? solvers->subDict(f) : nullptr;
+            return s ? s->scalarOr("tolerance", def) : def;
+        };
         const scalar tolP = solverTol("p", 1e-6), tolU = solverTol("U", 1e-8);
         const scalar tolK = solverTol("k", 1e-8), tolE = solverTol("epsilon", 1e-8);
 
@@ -117,7 +149,8 @@ int main(int argc, char** argv) {
         const scalar rcP = resCtl ? resCtl->scalarOr("p", -1) : -1, rcU = resCtl ? resCtl->scalarOr("U", -1) : -1;
         const scalar rcK = resCtl ? resCtl->scalarOr("k", -1) : -1, rcE = resCtl ? resCtl->scalarOr("epsilon", -1) : -1;
 
-        if (master) {
+        if (master)
+        {
             std::printf("brae_simpleFoam | case=%s np=%d | %s%s | nu=%.3g\n", caseDir.c_str(), nproc,
                         simType.c_str(), turbulent ? " (kEpsilon)" : "", nu);
             std::printf("  relax U=%.2g p=%.2g%s | tol p=%.1g U=%.1g | endTime=%d | residualControl=%s\n",
@@ -125,8 +158,9 @@ int main(int argc, char** argv) {
                         tolP, tolU, endTime, hasRC ? "on" : "off");
         }
 
-        // ---- mesh + start fields, decompose, distribute ----
-        PrimitiveMesh gm; gm.read(caseDir + "/constant/polyMesh");
+        // mesh + start fields, decompose, distribute
+        PrimitiveMesh gm;
+        gm.read(caseDir + "/constant/polyMesh");
         const label nC = gm.nCells();
         const FieldData<vector> Ufd = readField<vector>(caseDir + "/" + startStr + "/U");
         const FieldData<scalar> pfd = readField<scalar>(caseDir + "/" + startStr + "/p");
@@ -136,32 +170,47 @@ int main(int argc, char** argv) {
         Pstream::broadcast(cellToPart.data(), nC, 0);
         Partition P(gm, cellToPart, rank);
 
-        GeometricField<vector> U = distributeField<vector>(Ufd, gm.patches(), P.Lm, P.lp, P.procW, rank); U.evaluateBoundary();
-        GeometricField<scalar> p = distributeField<scalar>(pfd, gm.patches(), P.Lm, P.lp, P.procW, rank); p.evaluateBoundary();
+        GeometricField<vector> U = distributeField<vector>(Ufd, gm.patches(), P.Lm, P.lp, P.procW, rank);
+        U.evaluateBoundary();
+        GeometricField<scalar> p = distributeField<scalar>(pfd, gm.patches(), P.Lm, P.lp, P.procW, rank);
+        p.evaluateBoundary();
         SurfaceScalarField phi = fvc::flux(U, P.Lm.mesh, P.lg, P.lp);
 
         GeometricField<scalar> k, eps, nut;
         FieldData<scalar> kfd, efd, nfd;
-        if (turbulent) {
+        if (turbulent)
+        {
             kfd = readField<scalar>(caseDir + "/" + startStr + "/k");
             efd = readField<scalar>(caseDir + "/" + startStr + "/epsilon");
             nfd = readField<scalar>(caseDir + "/" + startStr + "/nut");
-            k   = distributeField<scalar>(kfd, gm.patches(), P.Lm, P.lp, P.procW, rank); k.evaluateBoundary();
-            eps = distributeField<scalar>(efd, gm.patches(), P.Lm, P.lp, P.procW, rank); eps.evaluateBoundary();
-            nut = distributeField<scalar>(nfd, gm.patches(), P.Lm, P.lp, P.procW, rank); nut.evaluateBoundary();
+            k   = distributeField<scalar>(kfd, gm.patches(), P.Lm, P.lp, P.procW, rank);
+            k.evaluateBoundary();
+            eps = distributeField<scalar>(efd, gm.patches(), P.Lm, P.lp, P.procW, rank);
+            eps.evaluateBoundary();
+            nut = distributeField<scalar>(nfd, gm.patches(), P.Lm, P.lp, P.procW, rank);
+            nut.evaluateBoundary();
         }
 
-        // ---- SIMPLE loop ----
+        // SIMPLE loop
         auto ok = [](scalar res, scalar ctl) { return ctl < 0 || res < ctl; };
-        int iter = 0; bool converged = false;
-        for (iter = 1; iter <= endTime && !converged; ++iter) {
+        int iter = 0;
+        bool converged = false;
+        for (iter = 1; iter <= endTime && !converged; ++iter)
+        {
             std::vector<scalar> nuEffCell(P.nCells(), nu);
             std::vector<std::vector<scalar>> nuEffBnd(P.lp.size());
-            for (std::size_t pi = 0; pi < P.lp.size(); ++pi) nuEffBnd[pi].assign(P.lp[pi].size, nu);
-            if (turbulent) {
-                for (label c = 0; c < P.nCells(); ++c) nuEffCell[c] = nu + nut.internal[c];
-                for (std::size_t pi = 0; pi < P.lp.size(); ++pi) { const auto& nv = nut.boundary[pi]->value();
-                    for (label i = 0; i < P.lp[pi].size; ++i) nuEffBnd[pi][i] = nu + nv[i]; }
+            for (std::size_t pi = 0; pi < P.lp.size(); ++pi)
+                nuEffBnd[pi].assign(P.lp[pi].size, nu);
+            if (turbulent)
+            {
+                for (label c = 0; c < P.nCells(); ++c)
+                    nuEffCell[c] = nu + nut.internal[c];
+                for (std::size_t pi = 0; pi < P.lp.size(); ++pi)
+                {
+                    const auto& nv = nut.boundary[pi]->value();
+                    for (label i = 0; i < P.lp[pi].size; ++i)
+                        nuEffBnd[pi][i] = nu + nv[i];
+                }
             }
             const ParStepResidual r = parallelSimpleStepLaminar(P, U, p, phi, nuEffCell, nuEffBnd, Ufd, relaxU, relaxP, tolU, tolP, boundedDiv);
             kepsilon::TurbResidual tres;
@@ -176,25 +225,34 @@ int main(int argc, char** argv) {
         if (master) std::printf(converged ? "SIMPLE solution converged in %d iterations\n"
                                            : "SIMPLE reached endTime (%d iterations)\n", nIter);
 
-        // ---- gather + write the converged time directory ----
+        // gather + write the converged time directory
         const std::vector<vector> Ug = gather(P, U.internal);
         const std::vector<scalar> pg = gather(P, p.internal);
         std::vector<scalar> kg, eg, ng;
-        if (turbulent) { kg = gather(P, k.internal); eg = gather(P, eps.internal); ng = gather(P, nut.internal); }
-        if (master) {
+        if (turbulent)
+        {
+            kg = gather(P, k.internal);
+            eg = gather(P, eps.internal);
+            ng = gather(P, nut.internal);
+        }
+        if (master)
+        {
             const std::string outDir = caseDir + "/" + std::to_string(nIter);
             std::filesystem::create_directories(outDir);
             const std::string src = caseDir + "/" + startStr + "/";
             writeVolField(src + "U", outDir + "/U", Ug, gm.patches(), precision);
             writeVolField(src + "p", outDir + "/p", pg, gm.patches(), precision);
-            if (turbulent) {
+            if (turbulent)
+            {
                 writeVolField(src + "k", outDir + "/k", kg, gm.patches(), precision);
                 writeVolField(src + "epsilon", outDir + "/epsilon", eg, gm.patches(), precision);
                 writeVolField(src + "nut", outDir + "/nut", ng, gm.patches(), precision);
             }
             std::printf("written %s/{U,p%s}\n", outDir.c_str(), turbulent ? ",k,epsilon,nut" : "");
         }
-    } catch (const std::exception& e) {
+    }
+    catch (const std::exception& e)
+    {
         if (master) std::fprintf(stderr, "brae_simpleFoam ERROR: %s\n", e.what());
         Pstream::finalize();
         return 1;

--- a/src/applications/solvers/simpleFoam/simple_foam.cuh
+++ b/src/applications/solvers/simpleFoam/simple_foam.cuh
@@ -22,7 +22,8 @@
 
 namespace brae {
 
-struct SimpleControls {
+struct SimpleControls
+{
     scalar nu       = 1e-5;
     scalar relaxU   = 0.7;
     scalar relaxP   = 0.3;
@@ -32,17 +33,27 @@ struct SimpleControls {
     bool   bounded  = false;   // "bounded Gauss upwind": add -Sp(div(phi),U). Set from fvSchemes; default off (plain).
 };
 
-struct StepResidual { scalar p = 0.0; scalar Ux = 0.0; };
+struct StepResidual
+{
+    scalar p = 0.0;
+    scalar Ux = 0.0;
+};
 
 // One SIMPLE iteration. nut == nullptr -> laminar (nuEff = nu); otherwise turbulent
 // (nuEff = nu + nut). The momentum is the full incompressible stress, mirroring OpenFOAM
 // simpleFoam UEqn.H == turbulence->divDevReff(U):
 //   fvm::div(phi,U) - fvm::laplacian(nuEff,U) - fvc::div(nuEff*dev2(T(grad U))).
-inline StepResidual simpleStep(GeometricField<vector>& U, GeometricField<scalar>& p, SurfaceScalarField& phi,
-                               const FieldData<vector>& Udata,
-                               const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& patches,
-                               const SimpleControls& ctl,
-                               const GeometricField<scalar>* nut = nullptr) {
+inline StepResidual simpleStep(
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    const FieldData<vector>& Udata,
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& patches,
+    const SimpleControls& ctl,
+    const GeometricField<scalar>* nut = nullptr)
+{
     const label nC = m.nCells(), nIf = m.nInternalFaces();
     const std::vector<label>& own = m.owner();
     const std::vector<label>& nei = m.neighbour();
@@ -52,64 +63,82 @@ inline StepResidual simpleStep(GeometricField<vector>& U, GeometricField<scalar>
     // nuEff = nu + nut (cell + boundary).
     std::vector<scalar> nuEffC(nC, ctl.nu);
     std::vector<std::vector<scalar>> nuEffB(patches.size());
-    for (std::size_t pi = 0; pi < patches.size(); ++pi) nuEffB[pi].assign(patches[pi].size, ctl.nu);
-    if (nut) {
-        for (label c = 0; c < nC; ++c) nuEffC[c] = ctl.nu + nut->internal[c];
-        for (std::size_t pi = 0; pi < patches.size(); ++pi) {
+    for (std::size_t pi = 0; pi < patches.size(); ++pi)
+        nuEffB[pi].assign(patches[pi].size, ctl.nu);
+    if (nut)
+    {
+        for (label c = 0; c < nC; ++c)
+            nuEffC[c] = ctl.nu + nut->internal[c];
+        for (std::size_t pi = 0; pi < patches.size(); ++pi)
+        {
             const std::vector<scalar>& nv = nut->boundary[pi]->value();
-            for (label i = 0; i < patches[pi].size; ++i) nuEffB[pi][i] = ctl.nu + nv[i];
+            for (label i = 0; i < patches[pi].size; ++i)
+                nuEffB[pi][i] = ctl.nu + nv[i];
         }
     }
 
-    // --- Momentum equation: div(phi,U) - laplacian(nuEff,U) - div(nuEff*dev2(T(grad U)))
+    // Momentum equation: div(phi,U) - laplacian(nuEff,U) - div(nuEff*dev2(T(grad U)))
     FvVectorMatrix UEqn = fvm::div(phi.internal, phi.boundary, U, m, patches);
     SurfaceScalarField nuEff_f;                                  // nuEff at faces (boundary = nuEffB)
     nuEff_f.internal.resize(nIf);
-    for (label f = 0; f < nIf; ++f) nuEff_f.internal[f] = wt[f] * nuEffC[own[f]] + (1.0 - wt[f]) * nuEffC[nei[f]];
+    for (label f = 0; f < nIf; ++f)
+        nuEff_f.internal[f] = wt[f] * nuEffC[own[f]] + (1.0 - wt[f]) * nuEffC[nei[f]];
     nuEff_f.boundary = nuEffB;
     addEqual(UEqn, fvm::laplacian(nuEff_f, U, m, g, patches), -1.0);
     // explicit transpose stress: source += V * fvc::div(nuEff*dev2(T(grad U)))
     const std::vector<tensor> gradC = fvc::gaussGrad(U, m, g, patches);
     const std::vector<std::vector<tensor>> gradB = fvc::gradUBoundary(U, gradC, m, g, patches);
     std::vector<tensor> sigC(nC);
-    for (label c = 0; c < nC; ++c) sigC[c] = nuEffC[c] * dev2(transpose(gradC[c]));
+    for (label c = 0; c < nC; ++c)
+        sigC[c] = nuEffC[c] * dev2(transpose(gradC[c]));
     std::vector<std::vector<tensor>> sigB(patches.size());
-    for (std::size_t pi = 0; pi < patches.size(); ++pi) {
+    for (std::size_t pi = 0; pi < patches.size(); ++pi)
+    {
         sigB[pi].resize(patches[pi].size);
-        for (label i = 0; i < patches[pi].size; ++i) sigB[pi][i] = nuEffB[pi][i] * dev2(transpose(gradB[pi][i]));
+        for (label i = 0; i < patches[pi].size; ++i)
+            sigB[pi][i] = nuEffB[pi][i] * dev2(transpose(gradB[pi][i]));
     }
     const std::vector<vector> divSig = fvc::div(sigC, sigB, m, g, patches);
-    for (label c = 0; c < nC; ++c) UEqn.source[c] += g.V()[c] * divSig[c];
+    for (label c = 0; c < nC; ++c)
+        UEqn.source[c] += g.V()[c] * divSig[c];
     // bounded Gauss upwind: - fvm::Sp(fvc::div(phi), U). Diagonal gets -V*div(phi), stabilises the transient
     // (e.g. a rest-start inlet cell where div(phi)!=0 at low nu); vanishes at convergence (div(phi)->0).
-    if (ctl.bounded) { const std::vector<scalar> divPhi = fvc::div(phi, m, g, patches);
-        for (label c = 0; c < nC; ++c) UEqn.diag[c] -= divPhi[c] * g.V()[c]; }
+    if (ctl.bounded)
+    {
+        const std::vector<scalar> divPhi = fvc::div(phi, m, g, patches);
+        for (label c = 0; c < nC; ++c)
+            UEqn.diag[c] -= divPhi[c] * g.V()[c];
+    }
     relaxMatrix(UEqn, U, m, patches, ctl.relaxU);
 
     // Momentum predictor: solve(UEqn == -grad(p)) on a copy (UEqn unchanged for A()/H()).
     {
         const std::vector<vector> gradP = fvc::gaussGrad(p, m, g, patches);
         FvVectorMatrix Mp = UEqn;
-        for (label c = 0; c < nC; ++c) Mp.source[c] += (-g.V()[c]) * gradP[c];
+        for (label c = 0; c < nC; ++c)
+            Mp.source[c] += (-g.V()[c]) * gradP[c];
         const SolverPerformance up = solveVector(Mp, U, m, patches, ctl.tolU, ctl.relTolU, ctl.maxIter);
         res.Ux = up.initialResidual;
     }
 
-    // --- Pressure equation
+    // Pressure equation
     const std::vector<scalar> A = matrixA(UEqn, m, g, patches);
     std::vector<scalar> rAU(nC);
-    for (label c = 0; c < nC; ++c) rAU[c] = 1.0 / A[c];
+    for (label c = 0; c < nC; ++c)
+        rAU[c] = 1.0 / A[c];
     const std::vector<vector> H = matrixH(UEqn, U, m, g, patches);
 
     GeometricField<vector> HbyA = buildField<vector>(Udata, patches, nC);   // constrainHbyA via U's BCs
-    for (label c = 0; c < nC; ++c) HbyA.internal[c] = rAU[c] * H[c];
+    for (label c = 0; c < nC; ++c)
+        HbyA.internal[c] = rAU[c] * H[c];
     HbyA.evaluateBoundary();
     const SurfaceScalarField phiHbyA = fvc::flux(HbyA, m, g, patches);
 
     const SurfaceScalarField gammaf = fvc::interpolate(rAU, m, g, patches);
     FvScalarMatrix pEqn = fvm::laplacian(gammaf, p, m, g, patches);
     const std::vector<scalar> divPhiHbyA = fvc::div(phiHbyA, m, g, patches);
-    for (label c = 0; c < nC; ++c) pEqn.source[c] += g.V()[c] * divPhiHbyA[c];
+    for (label c = 0; c < nC; ++c)
+        pEqn.source[c] += g.V()[c] * divPhiHbyA[c];
 
     const std::vector<scalar> pPrev = p.internal;
     const SolverPerformance pp = gamg(pEqn, p.internal, m, g, patches, ctl.tolP, ctl.relTolP, ctl.maxIter);
@@ -118,20 +147,24 @@ inline StepResidual simpleStep(GeometricField<vector>& U, GeometricField<scalar>
     // Conservative flux: phi = phiHbyA - pEqn.flux()
     const SurfaceScalarField pflux = matrixFlux(pEqn, p, m, patches);
     phi.internal.resize(nIf);
-    for (label f = 0; f < nIf; ++f) phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
+    for (label f = 0; f < nIf; ++f)
+        phi.internal[f] = phiHbyA.internal[f] - pflux.internal[f];
     phi.boundary.resize(patches.size());
-    for (std::size_t pi = 0; pi < patches.size(); ++pi) {
+    for (std::size_t pi = 0; pi < patches.size(); ++pi)
+    {
         phi.boundary[pi].resize(patches[pi].size);
         for (label i = 0; i < patches[pi].size; ++i)
             phi.boundary[pi][i] = phiHbyA.boundary[pi][i] - pflux.boundary[pi][i];
     }
 
     // p relaxation, then momentum corrector.
-    for (label c = 0; c < nC; ++c) p.internal[c] = pPrev[c] + ctl.relaxP * (p.internal[c] - pPrev[c]);
+    for (label c = 0; c < nC; ++c)
+        p.internal[c] = pPrev[c] + ctl.relaxP * (p.internal[c] - pPrev[c]);
     p.evaluateBoundary();
 
     const std::vector<vector> gradPnew = fvc::gaussGrad(p, m, g, patches);
-    for (label c = 0; c < nC; ++c) U.internal[c] = HbyA.internal[c] - rAU[c] * gradPnew[c];
+    for (label c = 0; c < nC; ++c)
+        U.internal[c] = HbyA.internal[c] - rAU[c] * gradPnew[c];
     U.evaluateBoundary();
 
     return res;
@@ -139,40 +172,78 @@ inline StepResidual simpleStep(GeometricField<vector>& U, GeometricField<scalar>
 
 // The SIMPLE loop: iterate simpleStep until both residuals fall below resControl. Returns the
 // number of outer iterations performed. Tracks the worst residual seen (for diagnostics).
-inline int runSimple(GeometricField<vector>& U, GeometricField<scalar>& p, SurfaceScalarField& phi,
-                     const FieldData<vector>& Udata,
-                     const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& patches,
-                     const SimpleControls& ctl, int maxOuter, scalar resControl,
-                     scalar* firstP = nullptr, scalar* lastP = nullptr) {
+inline int runSimple(
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    const FieldData<vector>& Udata,
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& patches,
+    const SimpleControls& ctl,
+    int maxOuter,
+    scalar resControl,
+    scalar* firstP = nullptr,
+    scalar* lastP = nullptr)
+{
     int iter = 0;
-    for (; iter < maxOuter; ++iter) {
+    for (; iter < maxOuter; ++iter)
+    {
         const StepResidual r = simpleStep(U, p, phi, Udata, m, g, patches, ctl);
         if (iter == 0 && firstP) *firstP = r.p;
         if (lastP) *lastP = r.p;
-        if (r.p < resControl && r.Ux < resControl) { ++iter; break; }
+        if (r.p < resControl && r.Ux < resControl)
+        {
+            ++iter;
+            break;
+        }
     }
     return iter;
 }
 
-struct TurbControls { scalar relaxK = 0.7; scalar relaxEps = 0.7; scalar tol = 1e-8; scalar relTol = 0.0; int maxIter = 1000; };
+struct TurbControls
+{
+    scalar relaxK = 0.7;
+    scalar relaxEps = 0.7;
+    scalar tol = 1e-8;
+    scalar relTol = 0.0;
+    int maxIter = 1000;
+};
 
 // Turbulent SIMPLE loop: each outer iteration runs the momentum+pressure step (nuEff = nu + nut)
 // then turbulence->correct(), mirroring OpenFOAM simpleFoam's loop body (UEqn.H, pEqn.H, then
 // turbulence->correct()). k/epsilon/nut are carried as fields with boundaries between iterations.
-inline int runSimpleTurbulent(GeometricField<vector>& U, GeometricField<scalar>& p, SurfaceScalarField& phi,
-                              GeometricField<scalar>& k, GeometricField<scalar>& eps, GeometricField<scalar>& nut,
-                              const FieldData<vector>& Udata,
-                              const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& patches,
-                              const SimpleControls& ctl, const TurbControls& tctl, int maxOuter, scalar resControl,
-                              scalar* firstP = nullptr, scalar* lastP = nullptr) {
+inline int runSimpleTurbulent(
+    GeometricField<vector>& U,
+    GeometricField<scalar>& p,
+    SurfaceScalarField& phi,
+    GeometricField<scalar>& k,
+    GeometricField<scalar>& eps,
+    GeometricField<scalar>& nut,
+    const FieldData<vector>& Udata,
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& patches,
+    const SimpleControls& ctl,
+    const TurbControls& tctl,
+    int maxOuter,
+    scalar resControl,
+    scalar* firstP = nullptr,
+    scalar* lastP = nullptr)
+{
     int iter = 0;
-    for (; iter < maxOuter; ++iter) {
+    for (; iter < maxOuter; ++iter)
+    {
         const StepResidual r = simpleStep(U, p, phi, Udata, m, g, patches, ctl, &nut);
         kepsilon::correct(U, k, eps, nut, phi, ctl.nu, m, g, patches,
                           tctl.relaxEps, tctl.relaxK, tctl.tol, tctl.relTol, tctl.maxIter);
         if (iter == 0 && firstP) *firstP = r.p;
         if (lastP) *lastP = r.p;
-        if (r.p < resControl && r.Ux < resControl) { ++iter; break; }
+        if (r.p < resControl && r.Ux < resControl)
+        {
+            ++iter;
+            break;
+        }
     }
     return iter;
 }

--- a/src/applications/solvers/simpleFoam/sweep_cases.cuh
+++ b/src/applications/solvers/simpleFoam/sweep_cases.cuh
@@ -19,84 +19,153 @@
 
 namespace braesweep {
 
-struct CaseState {
+struct CaseState
+{
     std::string name, path;
     int gpu = -1, iter = 0;
     std::string pResid = "-", uxResid = "-", status = "queued";
     double t0 = 0, t1 = 0;
 };
 
-inline std::string firstTok(const char* p) {   // number up to the next comma/space
-    std::string s; while (*p && *p != ',' && *p != ' ' && *p != '\n') s += *p++;
+inline std::string firstTok(const char* p)   // number up to the next comma/space
+{
+    std::string s;
+    while (*p && *p != ',' && *p != ' ' && *p != '\n')
+        s += *p++;
     return s.empty() ? std::string("-") : s;
 }
-inline double now() {
+
+inline double now()
+{
     return std::chrono::duration<double>(std::chrono::steady_clock::now().time_since_epoch()).count();
 }
-inline int detectGPUs() {
-    if (const char* e = std::getenv("BRAE_GPUS")) { int n = std::atoi(e); if (n > 0) return n; }
-    int n = 0; if (FILE* f = popen("nvidia-smi -L 2>/dev/null", "r")) {
-        char b[256]; while (fgets(b, sizeof b, f)) if (b[0] != '\n') n++; pclose(f); }
+
+inline int detectGPUs()
+{
+    if (const char* e = std::getenv("BRAE_GPUS"))
+    {
+        int n = std::atoi(e);
+        if (n > 0) return n;
+    }
+    int n = 0;
+    if (FILE* f = popen("nvidia-smi -L 2>/dev/null", "r"))
+    {
+        char b[256];
+        while (fgets(b, sizeof b, f))
+            if (b[0] != '\n') n++;
+        pclose(f);
+    }
     return n > 0 ? n : 1;
 }
-inline std::string selfExe() {
-    char b[4096]; ssize_t k = readlink("/proc/self/exe", b, sizeof b - 1);
-    if (k > 0) { b[k] = 0; return b; } return "brae";
+
+inline std::string selfExe()
+{
+    char b[4096];
+    ssize_t k = readlink("/proc/self/exe", b, sizeof b - 1);
+    if (k > 0)
+    {
+        b[k] = 0;
+        return b;
+    }
+    return "brae";
 }
-inline std::string cellStr(const std::string& c) {
+
+inline std::string cellStr(const std::string& c)
+{
     FILE* f = std::fopen((c + "/constant/polyMesh/owner").c_str(), "rb");
     if (!f) return "?";
-    char b[2048]; size_t n = std::fread(b, 1, sizeof b - 1, f); b[n] = 0; std::fclose(f);
+    char b[2048];
+    size_t n = std::fread(b, 1, sizeof b - 1, f);
+    b[n] = 0;
+    std::fclose(f);
     const char* p = std::strstr(b, "nCells:");
     if (!p) return "?";
-    long nc = std::atol(p + 7); char o[32];
-    if (nc >= 100000) std::snprintf(o, sizeof o, "%.2fM", nc / 1e6);
-    else              std::snprintf(o, sizeof o, "%ldk", nc / 1000);
+    long nc = std::atol(p + 7);
+    char o[32];
+    if (nc >= 100000)
+        std::snprintf(o, sizeof o, "%.2fM", nc / 1e6);
+    else
+        std::snprintf(o, sizeof o, "%ldk", nc / 1000);
     return o;
 }
 
 // Run one case as a child brae process pinned to `gpu`; tag its stdout and parse residuals.
-inline void runOne(CaseState& st, int gpu, const std::string& self, std::mutex& outmx) {
-    st.gpu = gpu; st.status = "running"; st.t0 = now();
+inline void runOne(
+    CaseState& st,
+    int gpu,
+    const std::string& self,
+    std::mutex& outmx)
+{
+    st.gpu = gpu;
+    st.status = "running";
+    st.t0 = now();
     int fds[2];
-    if (pipe(fds) != 0) { st.status = "failed"; st.t1 = now(); return; }
+    if (pipe(fds) != 0)
+    {
+        st.status = "failed";
+        st.t1 = now();
+        return;
+    }
     pid_t pid = fork();
-    if (pid == 0) {                              // child
+    if (pid == 0)   // child
+    {
         close(fds[0]);
-        dup2(fds[1], STDOUT_FILENO); dup2(fds[1], STDERR_FILENO); close(fds[1]);
-        char g[16]; std::snprintf(g, sizeof g, "%d", gpu);
+        dup2(fds[1], STDOUT_FILENO);
+        dup2(fds[1], STDERR_FILENO);
+        close(fds[1]);
+        char g[16];
+        std::snprintf(g, sizeof g, "%d", gpu);
         setenv("CUDA_VISIBLE_DEVICES", g, 1);
         execl(self.c_str(), "brae", "-case", st.path.c_str(), (char*)nullptr);
         _exit(127);
     }
     close(fds[1]);
     FILE* f = fdopen(fds[0], "r");
-    char tag[288]; std::snprintf(tag, sizeof tag, "[GPU%d %s]", gpu, st.name.c_str());
+    char tag[288];
+    std::snprintf(tag, sizeof tag, "[GPU%d %s]", gpu, st.name.c_str());
     char buf[2048];
-    while (f && fgets(buf, sizeof buf, f)) {
-        size_t L = std::strlen(buf); if (L && buf[L-1] == '\n') buf[L-1] = 0;
-        if (buf[0]) { std::lock_guard<std::mutex> lk(outmx); std::printf("%s  %s\n", tag, buf); std::fflush(stdout); }
+    while (f && fgets(buf, sizeof buf, f))
+    {
+        size_t L = std::strlen(buf);
+        if (L && buf[L-1] == '\n') buf[L-1] = 0;
+        if (buf[0])
+        {
+            std::lock_guard<std::mutex> lk(outmx);
+            std::printf("%s  %s\n", tag, buf);
+            std::fflush(stdout);
+        }
         if (std::strncmp(buf, "Time = ", 7) == 0) st.iter = std::atoi(buf + 7);
         if (const char* p = std::strstr(buf, "Solving for Ux, Initial residual = ")) st.uxResid = firstTok(p + 35);
         if (const char* p = std::strstr(buf, "Solving for p, Initial residual = "))  st.pResid  = firstTok(p + 34);
         if (std::strstr(buf, "-nan") || std::strstr(buf, "FATAL")) st.status = "diverged";
     }
     if (f) std::fclose(f);
-    int ws = 0; waitpid(pid, &ws, 0);
+    int ws = 0;
+    waitpid(pid, &ws, 0);
     st.t1 = now();
     if (st.status == "running")
         st.status = (WIFEXITED(ws) && WEXITSTATUS(ws) == 0) ? "done" : "failed";
 }
 
-inline int runSweepCases(const std::vector<std::string>& paths) {
+inline int runSweepCases(const std::vector<std::string>& paths)
+{
     std::vector<CaseState> cases;
-    for (auto c : paths) {
-        while (c.size() > 1 && c.back() == '/') c.pop_back();
-        CaseState s; s.path = c; s.name = c.substr(c.find_last_of('/') + 1); cases.push_back(std::move(s));
+    for (auto c : paths)
+    {
+        while (c.size() > 1 && c.back() == '/')
+            c.pop_back();
+        CaseState s;
+        s.path = c;
+        s.name = c.substr(c.find_last_of('/') + 1);
+        cases.push_back(std::move(s));
     }
     const int nGPU = detectGPUs();
     int jobs = nGPU;
-    if (const char* e = std::getenv("BRAE_JOBS")) { int j = std::atoi(e); if (j > 0) jobs = j; }
+    if (const char* e = std::getenv("BRAE_JOBS"))
+    {
+        int j = std::atoi(e);
+        if (j > 0) jobs = j;
+    }
     const std::string self = selfExe();
     std::printf("brae mesh study: %zu case(s), %d GPU(s) found, running %d at a time\n",
                 cases.size(), nGPU, jobs);
@@ -111,22 +180,32 @@ inline int runSweepCases(const std::vector<std::string>& paths) {
 
     std::atomic<size_t> next{0};
     std::mutex outmx;
-    auto worker = [&](int wid) {
+    auto worker = [&](int wid)
+    {
         const int gpu = wid % nGPU;
-        for (;;) { size_t i = next.fetch_add(1); if (i >= cases.size()) break; runOne(cases[i], gpu, self, outmx); }
+        for (;;)
+        {
+            size_t i = next.fetch_add(1);
+            if (i >= cases.size()) break;
+            runOne(cases[i], gpu, self, outmx);
+        }
     };
     std::vector<std::thread> th;
-    for (int w = 0; w < jobs; ++w) th.emplace_back(worker, w);
-    for (auto& t : th) t.join();
+    for (int w = 0; w < jobs; ++w)
+        th.emplace_back(worker, w);
+    for (auto& t : th)
+        t.join();
 
     std::printf("\n%s\n", std::string(84, '=').c_str());
     std::printf("mesh study complete (%zu cases)\n\n", cases.size());
     std::printf("  %-16s %4s %9s %7s %11s %11s %9s   %s\n",
                 "case", "GPU", "cells", "iters", "p resid", "Ux resid", "wall", "status");
     std::printf("  %s\n", std::string(78, '-').c_str());
-    for (auto& s : cases) {
+    for (auto& s : cases)
+    {
         int wall = (int)(s.t1 - s.t0);
-        char w[16]; std::snprintf(w, sizeof w, "%dm%02ds", wall / 60, wall % 60);
+        char w[16];
+        std::snprintf(w, sizeof w, "%dm%02ds", wall / 60, wall % 60);
         std::printf("  %-16s %4d %9s %7d %11s %11s %9s   %s\n",
                     s.name.c_str(), s.gpu, cellStr(s.path).c_str(), s.iter,
                     s.pResid.c_str(), s.uxResid.c_str(), w, s.status.c_str());

--- a/src/cuda/device_ami.cuh
+++ b/src/cuda/device_ami.cuh
@@ -1,7 +1,7 @@
 #pragma once
 // cf GPU offload, cyclicAMI (Arbitrary Mesh Interface) coupling. The cyclic 1:1 (own,nbr) pair becomes a
 // weighted STENCIL: each source face couples to a CSR list of neighbour cells with area weights (the AMI).
-//   pnf[srcFace]      = sum_{k in [off[i],off[i+1])} w[k] * (forwardT · psi[nbrCell[k]])      (interpolateToSource)
+//   pnf[srcFace]      = sum_{k in [off[i],off[i+1])} w[k] * (forwardT . psi[nbrCell[k]])      (interpolateToSource)
 //   Apsi[ownCell[i]] += ifCoeff[i] * pnf[srcFace]                                             (updateInterfaceMatrix)
 // Mirrors OF AMIInterpolation::interpolateToSource + cyclicAMIFvPatchField::updateInterfaceMatrix. Both src+tgt
 // sides are flattened (symmetric), exactly like DeviceCyclic. Host weights: AMIInterface (faceAreaWeightAMI).
@@ -12,7 +12,8 @@
 
 namespace brae {
 
-struct DeviceAMI {
+struct DeviceAMI
+{
     int n = 0;                                  // total SOURCE faces (both sides of the pair flattened)
     int nnz = 0;                                // total stencil entries
     DeviceBuffer<label>  ownCell;               // owner cell of each source face            (n)
@@ -33,55 +34,98 @@ struct DeviceAMI {
     bool empty() const { return n == 0; }
 };
 
-inline DeviceAMI buildDeviceAMI(const std::vector<AMIInterface>& amis) {
-    std::vector<label> oc, offv, nc; std::vector<scalar> w, ws, msf, dcf, wt, sfx, sfy, sfz;
+inline DeviceAMI buildDeviceAMI(const std::vector<AMIInterface>& amis)
+{
+    std::vector<label> oc, offv, nc;
+    std::vector<scalar> w, ws, msf, dcf, wt, sfx, sfy, sfz;
     std::vector<scalar> cvx,cvy,cvz, dox,doy,doz, dnx,dny,dnz;
-    bool rot = false; for (const auto& a : amis) if (!a.translational) rot = true;
+    bool rot = false;
+    for (const auto& a : amis)
+        if (!a.translational) rot = true;
     offv.push_back(0);
-    for (const auto& a : amis) {
-        for (std::size_t i = 0; i < a.ownCell.size(); ++i) {
-            oc.push_back(a.ownCell[i]); ws.push_back(a.weightsSum[i]);
-            msf.push_back(a.magSf[i]); dcf.push_back(a.deltaCoeffs[i]); wt.push_back(a.weights[i]);
-            sfx.push_back(a.Sf[i].x); sfy.push_back(a.Sf[i].y); sfz.push_back(a.Sf[i].z);
+    for (const auto& a : amis)
+    {
+        for (std::size_t i = 0; i < a.ownCell.size(); ++i)
+        {
+            oc.push_back(a.ownCell[i]);
+            ws.push_back(a.weightsSum[i]);
+            msf.push_back(a.magSf[i]);
+            dcf.push_back(a.deltaCoeffs[i]);
+            wt.push_back(a.weights[i]);
+            sfx.push_back(a.Sf[i].x);
+            sfy.push_back(a.Sf[i].y);
+            sfz.push_back(a.Sf[i].z);
             // corrVec/dOwn/dNbr feed only the linearUpwind/non-orth interface corrections; a minimal AMIInterface
             // (e.g. the device unit test) may leave them empty -> default to zero (those corrections then no-op).
             const vector cv = i < a.corrVec.size() ? a.corrVec[i] : vector{0,0,0};
             const vector dO = i < a.dOwn.size()    ? a.dOwn[i]    : vector{0,0,0};
-            cvx.push_back(cv.x); cvy.push_back(cv.y); cvz.push_back(cv.z);
-            dox.push_back(dO.x); doy.push_back(dO.y); doz.push_back(dO.z);
+            cvx.push_back(cv.x);
+            cvy.push_back(cv.y);
+            cvz.push_back(cv.z);
+            dox.push_back(dO.x);
+            doy.push_back(dO.y);
+            doz.push_back(dO.z);
             const label b = a.srcOffset[i], e = a.srcOffset[i+1];
-            for (label k = b; k < e; ++k) { nc.push_back(a.nbrCell[k]); w.push_back(a.weight[k]);
+            for (label k = b; k < e; ++k)
+            {
+                nc.push_back(a.nbrCell[k]);
+                w.push_back(a.weight[k]);
                 const vector dN = (std::size_t)k < a.dNbr.size() ? a.dNbr[k] : vector{0,0,0};
-                dnx.push_back(dN.x); dny.push_back(dN.y); dnz.push_back(dN.z); }
+                dnx.push_back(dN.x);
+                dny.push_back(dN.y);
+                dnz.push_back(dN.z);
+            }
             offv.push_back((label)nc.size());
         }
     }
-    DeviceAMI d; d.n = (int)oc.size(); d.nnz = (int)nc.size(); d.rotational = rot;
-    d.ownCell.copyFrom(oc); d.off.copyFrom(offv); d.nbrCell.copyFrom(nc);
-    d.weight.copyFrom(w); d.weightsSum.copyFrom(ws);
-    d.magSf.copyFrom(msf); d.deltaCoeffs.copyFrom(dcf); d.weights.copyFrom(wt);
-    d.Sfx.copyFrom(sfx); d.Sfy.copyFrom(sfy); d.Sfz.copyFrom(sfz);
-    d.corrVecX.copyFrom(cvx); d.corrVecY.copyFrom(cvy); d.corrVecZ.copyFrom(cvz);
-    d.dOwnX.copyFrom(dox); d.dOwnY.copyFrom(doy); d.dOwnZ.copyFrom(doz);
-    d.dNbrX.copyFrom(dnx); d.dNbrY.copyFrom(dny); d.dNbrZ.copyFrom(dnz);
-    d.ifCoeff.resize(d.n); d.phi.resize(d.n);
-    if (rot) {
-        std::vector<scalar> ft((std::size_t)9 * d.n); std::size_t f = 0;
-        for (const auto& a : amis) {
+    DeviceAMI d;
+    d.n = (int)oc.size();
+    d.nnz = (int)nc.size();
+    d.rotational = rot;
+    d.ownCell.copyFrom(oc);
+    d.off.copyFrom(offv);
+    d.nbrCell.copyFrom(nc);
+    d.weight.copyFrom(w);
+    d.weightsSum.copyFrom(ws);
+    d.magSf.copyFrom(msf);
+    d.deltaCoeffs.copyFrom(dcf);
+    d.weights.copyFrom(wt);
+    d.Sfx.copyFrom(sfx);
+    d.Sfy.copyFrom(sfy);
+    d.Sfz.copyFrom(sfz);
+    d.corrVecX.copyFrom(cvx);
+    d.corrVecY.copyFrom(cvy);
+    d.corrVecZ.copyFrom(cvz);
+    d.dOwnX.copyFrom(dox);
+    d.dOwnY.copyFrom(doy);
+    d.dOwnZ.copyFrom(doz);
+    d.dNbrX.copyFrom(dnx);
+    d.dNbrY.copyFrom(dny);
+    d.dNbrZ.copyFrom(dnz);
+    d.ifCoeff.resize(d.n);
+    d.phi.resize(d.n);
+    if (rot)
+    {
+        std::vector<scalar> ft((std::size_t)9 * d.n);
+        std::size_t f = 0;
+        for (const auto& a : amis)
+        {
             const tensor& T = a.forwardT;
             const scalar tc[9] = { T.xx,T.xy,T.xz, T.yx,T.yy,T.yz, T.zx,T.zy,T.zz };
             for (std::size_t i = 0; i < a.ownCell.size(); ++i, ++f)
-                for (int k = 0; k < 9; ++k) ft[(std::size_t)k * d.n + f] = tc[k];
+                for (int k = 0; k < 9; ++k)
+                    ft[(std::size_t)k * d.n + f] = tc[k];
         }
         d.fT.copyFrom(ft);
-        for (int k = 0; k < 3; ++k) d.ifCoeffC[k].resize(d.n);
+        for (int k = 0; k < 3; ++k)
+            d.ifCoeffC[k].resize(d.n);
     }
     return d;
 }
 
 // AMI interpolate-to-source of a SCALAR cell field: out[i] = sum_k weight[k]*psi[nbrCell[k]]  (no transform).
 void deviceAmiInterpolate(const DeviceAMI& ami, const DeviceBuffer<scalar>& psi, DeviceBuffer<scalar>& out);
-// AMI interpolate-to-source of a VECTOR field, rotated: outX/Y/Z[i] = sum_k w[k]*(forwardT·U[nbrCell[k]]).
+// AMI interpolate-to-source of a VECTOR field, rotated: outX/Y/Z[i] = sum_k w[k]*(forwardT.U[nbrCell[k]]).
 void deviceAmiInterpolateVec(const DeviceAMI& ami, const DeviceBuffer<scalar>& Ux, const DeviceBuffer<scalar>& Uy,
                              const DeviceBuffer<scalar>& Uz, DeviceBuffer<scalar>& oX, DeviceBuffer<scalar>& oY,
                              DeviceBuffer<scalar>& oZ);
@@ -91,7 +135,7 @@ void deviceAmiInterpolateVec(const DeviceAMI& ami, const DeviceBuffer<scalar>& U
 // alongside the internal-face amul; pass cyc.ifCoeff assembled by the laplacian/momentum AMI assembly.
 void deviceAmiAmul(const DeviceAMI& ami, const DeviceBuffer<scalar>& psi, DeviceBuffer<scalar>& Apsi);
 
-// ---- assembly (mirrors device_cyclic, with the AMI weighted stencil; explicit ops use the interpolated nbr) ----
+// assembly (mirrors device_cyclic, with the AMI weighted stencil; explicit ops use the interpolated nbr)
 // MOMENTUM M = div(phi,U) - laplacian(nuEff,U): ifCoeff[i] = -(nuFace*dc*magSf) + min(phi,0); diag[own] +=
 // (nuFace*dc*magSf) + max(phi,0). nuFace = w*nuEff[own] + (1-w)*interp(nuEff). ami.phi must hold the current flux.
 void deviceAmiAssembleMomentum(DeviceAMI& ami, const DeviceBuffer<scalar>& nuEffCell, DeviceBuffer<scalar>& diag);
@@ -101,7 +145,7 @@ void deviceAmiAssembleLaplacian(DeviceAMI& ami, const DeviceBuffer<scalar>& gamm
 void deviceAmiOffDiagSum(const DeviceAMI& ami, DeviceBuffer<scalar>& sumOff);
 // H[own] -= ifCoeff * UkNbr[i] / V  (UkNbr = precomputed interp of the component, rotated if rotational).
 void deviceAmiAddH(const DeviceAMI& ami, const DeviceBuffer<scalar>& UkNbr, const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& H);
-// interface flux: phi[i] = (w*H[own] + (1-w)*interp(forwardT·H[nbr])) · Sf.
+// interface flux: phi[i] = (w*H[own] + (1-w)*interp(forwardT.H[nbr])) . Sf.
 void deviceAmiFlux(DeviceAMI& ami, const DeviceBuffer<scalar>& Hx, const DeviceBuffer<scalar>& Hy, const DeviceBuffer<scalar>& Hz);
 // continuity: div[own] += phi[i]/V.
 void deviceAmiAddDiv(const DeviceAMI& ami, const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& div);
@@ -117,10 +161,10 @@ void deviceAmiCorrectFlux(DeviceAMI& ami, const DeviceBuffer<scalar>& p);
 void deviceAmiAddTensorDiv(const DeviceAMI& ami, const DeviceBuffer<scalar>& sigmaC, int nC,
                            DeviceBuffer<scalar>& srcX, DeviceBuffer<scalar>& srcY, DeviceBuffer<scalar>& srcZ);
 
-// ---- ROTATIONAL (the predictor needs the diag-implicit + deferred split, like cyclic Bug #3) ----
+// ROTATIONAL (the predictor needs the diag-implicit + deferred split, like cyclic Bug #3)
 // fill ifCoeffC[kk] = ifCoeff * forwardT[kk][kk] (call after AssembleMomentum; the predictor uses ifCoeffC).
 void deviceAmiScaleImplicit(DeviceAMI& ami);
-// DEFERRED rotation mixing into the predictor source (component comp): src[own] -= ifCoeff*[(forwardT·U_interp)[comp]
+// DEFERRED rotation mixing into the predictor source (component comp): src[own] -= ifCoeff*[(forwardT.U_interp)[comp]
 //   - forwardT[comp][comp]*U_interp[comp]]. U_interp{X,Y,Z} = the UN-rotated AMI-interpolated neighbour per src face
 // (= deviceAmiInterpolate of each component, precomputed from the U_old snapshot). Pairs with ifCoeffC in the matrix
 // and the FULL-rotation H (deviceAmiAddH on the rotated interpVec of the post-solve U) -> consistent full rotation.
@@ -131,18 +175,18 @@ void deviceAmiAddDeferredRot(const DeviceAMI& ami, const DeviceBuffer<scalar>& u
 void deviceAmiAddGradRot(const DeviceAMI& ami, const DeviceBuffer<scalar>& Uown, const DeviceBuffer<scalar>& UNbr,
                          const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& gx, DeviceBuffer<scalar>& gy, DeviceBuffer<scalar>& gz);
 
-// ---- linearUpwind / non-orth deferred corrections at the AMI interface (Bug #5/#6 analogs; rotated) ----
-// linearUpwind deferred correction (component comp): corr[own] += phi*(gradU_upwind·d_upwind)[comp]; outflow uses
-// grad(U_comp)[own]·dOwn (no rotation), inflow uses (forwardT·(Σ_k w_k·(gradU[nbr_k]·dNbr_k)))[comp]. gU{x,y,z}[l] =
+// linearUpwind / non-orth deferred corrections at the AMI interface (Bug #5/#6 analogs; rotated)
+// linearUpwind deferred correction (component comp): corr[own] += phi*(gradU_upwind.d_upwind)[comp]; outflow uses
+// grad(U_comp)[own].dOwn (no rotation), inflow uses (forwardT.(Sum_k w_k.(gradU[nbr_k].dNbr_k)))[comp]. gU{x,y,z}[l] =
 // grad(U_l). Adds to the SAME corr buffer the internal linearUpwind wrote; caller does relaxSrc[comp] -= corr.
 void deviceAmiAddLinUpwindCorr(const DeviceAMI& ami, int comp, const DeviceBuffer<scalar>* gUx,
                                const DeviceBuffer<scalar>* gUy, const DeviceBuffer<scalar>* gUz, DeviceBuffer<scalar>& corr);
-// non-orth laplacian correction (momentum, component comp): src[own] -= gammaFace*magSf*(corrVec·grad(U_comp)_face);
-// neighbour grad rotated as a TENSOR R·gradU·R^T then AMI-interpolated. gammaCell = nuEff per cell.
+// non-orth laplacian correction (momentum, component comp): src[own] -= gammaFace*magSf*(corrVec.grad(U_comp)_face);
+// neighbour grad rotated as a TENSOR R.gradU.R^T then AMI-interpolated. gammaCell = nuEff per cell.
 void deviceAmiAddLapCorr(const DeviceAMI& ami, int comp, const DeviceBuffer<scalar>& gammaCell,
                          const DeviceBuffer<scalar>* gUx, const DeviceBuffer<scalar>* gUy, const DeviceBuffer<scalar>* gUz,
                          DeviceBuffer<scalar>& corr);
-// PRESSURE non-orth correction (scalar p): ffc = rAtU_face*magSf*(corrVec·grad(p)_face) (no rotation); -ffc into
+// PRESSURE non-orth correction (scalar p): ffc = rAtU_face*magSf*(corrVec.grad(p)_face) (no rotation); -ffc into
 // bp[own]; ffcOut[i] = ffc for the post-solve flux correction (ami.phi -= ffcOut).
 void deviceAmiLapCorrP(const DeviceAMI& ami, const DeviceBuffer<scalar>& gammaCell, const DeviceBuffer<scalar>& gx,
                        const DeviceBuffer<scalar>& gy, const DeviceBuffer<scalar>& gz, DeviceBuffer<scalar>& bp, DeviceBuffer<scalar>& ffcOut);

--- a/src/cuda/device_boundary.cuh
+++ b/src/cuda/device_boundary.cuh
@@ -15,7 +15,8 @@
 
 namespace brae {
 
-struct DeviceBoundary {
+struct DeviceBoundary
+{
     int n = 0;                              // total boundary faces (patch order = DeviceMesh bndCell order)
     DeviceBuffer<label>  bcType;            // 0 extrapolated, 1 fixedValue, 2 calculated (3=inletOutlet -> resolved
                                             // to 0|1 per face each step by deviceUpdateInletOutlet; 5=mixed/Robin)
@@ -30,27 +31,51 @@ struct DeviceBoundary {
     DeviceBuffer<label>  faceCell;
 };
 
-inline DeviceBoundary buildDeviceBoundary(const GeometricField<scalar>& f, const std::vector<FvPatch>& fvp, const FvGeometry& g) {
-    std::vector<label> ty, fc, io, oio, mx, pv, sm, tp; std::vector<scalar> ref, dc, ms, vf, p0;
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) {
+inline DeviceBoundary buildDeviceBoundary(
+    const GeometricField<scalar>& f,
+    const std::vector<FvPatch>& fvp,
+    const FvGeometry& g)
+{
+    std::vector<label> ty, fc, io, oio, mx, pv, sm, tp;
+    std::vector<scalar> ref, dc, ms, vf, p0;
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+    {
         if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;                     // cyclic = internal-like (handled by appended faces)
         const int cat = f.boundary[pi]->bcCategory();
         const std::vector<scalar>& val = f.boundary[pi]->value();   // inletOutlet/outletInlet/mixed: value() = refValue; totalPressure: p0
         const std::vector<scalar>* vfp = f.boundary[pi]->valueFractionPtr();   // mixed (cat 5): per-face vf seed
-        for (label i = 0; i < fvp[pi].size; ++i) {
+        for (label i = 0; i < fvp[pi].size; ++i)
+        {
             ty.push_back((cat == 3 || cat == 4 || cat == 7) ? 1 : cat);   // io/oio/totalPressure init fixedValue (resolved per-step); 5 stays mixed
-            io.push_back(cat == 3 ? 1 : 0); oio.push_back(cat == 4 ? 1 : 0); mx.push_back(cat == 5 ? 1 : 0); pv.push_back(0); sm.push_back(0);
-            tp.push_back(cat == 7 ? 1 : 0); p0.push_back(cat == 7 ? val[i] : 0.0);   // totalPressure: mask + the reference p0
+            io.push_back(cat == 3 ? 1 : 0);
+            oio.push_back(cat == 4 ? 1 : 0);
+            mx.push_back(cat == 5 ? 1 : 0);
+            pv.push_back(0);
+            sm.push_back(0);
+            tp.push_back(cat == 7 ? 1 : 0);
+            p0.push_back(cat == 7 ? val[i] : 0.0);   // totalPressure: mask + the reference p0
             vf.push_back((cat == 5 && vfp) ? (*vfp)[i] : 0.0);
-            ref.push_back(val[i]); dc.push_back(fvp[pi].deltaCoeffs[i]);
-            ms.push_back(g.magSf()[fvp[pi].start + i]); fc.push_back(fvp[pi].faceCells[i]);
+            ref.push_back(val[i]);
+            dc.push_back(fvp[pi].deltaCoeffs[i]);
+            ms.push_back(g.magSf()[fvp[pi].start + i]);
+            fc.push_back(fvp[pi].faceCells[i]);
         }
     }
-    DeviceBoundary db; db.n = static_cast<int>(ty.size());
-    db.bcType.copyFrom(ty); db.ioMask.copyFrom(io); db.oioMask.copyFrom(oio); db.mixedMask.copyFrom(mx); db.piovMask.copyFrom(pv); db.symMask.copyFrom(sm);
-    db.tpMask.copyFrom(tp); db.p0.copyFrom(p0);
-    db.valueFraction.copyFrom(vf); db.refValue.copyFrom(ref);
-    db.deltaCoeffs.copyFrom(dc); db.magSf.copyFrom(ms); db.faceCell.copyFrom(fc);
+    DeviceBoundary db;
+    db.n = static_cast<int>(ty.size());
+    db.bcType.copyFrom(ty);
+    db.ioMask.copyFrom(io);
+    db.oioMask.copyFrom(oio);
+    db.mixedMask.copyFrom(mx);
+    db.piovMask.copyFrom(pv);
+    db.symMask.copyFrom(sm);
+    db.tpMask.copyFrom(tp);
+    db.p0.copyFrom(p0);
+    db.valueFraction.copyFrom(vf);
+    db.refValue.copyFrom(ref);
+    db.deltaCoeffs.copyFrom(dc);
+    db.magSf.copyFrom(ms);
+    db.faceCell.copyFrom(fc);
     return db;
 }
 
@@ -73,11 +98,18 @@ void deviceMatrixFluxBoundary(const DeviceBoundary& db, const DeviceBuffer<scala
 // A vector field's BC is three scalar boundaries (one per component): the laplacian/div internalCoeffs are
 // isotropic (component-independent), only the refValue-dependent boundaryCoeffs / value differ by component.
 // So the per-component momentum boundary coeffs reuse the scalar kernels on comp[k].
-struct DeviceVectorBoundary { DeviceBoundary comp[3]; int n = 0; DeviceBuffer<scalar> nx, ny, nz; };   // nx/ny/nz = unit face normal (pressureInletOutletVelocity)
+struct DeviceVectorBoundary
+{
+    DeviceBoundary comp[3];
+    int n = 0;
+    DeviceBuffer<scalar> nx, ny, nz;   // nx/ny/nz = unit face normal (pressureInletOutletVelocity)
+};
 
 // inletOutlet on a vector field: same patch flux for all 3 components -> update each component's bcType.
-inline void deviceUpdateInletOutlet(DeviceVectorBoundary& db, const DeviceBuffer<scalar>& phiBnd) {
-    for (int k = 0; k < 3; ++k) deviceUpdateInletOutlet(db.comp[k], phiBnd);
+inline void deviceUpdateInletOutlet(DeviceVectorBoundary& db, const DeviceBuffer<scalar>& phiBnd)
+{
+    for (int k = 0; k < 3; ++k)
+        deviceUpdateInletOutlet(db.comp[k], phiBnd);
 }
 
 // mixed (Robin) freestreamVelocity/Pressure updateCoeffs: recompute per-face vf from the flow angle. The normal
@@ -120,39 +152,79 @@ void deviceUpdateSymmetry(DeviceVectorBoundary& dbU, const DeviceBuffer<scalar>&
 void deviceUpdateTotalPressure(DeviceBoundary& db, const DeviceBuffer<scalar>& phiB, const DeviceBuffer<scalar>& Uxb,
                                const DeviceBuffer<scalar>& Uyb, const DeviceBuffer<scalar>& Uzb);
 
-inline DeviceVectorBoundary buildDeviceVectorBoundary(const GeometricField<vector>& f, const std::vector<FvPatch>& fvp, const FvGeometry& g) {
-    std::vector<label> ty[3], fc, io, oio, mx, pv, sm; std::vector<scalar> dc, ms, ref[3], vf[3], nrm[3];
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) {
+inline DeviceVectorBoundary buildDeviceVectorBoundary(
+    const GeometricField<vector>& f,
+    const std::vector<FvPatch>& fvp,
+    const FvGeometry& g)
+{
+    std::vector<label> ty[3], fc, io, oio, mx, pv, sm;
+    std::vector<scalar> dc, ms, ref[3], vf[3], nrm[3];
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+    {
         if (fvp[pi].type == "cyclic" || fvp[pi].type == "cyclicAMI") continue;                     // cyclic = internal-like (handled by appended faces)
         const int cat = f.boundary[pi]->bcCategory();
         const bool sym = f.boundary[pi]->isSymmetry();
         const std::vector<vector>& val = f.boundary[pi]->value();   // inletOutlet/mixed: value() = freestreamValue (= refValue)
         const std::vector<scalar>* vfp = f.boundary[pi]->valueFractionPtr();   // mixed (cat 5): per-face vf seed
-        for (label i = 0; i < fvp[pi].size; ++i) {
-            fc.push_back(fvp[pi].faceCells[i]); dc.push_back(fvp[pi].deltaCoeffs[i]); ms.push_back(g.magSf()[fvp[pi].start + i]);
-            io.push_back(cat == 3 ? 1 : 0); oio.push_back(cat == 4 ? 1 : 0);   // inletOutlet / outletInlet (same flux for all 3 comps)
-            mx.push_back(cat == 5 ? 1 : 0); pv.push_back(cat == 6 ? 1 : 0); sm.push_back(sym ? 1 : 0);   // mixed / piov / symmetry masks
+        for (label i = 0; i < fvp[pi].size; ++i)
+        {
+            fc.push_back(fvp[pi].faceCells[i]);
+            dc.push_back(fvp[pi].deltaCoeffs[i]);
+            ms.push_back(g.magSf()[fvp[pi].start + i]);
+            io.push_back(cat == 3 ? 1 : 0);
+            oio.push_back(cat == 4 ? 1 : 0);   // inletOutlet / outletInlet (same flux for all 3 comps)
+            mx.push_back(cat == 5 ? 1 : 0);
+            pv.push_back(cat == 6 ? 1 : 0);
+            sm.push_back(sym ? 1 : 0);   // mixed / piov / symmetry masks
             const scalar seedVf = (cat == 5 && vfp) ? (*vfp)[i] : 0.0;
-            { const vector Sf = g.Sf()[fvp[pi].start + i]; const scalar mg = g.magSf()[fvp[pi].start + i];   // unit face normal
-              const scalar inv = mg > 0 ? 1.0 / mg : 0.0; nrm[0].push_back(Sf.x * inv); nrm[1].push_back(Sf.y * inv); nrm[2].push_back(Sf.z * inv); }
+            {
+                const vector Sf = g.Sf()[fvp[pi].start + i];
+                const scalar mg = g.magSf()[fvp[pi].start + i];   // unit face normal
+                const scalar inv = mg > 0 ? 1.0 / mg : 0.0;
+                nrm[0].push_back(Sf.x * inv);
+                nrm[1].push_back(Sf.y * inv);
+                nrm[2].push_back(Sf.z * inv);
+            }
             const scalar rv[3] = { val[i].x, val[i].y, val[i].z };
-            if (sym) {   // mixed kernels; vf_k=|n_k|, ref recomputed per step (init = host value v - n(n.v))
-                for (int k = 0; k < 3; ++k) { ty[k].push_back(5); vf[k].push_back(std::fabs(nrm[k].back())); ref[k].push_back(rv[k]); }
-            } else {
-                for (int k = 0; k < 3; ++k) {
+            if (sym)   // mixed kernels; vf_k=|n_k|, ref recomputed per step (init = host value v - n(n.v))
+            {
+                for (int k = 0; k < 3; ++k)
+                {
+                    ty[k].push_back(5);
+                    vf[k].push_back(std::fabs(nrm[k].back()));
+                    ref[k].push_back(rv[k]);
+                }
+            }
+            else
+            {
+                for (int k = 0; k < 3; ++k)
+                {
                     ty[k].push_back((cat == 3 || cat == 4) ? 1 : (cat == 6 ? 0 : cat));   // io/oio fixedValue init; piov zeroGradient init (device sets per-step)
-                    vf[k].push_back(seedVf); ref[k].push_back(rv[k]);
+                    vf[k].push_back(seedVf);
+                    ref[k].push_back(rv[k]);
                 }
             }
         }
     }
-    DeviceVectorBoundary db; db.n = static_cast<int>(fc.size());
-    db.nx.copyFrom(nrm[0]); db.ny.copyFrom(nrm[1]); db.nz.copyFrom(nrm[2]);
-    for (int k = 0; k < 3; ++k) {
-        db.comp[k].n = db.n; db.comp[k].bcType.copyFrom(ty[k]); db.comp[k].ioMask.copyFrom(io); db.comp[k].oioMask.copyFrom(oio);
-        db.comp[k].mixedMask.copyFrom(mx); db.comp[k].piovMask.copyFrom(pv); db.comp[k].symMask.copyFrom(sm); db.comp[k].valueFraction.copyFrom(vf[k]);
-        db.comp[k].refValue.copyFrom(ref[k]); db.comp[k].deltaCoeffs.copyFrom(dc);
-        db.comp[k].magSf.copyFrom(ms); db.comp[k].faceCell.copyFrom(fc);
+    DeviceVectorBoundary db;
+    db.n = static_cast<int>(fc.size());
+    db.nx.copyFrom(nrm[0]);
+    db.ny.copyFrom(nrm[1]);
+    db.nz.copyFrom(nrm[2]);
+    for (int k = 0; k < 3; ++k)
+    {
+        db.comp[k].n = db.n;
+        db.comp[k].bcType.copyFrom(ty[k]);
+        db.comp[k].ioMask.copyFrom(io);
+        db.comp[k].oioMask.copyFrom(oio);
+        db.comp[k].mixedMask.copyFrom(mx);
+        db.comp[k].piovMask.copyFrom(pv);
+        db.comp[k].symMask.copyFrom(sm);
+        db.comp[k].valueFraction.copyFrom(vf[k]);
+        db.comp[k].refValue.copyFrom(ref[k]);
+        db.comp[k].deltaCoeffs.copyFrom(dc);
+        db.comp[k].magSf.copyFrom(ms);
+        db.comp[k].faceCell.copyFrom(fc);
     }
     return db;
 }

--- a/src/cuda/device_buffer.cuh
+++ b/src/cuda/device_buffer.cuh
@@ -13,7 +13,8 @@
 
 namespace brae {
 
-inline void cudaCheck(cudaError_t e, const char* what) {
+inline void cudaCheck(cudaError_t e, const char* what)
+{
     if (e != cudaSuccess) throw std::runtime_error(std::string("brae cuda: ") + what + ": " + cudaGetErrorString(e));
 }
 
@@ -26,18 +27,29 @@ namespace detail {
 // Single-threaded use (cf runs one solve on one host thread; the GPU path is not entered concurrently). Disable
 // with BRAE_NO_DEVICE_POOL=1 to A/B against the raw-cudaMalloc behaviour. The pool is intentionally leaked (never
 // destructed) so there is no static-destruction-order hazard and no cudaFree after the CUDA context is torn down.
-class DevicePool {
+class DevicePool
+{
 public:
     DevicePool() : enabled_(std::getenv("BRAE_NO_DEVICE_POOL") == nullptr) {}
-    void* take(std::size_t bytes) {
+    void* take(std::size_t bytes)
+    {
         if (bytes == 0) return nullptr;
-        if (enabled_) {
+        if (enabled_)
+        {
             auto it = free_.find(bytes);
-            if (it != free_.end() && !it->second.empty()) { void* p = it->second.back(); it->second.pop_back(); return p; }
+            if (it != free_.end() && !it->second.empty())
+            {
+                void* p = it->second.back();
+                it->second.pop_back();
+                return p;
+            }
         }
-        void* p = nullptr; cudaCheck(cudaMalloc(&p, bytes), "pool cudaMalloc"); return p;
+        void* p = nullptr;
+        cudaCheck(cudaMalloc(&p, bytes), "pool cudaMalloc");
+        return p;
     }
-    void give(void* p, std::size_t bytes) {
+    void give(void* p, std::size_t bytes)
+    {
         if (!p) return;
         if (enabled_ && bytes) free_[bytes].push_back(p);      // retain for reuse; no cudaFree during the run
         else cudaFree(p);
@@ -50,7 +62,8 @@ inline DevicePool& devicePool() { static DevicePool* p = new DevicePool(); retur
 } // namespace detail
 
 template <typename T>
-class DeviceBuffer {
+class DeviceBuffer
+{
 public:
     DeviceBuffer() = default;
     explicit DeviceBuffer(std::size_t n) { resize(n); }
@@ -60,21 +73,34 @@ public:
     DeviceBuffer(const DeviceBuffer&) = delete;
     DeviceBuffer& operator=(const DeviceBuffer&) = delete;
     DeviceBuffer(DeviceBuffer&& o) noexcept : d_(o.d_), n_(o.n_) { o.d_ = nullptr; o.n_ = 0; }
-    DeviceBuffer& operator=(DeviceBuffer&& o) noexcept {
-        if (this != &o) { if (d_) detail::devicePool().give(d_, n_ * sizeof(T));
-                          d_ = o.d_; n_ = o.n_; o.d_ = nullptr; o.n_ = 0; } return *this; }
+    DeviceBuffer& operator=(DeviceBuffer&& o) noexcept
+    {
+        if (this != &o)
+        {
+            if (d_) detail::devicePool().give(d_, n_ * sizeof(T));
+            d_ = o.d_;
+            n_ = o.n_;
+            o.d_ = nullptr;
+            o.n_ = 0;
+        }
+        return *this;
+    }
 
-    void resize(std::size_t n) {
+    void resize(std::size_t n)
+    {
         if (n == n_) return;
         if (d_) detail::devicePool().give(d_, n_ * sizeof(T));            // return OLD block (OLD n_) to the pool
-        n_ = n; d_ = nullptr;
+        n_ = n;
+        d_ = nullptr;
         if (n_) d_ = static_cast<T*>(detail::devicePool().take(n_ * sizeof(T)));
     }
-    void copyFrom(const std::vector<T>& h) {                              // H2D
+    void copyFrom(const std::vector<T>& h)                                // H2D
+    {
         if (h.size() != n_) resize(h.size());
         cudaCheck(cudaMemcpy(d_, h.data(), n_ * sizeof(T), cudaMemcpyHostToDevice), "H2D");
     }
-    void copyTo(std::vector<T>& h) const {                               // D2H
+    void copyTo(std::vector<T>& h) const                                 // D2H
+    {
         h.resize(n_);
         cudaCheck(cudaMemcpy(h.data(), d_, n_ * sizeof(T), cudaMemcpyDeviceToHost), "D2H");
     }

--- a/src/cuda/device_cyclic.cuh
+++ b/src/cuda/device_cyclic.cuh
@@ -18,7 +18,8 @@
 
 namespace brae {
 
-struct DeviceCyclic {
+struct DeviceCyclic
+{
     int n = 0;                                  // total cyclic faces (BOTH sides of every pair)
     DeviceBuffer<label>  ownCell, nbrCell;      // this-side cell, periodic-neighbour cell
     DeviceBuffer<scalar> deltaCoeffs, weights, magSf;   // face geometry (own weight w; |Sf|; 1/|delta|)
@@ -38,43 +39,81 @@ struct DeviceCyclic {
 };
 
 // Flatten every cyclic interface (both patches of each pair) into device arrays.
-inline DeviceCyclic buildDeviceCyclic(const std::vector<CyclicInterface>& cyclics,
-                                      const FvGeometry& g, const std::vector<FvPatch>& fvp) {
-    std::vector<label> oc, nc; std::vector<scalar> dc, w, ms, sfx, sfy, sfz;
+inline DeviceCyclic buildDeviceCyclic(
+    const std::vector<CyclicInterface>& cyclics,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp)
+{
+    std::vector<label> oc, nc;
+    std::vector<scalar> dc, w, ms, sfx, sfy, sfz;
     std::vector<scalar> dox, doy, doz, dnx, dny, dnz, cvx, cvy, cvz;
     bool rot = false;
-    for (const auto& c : cyclics) { if (!c.translational) rot = true; }
-    for (const auto& c : cyclics) {
+    for (const auto& c : cyclics)
+    {
+        if (!c.translational) rot = true;
+    }
+    for (const auto& c : cyclics)
+    {
         const FvPatch& P = fvp[c.patch];
-        for (std::size_t i = 0; i < c.faceCells.size(); ++i) {
+        for (std::size_t i = 0; i < c.faceCells.size(); ++i)
+        {
             const label gf = P.start + (label)i;
-            oc.push_back(c.faceCells[i]); nc.push_back(c.nbrFaceCells[i]);
-            dc.push_back(c.deltaCoeffs[i]); w.push_back(c.weights[i]); ms.push_back(g.magSf()[gf]);
-            sfx.push_back(g.Sf()[gf].x); sfy.push_back(g.Sf()[gf].y); sfz.push_back(g.Sf()[gf].z);
-            dox.push_back(c.dOwn[i].x); doy.push_back(c.dOwn[i].y); doz.push_back(c.dOwn[i].z);
-            dnx.push_back(c.dNbr[i].x); dny.push_back(c.dNbr[i].y); dnz.push_back(c.dNbr[i].z);
-            cvx.push_back(c.corrVec[i].x); cvy.push_back(c.corrVec[i].y); cvz.push_back(c.corrVec[i].z);
+            oc.push_back(c.faceCells[i]);
+            nc.push_back(c.nbrFaceCells[i]);
+            dc.push_back(c.deltaCoeffs[i]);
+            w.push_back(c.weights[i]);
+            ms.push_back(g.magSf()[gf]);
+            sfx.push_back(g.Sf()[gf].x);
+            sfy.push_back(g.Sf()[gf].y);
+            sfz.push_back(g.Sf()[gf].z);
+            dox.push_back(c.dOwn[i].x);
+            doy.push_back(c.dOwn[i].y);
+            doz.push_back(c.dOwn[i].z);
+            dnx.push_back(c.dNbr[i].x);
+            dny.push_back(c.dNbr[i].y);
+            dnz.push_back(c.dNbr[i].z);
+            cvx.push_back(c.corrVec[i].x);
+            cvy.push_back(c.corrVec[i].y);
+            cvz.push_back(c.corrVec[i].z);
         }
     }
-    DeviceCyclic d; d.n = (int)oc.size(); d.rotational = rot;
-    d.ownCell.copyFrom(oc); d.nbrCell.copyFrom(nc);
-    d.deltaCoeffs.copyFrom(dc); d.weights.copyFrom(w); d.magSf.copyFrom(ms);
-    d.Sfx.copyFrom(sfx); d.Sfy.copyFrom(sfy); d.Sfz.copyFrom(sfz);
-    d.dOwnX.copyFrom(dox); d.dOwnY.copyFrom(doy); d.dOwnZ.copyFrom(doz);
-    d.dNbrX.copyFrom(dnx); d.dNbrY.copyFrom(dny); d.dNbrZ.copyFrom(dnz);
-    d.corrVecX.copyFrom(cvx); d.corrVecY.copyFrom(cvy); d.corrVecZ.copyFrom(cvz);
-    d.ifCoeff.resize(d.n); d.phi.resize(d.n);
-    if (rot) {   // pack forwardT (9*n, component-major) + the per-component implicit scratch
+    DeviceCyclic d;
+    d.n = (int)oc.size();
+    d.rotational = rot;
+    d.ownCell.copyFrom(oc);
+    d.nbrCell.copyFrom(nc);
+    d.deltaCoeffs.copyFrom(dc);
+    d.weights.copyFrom(w);
+    d.magSf.copyFrom(ms);
+    d.Sfx.copyFrom(sfx);
+    d.Sfy.copyFrom(sfy);
+    d.Sfz.copyFrom(sfz);
+    d.dOwnX.copyFrom(dox);
+    d.dOwnY.copyFrom(doy);
+    d.dOwnZ.copyFrom(doz);
+    d.dNbrX.copyFrom(dnx);
+    d.dNbrY.copyFrom(dny);
+    d.dNbrZ.copyFrom(dnz);
+    d.corrVecX.copyFrom(cvx);
+    d.corrVecY.copyFrom(cvy);
+    d.corrVecZ.copyFrom(cvz);
+    d.ifCoeff.resize(d.n);
+    d.phi.resize(d.n);
+    if (rot)   // pack forwardT (9*n, component-major) + the per-component implicit scratch
+    {
         std::vector<scalar> ft((std::size_t)9 * d.n);
         std::size_t f = 0;
-        for (const auto& c : cyclics) {
+        for (const auto& c : cyclics)
+        {
             const tensor& T = c.forwardT;
             const scalar tc[9] = { T.xx, T.xy, T.xz, T.yx, T.yy, T.yz, T.zx, T.zy, T.zz };
             for (std::size_t i = 0; i < c.faceCells.size(); ++i, ++f)
-                for (int k = 0; k < 9; ++k) ft[(std::size_t)k * d.n + f] = tc[k];
+                for (int k = 0; k < 9; ++k)
+                    ft[(std::size_t)k * d.n + f] = tc[k];
         }
         d.fT.copyFrom(ft);
-        for (int k = 0; k < 3; ++k) d.ifCoeffC[k].resize(d.n);
+        for (int k = 0; k < 3; ++k)
+            d.ifCoeffC[k].resize(d.n);
     }
     return d;
 }
@@ -109,21 +148,21 @@ void deviceCyclicOffDiagSum(const DeviceCyclic& cyc, DeviceBuffer<scalar>& sumOf
 void deviceCyclicFlux(DeviceCyclic& cyc, const DeviceBuffer<scalar>& Hx, const DeviceBuffer<scalar>& Hy,
                       const DeviceBuffer<scalar>& Hz);
 
-// ---- ROTATIONAL (Phase 1), only the VECTOR (U/HbyA) couplings differ; scalars use the functions above ----
+// ROTATIONAL (Phase 1), only the VECTOR (U/HbyA) couplings differ; scalars use the functions above
 // fill the per-component implicit off-diagonal ifCoeffC[kk] = ifCoeff * forwardT[kk][kk] (call after AssembleMomentum).
 void deviceCyclicScaleImplicit(DeviceCyclic& cyc);
-// rotational HbyA flux: the neighbour vector is rotated, phi = (w*H[own] + (1-w)*forwardT·H[nbr]) · Sf.
+// rotational HbyA flux: the neighbour vector is rotated, phi = (w*H[own] + (1-w)*forwardT.H[nbr]) . Sf.
 void deviceCyclicFluxRot(DeviceCyclic& cyc, const DeviceBuffer<scalar>& Hx, const DeviceBuffer<scalar>& Hy,
                          const DeviceBuffer<scalar>& Hz);
-// rotational H (full rotation, mixes components): H[kk][own] -= ifCoeff * (forwardT·U[nbr])[kk] / V[own], all 3 kk.
+// rotational H (full rotation, mixes components): H[kk][own] -= ifCoeff * (forwardT.U[nbr])[kk] / V[own], all 3 kk.
 void deviceCyclicAddHRot(const DeviceCyclic& cyc, const DeviceBuffer<scalar>& Ux, const DeviceBuffer<scalar>& Uy,
                          const DeviceBuffer<scalar>& Uz, const DeviceBuffer<scalar>& V,
                          DeviceBuffer<scalar>& Hx, DeviceBuffer<scalar>& Hy, DeviceBuffer<scalar>& Hz);
-// rotational gaussGrad of vector component `comp`: grad[own] += Sf * (w*U[comp][own] + (1-w)*(forwardT·U[nbr])[comp]) / V.
+// rotational gaussGrad of vector component `comp`: grad[own] += Sf * (w*U[comp][own] + (1-w)*(forwardT.U[nbr])[comp]) / V.
 void deviceCyclicAddGradRot(const DeviceCyclic& cyc, const DeviceBuffer<scalar>& Ux, const DeviceBuffer<scalar>& Uy,
                             const DeviceBuffer<scalar>& Uz, int comp, const DeviceBuffer<scalar>& V,
                             DeviceBuffer<scalar>& gx, DeviceBuffer<scalar>& gy, DeviceBuffer<scalar>& gz);
-// DEFERRED rotation correction (component comp) into the momentum source: src[own] -= ifCoeff*[(forwardT·U[nbr])[comp]
+// DEFERRED rotation correction (component comp) into the momentum source: src[own] -= ifCoeff*[(forwardT.U[nbr])[comp]
 //   - forwardT[comp][comp]*U[comp][nbr]] (the off-diagonal component-MIXING the diag-only implicit drops). With this in
 // the source AND the diagonal H (deviceCyclicAddHDiag), the predictor + H both carry the FULL rotation -> consistent ->
 // converges. Mirrors the standard deferred-correction split of a non-implementable implicit term. NOT /V (matrixH does).
@@ -152,7 +191,7 @@ void deviceCyclicAddLinUpwindCorr(const DeviceCyclic& cyc, int comp,
 // non-orth laplacian "corrected" correction at the cyclic interface (component comp). Per face the explicit face-flux
 // correction is ffc = gammaFace*magSf*(corrVec . grad(U_comp)_face), gathered as src[own] -= ffc (owner side), and the
 // caller does relaxSrc -= src (mirrors the internal deviceLaplacianCorr). The neighbour gradient ROTATES as a tensor:
-// grad((forwardT·U)_comp) = (forwardT · gradU[nbr] · forwardTᵀ)[comp][:], so it needs ALL 3 component gradients.
+// grad((forwardT.U)_comp) = (forwardT . gradU[nbr] . forwardT^T)[comp][:], so it needs ALL 3 component gradients.
 // gammaCell = nuEff per cell (interpolated to the face by w). corr is the SAME buffer the internal corr was written to.
 void deviceCyclicAddLapCorr(const DeviceCyclic& cyc, int comp, const DeviceBuffer<scalar>& gammaCell,
                             const DeviceBuffer<scalar>* gUx, const DeviceBuffer<scalar>* gUy,

--- a/src/cuda/device_kepsilon.cuh
+++ b/src/cuda/device_kepsilon.cuh
@@ -27,7 +27,11 @@ struct DeviceCyclic;  // cyclic interface     (scalar-transport coupling, option
 // OF-style turbulence residual reporting. Every turbulence scalar solve (k / epsilon / omega / nuTilda / ReThetat /
 // gammaInt) appends its field name + solve perf here, in solve order, so the SIMPLE driver can print an
 // "smoothSolver:  Solving for <field>, Initial residual = ..." block exactly like OpenFOAM. Cleared once per SIMPLE step.
-struct ScalarSolveEntry { std::string field; DeviceSolverPerf perf; };
+struct ScalarSolveEntry
+{
+    std::string field;
+    DeviceSolverPerf perf;
+};
 void clearTurbulenceReport();
 const std::vector<ScalarSolveEntry>& turbulenceReport();
 
@@ -58,27 +62,56 @@ void deviceNut(const DeviceBuffer<scalar>& k, const DeviceBuffer<scalar>& eps, D
 void deviceBoundField(const DeviceMesh& dm, DeviceBuffer<scalar>& x, scalar floor);
 
 // Static wall geometry for the wall functions (nearWallDist y, wall-face cell/deltaCoeffs/velocity, 1/nWallFaces).
-struct DeviceWallData {
+struct DeviceWallData
+{
     int nWF = 0;
     DeviceBuffer<label>  wfCell, isWallCell;
     DeviceBuffer<scalar> wfY, wfDc, wfUwx, wfUwy, wfUwz, invNw;
 };
-inline DeviceWallData buildDeviceWallData(const PrimitiveMesh& m, const FvGeometry& g,
-                                          const std::vector<FvPatch>& fvp, const GeometricField<vector>& U) {
+inline DeviceWallData buildDeviceWallData(
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp,
+    const GeometricField<vector>& U)
+{
     const std::vector<std::vector<scalar>> yW = nearWallDist(m, g, fvp);
-    std::vector<label> wfCell; std::vector<scalar> wfY, wfDc, wux, wuy, wuz; std::vector<label> nw(m.nCells(), 0);
-    for (std::size_t pi = 0; pi < fvp.size(); ++pi) if (fvp[pi].type == "wall") {
-        const std::vector<vector>& uv = U.boundary[pi]->value();
-        for (label i = 0; i < fvp[pi].size; ++i) { const label c = fvp[pi].faceCells[i];
-            wfCell.push_back(c); wfY.push_back(yW[pi][i]); wfDc.push_back(fvp[pi].deltaCoeffs[i]);
-            wux.push_back(uv[i].x); wuy.push_back(uv[i].y); wuz.push_back(uv[i].z); ++nw[c]; }
-    }
-    std::vector<scalar> invNw(m.nCells(), 0.0); std::vector<label> isW(m.nCells(), 0);
-    for (label c = 0; c < m.nCells(); ++c) if (nw[c] > 0) { invNw[c] = 1.0 / nw[c]; isW[c] = 1; }
-    DeviceWallData w; w.nWF = static_cast<int>(wfCell.size());
-    w.wfCell.copyFrom(wfCell); w.wfY.copyFrom(wfY); w.wfDc.copyFrom(wfDc);
-    w.wfUwx.copyFrom(wux); w.wfUwy.copyFrom(wuy); w.wfUwz.copyFrom(wuz);
-    w.invNw.copyFrom(invNw); w.isWallCell.copyFrom(isW);
+    std::vector<label> wfCell;
+    std::vector<scalar> wfY, wfDc, wux, wuy, wuz;
+    std::vector<label> nw(m.nCells(), 0);
+    for (std::size_t pi = 0; pi < fvp.size(); ++pi)
+        if (fvp[pi].type == "wall")
+        {
+            const std::vector<vector>& uv = U.boundary[pi]->value();
+            for (label i = 0; i < fvp[pi].size; ++i)
+            {
+                const label c = fvp[pi].faceCells[i];
+                wfCell.push_back(c);
+                wfY.push_back(yW[pi][i]);
+                wfDc.push_back(fvp[pi].deltaCoeffs[i]);
+                wux.push_back(uv[i].x);
+                wuy.push_back(uv[i].y);
+                wuz.push_back(uv[i].z);
+                ++nw[c];
+            }
+        }
+    std::vector<scalar> invNw(m.nCells(), 0.0);
+    std::vector<label> isW(m.nCells(), 0);
+    for (label c = 0; c < m.nCells(); ++c)
+        if (nw[c] > 0)
+        {
+            invNw[c] = 1.0 / nw[c];
+            isW[c] = 1;
+        }
+    DeviceWallData w;
+    w.nWF = static_cast<int>(wfCell.size());
+    w.wfCell.copyFrom(wfCell);
+    w.wfY.copyFrom(wfY);
+    w.wfDc.copyFrom(wfDc);
+    w.wfUwx.copyFrom(wux);
+    w.wfUwy.copyFrom(wuy);
+    w.wfUwz.copyFrom(wuz);
+    w.invNw.copyFrom(invNw);
+    w.isWallCell.copyFrom(isW);
     return w;
 }
 
@@ -119,7 +152,7 @@ void deviceKEpsilonCorrect(const DeviceMesh& dm, const DeviceWallData& wall, con
 
 // Closed device kOmegaSST::correct(): production (raw GbyNu0 + omega-wall G0 override) -> F1/F2/CDkOmega/S2 ->
 // omega eqn (loose solve, omega-wall setValues) -> bound -> k eqn (loose solve) -> bound -> correctNut (Bradshaw
-// limiter). y = precomputed cell wall distance (cellWallDist). All blocks reuse the C①-⑥ validated kernels +
+// limiter). y = precomputed cell wall distance (cellWallDist). All blocks reuse the C1-6 validated kernels +
 // the shared deviceSolveScalarTransport scaffold. Updates k/omega/nut in place. Mirrors kOmegaSSTBase::correct().
 void deviceKOmegaSSTCorrect(const DeviceMesh& dm, const DeviceWallData& wall, const DeviceBoundary& dbOmega,
                             const DeviceBoundary& dbK, const DeviceVectorBoundary& dbU,

--- a/src/cuda/device_ldu.cuh
+++ b/src/cuda/device_ldu.cuh
@@ -14,27 +14,42 @@ namespace brae {
 
 // A non-owning view of an lduMatrix on device (raw pointers): lets the G4-assembled coefficients reuse a
 // DeviceMesh's addressing without copying, and lets a self-contained DeviceLduMatrix expose the same shape.
-struct DeviceLduView {
+struct DeviceLduView
+{
     int nCells = 0, nInternalFaces = 0;
-    const scalar* diag = nullptr; const scalar* upper = nullptr; const scalar* lower = nullptr;
-    const label*  owner = nullptr; const label* nei = nullptr;
-    const label*  ownerStart = nullptr; const label* losort = nullptr; const label* losortStart = nullptr;
+    const scalar* diag = nullptr;
+    const scalar* upper = nullptr;
+    const scalar* lower = nullptr;
+    const label*  owner = nullptr;
+    const label* nei = nullptr;
+    const label*  ownerStart = nullptr;
+    const label* losort = nullptr;
+    const label* losortStart = nullptr;
     // optional cyclic (periodic) interface, OpenFOAM cyclicFvPatchField::updateInterfaceMatrix. Applied in
     // deviceAmul as Apsi[cycOwn[j]] += cycCoeff[j]*psi[cycNbr[j]] (the diagonal part is folded into `diag`).
-    int nCyc = 0; const label* cycOwn = nullptr; const label* cycNbr = nullptr; const scalar* cycCoeff = nullptr;
+    int nCyc = 0;
+    const label* cycOwn = nullptr;
+    const label* cycNbr = nullptr;
+    const scalar* cycCoeff = nullptr;
     // optional cyclicAMI interface, OF cyclicAMIFvPatchField::updateInterfaceMatrix. Applied in deviceAmul as
     // Apsi[amiOwn[i]] += amiIfc[i] * sum_{k in [amiOff[i],amiOff[i+1])} amiW[k]*psi[amiNbr[k]] (weighted stencil).
-    int nAmi = 0; const label* amiOwn = nullptr; const label* amiOff = nullptr; const label* amiNbr = nullptr;
-    const scalar* amiW = nullptr; const scalar* amiIfc = nullptr;
+    int nAmi = 0;
+    const label* amiOwn = nullptr;
+    const label* amiOff = nullptr;
+    const label* amiNbr = nullptr;
+    const scalar* amiW = nullptr;
+    const scalar* amiIfc = nullptr;
 };
 
-struct DeviceLduMatrix {
+struct DeviceLduMatrix
+{
     int nCells = 0, nFaces = 0;
     DeviceBuffer<scalar> diag, upper, lower;
     DeviceBuffer<label>  owner, nei;
     DeviceBuffer<label>  ownerStart, losort, losortStart;
 
-    DeviceLduView view() const {
+    DeviceLduView view() const
+    {
         return {nCells, nFaces, diag.data(), upper.data(), lower.data(), owner.data(), nei.data(),
                 ownerStart.data(), losort.data(), losortStart.data()};
     }
@@ -43,45 +58,90 @@ struct DeviceLduMatrix {
 // Build the device matrix from host lduMatrix arrays. owner/neighbour are upper-triangular ordered
 // (faces sorted by owner) as in cf's mesh, so ownerStart is a plain prefix sum; losort is a counting
 // sort of the faces by neighbour cell.
-inline DeviceLduMatrix buildDeviceLdu(const std::vector<scalar>& diag, const std::vector<scalar>& upper,
-                                      const std::vector<scalar>& lower, const std::vector<label>& owner,
-                                      const std::vector<label>& nei, int nCells) {
+inline DeviceLduMatrix buildDeviceLdu(
+    const std::vector<scalar>& diag,
+    const std::vector<scalar>& upper,
+    const std::vector<scalar>& lower,
+    const std::vector<label>& owner,
+    const std::vector<label>& nei,
+    int nCells)
+{
     const int nF = static_cast<int>(owner.size());
     std::vector<label> ownerStart(nCells + 1, 0), losortStart(nCells + 1, 0), losort(nF);
-    for (int f = 0; f < nF; ++f) { ownerStart[owner[f] + 1]++; losortStart[nei[f] + 1]++; }
-    for (int c = 0; c < nCells; ++c) { ownerStart[c + 1] += ownerStart[c]; losortStart[c + 1] += losortStart[c]; }
+    for (int f = 0; f < nF; ++f)
+    {
+        ownerStart[owner[f] + 1]++;
+        losortStart[nei[f] + 1]++;
+    }
+    for (int c = 0; c < nCells; ++c)
+    {
+        ownerStart[c + 1] += ownerStart[c];
+        losortStart[c + 1] += losortStart[c];
+    }
     std::vector<label> pos(losortStart.begin(), losortStart.end());
-    for (int f = 0; f < nF; ++f) losort[pos[nei[f]]++] = f;
+    for (int f = 0; f < nF; ++f)
+        losort[pos[nei[f]]++] = f;
 
-    DeviceLduMatrix A; A.nCells = nCells; A.nFaces = nF;
-    A.diag.copyFrom(diag); A.upper.copyFrom(upper); A.lower.copyFrom(lower);
-    A.owner.copyFrom(owner); A.nei.copyFrom(nei);
-    A.ownerStart.copyFrom(ownerStart); A.losort.copyFrom(losort); A.losortStart.copyFrom(losortStart);
+    DeviceLduMatrix A;
+    A.nCells = nCells;
+    A.nFaces = nF;
+    A.diag.copyFrom(diag);
+    A.upper.copyFrom(upper);
+    A.lower.copyFrom(lower);
+    A.owner.copyFrom(owner);
+    A.nei.copyFrom(nei);
+    A.ownerStart.copyFrom(ownerStart);
+    A.losort.copyFrom(losort);
+    A.losortStart.copyFrom(losortStart);
     return A;
 }
 
 // A view over a DeviceMesh's addressing + externally-assembled (G4) coefficients, no copy.
-inline DeviceLduView deviceLduView(const DeviceMesh& dm, const DeviceBuffer<scalar>& diag,
-                                   const DeviceBuffer<scalar>& upper, const DeviceBuffer<scalar>& lower) {
+inline DeviceLduView deviceLduView(
+    const DeviceMesh& dm,
+    const DeviceBuffer<scalar>& diag,
+    const DeviceBuffer<scalar>& upper,
+    const DeviceBuffer<scalar>& lower)
+{
     return {dm.nCells, dm.nInternalFaces, diag.data(), upper.data(), lower.data(), dm.owner.data(), dm.nei.data(),
             dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), 0, nullptr, nullptr, nullptr};
 }
 // Same view, augmented with a cyclic interface (cycOwn/cycNbr/cycCoeff over nCyc periodic faces). deviceAmul
 // applies the interface off-diagonal; the matching diagonal contribution must already be folded into `diag`.
-inline DeviceLduView deviceLduViewCyclic(const DeviceMesh& dm, const DeviceBuffer<scalar>& diag,
-                                         const DeviceBuffer<scalar>& upper, const DeviceBuffer<scalar>& lower,
-                                         int nCyc, const label* cycOwn, const label* cycNbr, const scalar* cycCoeff) {
+inline DeviceLduView deviceLduViewCyclic(
+    const DeviceMesh& dm,
+    const DeviceBuffer<scalar>& diag,
+    const DeviceBuffer<scalar>& upper,
+    const DeviceBuffer<scalar>& lower,
+    int nCyc,
+    const label* cycOwn,
+    const label* cycNbr,
+    const scalar* cycCoeff)
+{
     return {dm.nCells, dm.nInternalFaces, diag.data(), upper.data(), lower.data(), dm.owner.data(), dm.nei.data(),
             dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), nCyc, cycOwn, cycNbr, cycCoeff};
 }
 // Same view, augmented with a cyclicAMI interface (the weighted CSR stencil over nAmi source faces). deviceAmul
 // applies the weighted off-diagonal; the matching diagonal contribution must already be folded into `diag`.
-inline DeviceLduView deviceLduViewAmi(const DeviceMesh& dm, const DeviceBuffer<scalar>& diag,
-                                      const DeviceBuffer<scalar>& upper, const DeviceBuffer<scalar>& lower,
-                                      int nAmi, const label* amiOwn, const label* amiOff, const label* amiNbr,
-                                      const scalar* amiW, const scalar* amiIfc) {
+inline DeviceLduView deviceLduViewAmi(
+    const DeviceMesh& dm,
+    const DeviceBuffer<scalar>& diag,
+    const DeviceBuffer<scalar>& upper,
+    const DeviceBuffer<scalar>& lower,
+    int nAmi,
+    const label* amiOwn,
+    const label* amiOff,
+    const label* amiNbr,
+    const scalar* amiW,
+    const scalar* amiIfc)
+{
     DeviceLduView v = deviceLduView(dm, diag, upper, lower);
-    v.nAmi = nAmi; v.amiOwn = amiOwn; v.amiOff = amiOff; v.amiNbr = amiNbr; v.amiW = amiW; v.amiIfc = amiIfc;
+    v.nAmi = nAmi;
+    v.amiOwn = amiOwn;
+    v.amiOff = amiOff;
+    v.amiNbr = amiNbr;
+    v.amiW = amiW;
+    v.amiIfc = amiIfc;
     return v;
 }
 

--- a/src/cuda/device_mesh.cuh
+++ b/src/cuda/device_mesh.cuh
@@ -14,7 +14,8 @@
 
 namespace brae {
 
-struct DeviceMesh {
+struct DeviceMesh
+{
     int nCells = 0, nInternalFaces = 0, nBndFaces = 0;
     DeviceBuffer<label>  owner, nei;                    // internal faces
     DeviceBuffer<scalar> w, V, Sfx, Sfy, Sfz;           // weights(nIf), V(nC), Sf components(all faces)
@@ -34,15 +35,24 @@ struct DeviceMesh {
 // cyclicFvPatchField::updateInterfaceMatrix, it is NOT merged into this owner-sorted internal-face LDU (doing
 // so breaks the amulKernel's owner-contiguous scatter, which assumes faces sorted by owner). The `cyclics`
 // argument is kept for API symmetry but the LDU itself carries only the mesh internal faces.
-inline DeviceMesh buildDeviceMesh(const PrimitiveMesh& m, const FvGeometry& g, const std::vector<FvPatch>& fvp,
-                                  const std::vector<CyclicInterface>& cyclics = {}) {
+inline DeviceMesh buildDeviceMesh(
+    const PrimitiveMesh& m,
+    const FvGeometry& g,
+    const std::vector<FvPatch>& fvp,
+    const std::vector<CyclicInterface>& cyclics = {})
+{
     (void)cyclics;
     const int nC = m.nCells(), nIf0 = m.nInternalFaces();
-    const std::vector<label>& own = m.owner(); const std::vector<label>& nei = m.neighbour();
-    const std::vector<vector>& Sf = g.Sf(); const std::vector<scalar>& magSfAll = g.magSf();
-    const std::vector<vector>& Cf = g.Cf(); const std::vector<vector>& C = g.C();
-    const std::vector<scalar>& wts = g.weights(); const std::vector<scalar>& dcAll = g.deltaCoeffs();
-    const std::vector<scalar>& nodcAll = g.nonOrthDeltaCoeffs(); const std::vector<vector>& cvAll = g.nonOrthCorrectionVectors();
+    const std::vector<label>& own = m.owner();
+    const std::vector<label>& nei = m.neighbour();
+    const std::vector<vector>& Sf = g.Sf();
+    const std::vector<scalar>& magSfAll = g.magSf();
+    const std::vector<vector>& Cf = g.Cf();
+    const std::vector<vector>& C = g.C();
+    const std::vector<scalar>& wts = g.weights();
+    const std::vector<scalar>& dcAll = g.deltaCoeffs();
+    const std::vector<scalar>& nodcAll = g.nonOrthDeltaCoeffs();
+    const std::vector<vector>& cvAll = g.nonOrthCorrectionVectors();
 
     const int nIf = nIf0;                                  // internal faces = mesh internal faces only (cyclic is a separate interface)
 
@@ -50,58 +60,125 @@ inline DeviceMesh buildDeviceMesh(const PrimitiveMesh& m, const FvGeometry& g, c
     std::vector<scalar> wI(nIf), dcI(nIf), nodcI(nIf);
     std::vector<scalar> dOwnX(nIf),dOwnY(nIf),dOwnZ(nIf), dNeiX(nIf),dNeiY(nIf),dNeiZ(nIf), corrX(nIf),corrY(nIf),corrZ(nIf);
     std::vector<scalar> SfxN, SfyN, SfzN, magSfN;          // Sf layout: [internal | non-cyclic boundary]
-    SfxN.reserve(magSfAll.size()); SfyN.reserve(magSfAll.size()); SfzN.reserve(magSfAll.size()); magSfN.reserve(magSfAll.size());
-    for (int f = 0; f < nIf0; ++f) {                       // original internal faces
-        ownI[f]=own[f]; neiI[f]=nei[f]; wI[f]=wts[f]; dcI[f]=dcAll[f]; nodcI[f]=nodcAll[f];
+    SfxN.reserve(magSfAll.size());
+    SfyN.reserve(magSfAll.size());
+    SfzN.reserve(magSfAll.size());
+    magSfN.reserve(magSfAll.size());
+    for (int f = 0; f < nIf0; ++f)                         // original internal faces
+    {
+        ownI[f]=own[f];
+        neiI[f]=nei[f];
+        wI[f]=wts[f];
+        dcI[f]=dcAll[f];
+        nodcI[f]=nodcAll[f];
         const vector dO=Cf[f]-C[own[f]], dN=Cf[f]-C[nei[f]];
-        dOwnX[f]=dO.x;dOwnY[f]=dO.y;dOwnZ[f]=dO.z; dNeiX[f]=dN.x;dNeiY[f]=dN.y;dNeiZ[f]=dN.z;
-        corrX[f]=cvAll[f].x; corrY[f]=cvAll[f].y; corrZ[f]=cvAll[f].z;
-        SfxN.push_back(Sf[f].x); SfyN.push_back(Sf[f].y); SfzN.push_back(Sf[f].z); magSfN.push_back(magSfAll[f]);
+        dOwnX[f]=dO.x;
+        dOwnY[f]=dO.y;
+        dOwnZ[f]=dO.z;
+        dNeiX[f]=dN.x;
+        dNeiY[f]=dN.y;
+        dNeiZ[f]=dN.z;
+        corrX[f]=cvAll[f].x;
+        corrY[f]=cvAll[f].y;
+        corrZ[f]=cvAll[f].z;
+        SfxN.push_back(Sf[f].x);
+        SfyN.push_back(Sf[f].y);
+        SfzN.push_back(Sf[f].z);
+        magSfN.push_back(magSfAll[f]);
     }
     std::vector<label> bndCell, bndGFace, bndIsEmpty;      // non-cyclic boundary faces (cyclic patches skipped)
     std::vector<scalar> dBndX, dBndY, dBndZ;               // Cf - C(faceCell) per boundary face (cellLimited grad)
-    for (const FvPatch& p : fvp) {
+    for (const FvPatch& p : fvp)
+    {
         if (p.type == "cyclic" || p.type == "cyclicAMI") continue;
         const label emp = (p.type == "empty") ? 1 : 0;
-        for (label i = 0; i < p.size; ++i) {
-            bndCell.push_back(p.faceCells[i]); bndGFace.push_back((label)SfxN.size()); bndIsEmpty.push_back(emp);
-            SfxN.push_back(Sf[p.start+i].x); SfyN.push_back(Sf[p.start+i].y); SfzN.push_back(Sf[p.start+i].z); magSfN.push_back(magSfAll[p.start+i]);
-            const vector dB = Cf[p.start+i] - C[p.faceCells[i]]; dBndX.push_back(dB.x); dBndY.push_back(dB.y); dBndZ.push_back(dB.z);
+        for (label i = 0; i < p.size; ++i)
+        {
+            bndCell.push_back(p.faceCells[i]);
+            bndGFace.push_back((label)SfxN.size());
+            bndIsEmpty.push_back(emp);
+            SfxN.push_back(Sf[p.start+i].x);
+            SfyN.push_back(Sf[p.start+i].y);
+            SfzN.push_back(Sf[p.start+i].z);
+            magSfN.push_back(magSfAll[p.start+i]);
+            const vector dB = Cf[p.start+i] - C[p.faceCells[i]];
+            dBndX.push_back(dB.x);
+            dBndY.push_back(dB.y);
+            dBndZ.push_back(dB.z);
         }
     }
     const int nB = static_cast<int>(bndCell.size());
 
     std::vector<label> ownerStart(nC+1,0), losortStart(nC+1,0), losort(nIf);   // gather addressing over the extended faces
-    for (int f = 0; f < nIf; ++f) { ownerStart[ownI[f]+1]++; losortStart[neiI[f]+1]++; }
-    for (int c = 0; c < nC; ++c) { ownerStart[c+1]+=ownerStart[c]; losortStart[c+1]+=losortStart[c]; }
-    { std::vector<label> pos(losortStart.begin(), losortStart.end());
-      for (int f = 0; f < nIf; ++f) losort[pos[neiI[f]]++] = f; }
+    for (int f = 0; f < nIf; ++f)
+    {
+        ownerStart[ownI[f]+1]++;
+        losortStart[neiI[f]+1]++;
+    }
+    for (int c = 0; c < nC; ++c)
+    {
+        ownerStart[c+1]+=ownerStart[c];
+        losortStart[c+1]+=losortStart[c];
+    }
+    {
+        std::vector<label> pos(losortStart.begin(), losortStart.end());
+        for (int f = 0; f < nIf; ++f)
+            losort[pos[neiI[f]]++] = f;
+    }
     std::vector<label> bndCellStart(nC+1,0), bndPerm(nB);
-    for (int k = 0; k < nB; ++k) bndCellStart[bndCell[k]+1]++;
-    for (int c = 0; c < nC; ++c) bndCellStart[c+1]+=bndCellStart[c];
-    { std::vector<label> pos(bndCellStart.begin(), bndCellStart.end());
-      for (int k = 0; k < nB; ++k) bndPerm[pos[bndCell[k]]++] = k; }
+    for (int k = 0; k < nB; ++k)
+        bndCellStart[bndCell[k]+1]++;
+    for (int c = 0; c < nC; ++c)
+        bndCellStart[c+1]+=bndCellStart[c];
+    {
+        std::vector<label> pos(bndCellStart.begin(), bndCellStart.end());
+        for (int k = 0; k < nB; ++k)
+            bndPerm[pos[bndCell[k]]++] = k;
+    }
 
-    DeviceMesh dm; dm.nCells = nC; dm.nInternalFaces = nIf; dm.nBndFaces = nB;
-    dm.owner.copyFrom(ownI); dm.nei.copyFrom(neiI);
-    dm.w.copyFrom(wI); dm.V.copyFrom(g.V());
-    dm.Sfx.copyFrom(SfxN); dm.Sfy.copyFrom(SfyN); dm.Sfz.copyFrom(SfzN);
-    dm.dc.copyFrom(dcI); dm.magSf.copyFrom(magSfN);
-    dm.ownerStart.copyFrom(ownerStart); dm.losort.copyFrom(losort); dm.losortStart.copyFrom(losortStart);
-    dm.bndCell.copyFrom(bndCell); dm.bndGFace.copyFrom(bndGFace);
-    dm.bndPerm.copyFrom(bndPerm); dm.bndCellStart.copyFrom(bndCellStart); dm.bndIsEmpty.copyFrom(bndIsEmpty);
-    dm.dOwnX.copyFrom(dOwnX); dm.dOwnY.copyFrom(dOwnY); dm.dOwnZ.copyFrom(dOwnZ);
-    dm.dNeiX.copyFrom(dNeiX); dm.dNeiY.copyFrom(dNeiY); dm.dNeiZ.copyFrom(dNeiZ);
-    dm.dBndX.copyFrom(dBndX); dm.dBndY.copyFrom(dBndY); dm.dBndZ.copyFrom(dBndZ);
+    DeviceMesh dm;
+    dm.nCells = nC;
+    dm.nInternalFaces = nIf;
+    dm.nBndFaces = nB;
+    dm.owner.copyFrom(ownI);
+    dm.nei.copyFrom(neiI);
+    dm.w.copyFrom(wI);
+    dm.V.copyFrom(g.V());
+    dm.Sfx.copyFrom(SfxN);
+    dm.Sfy.copyFrom(SfyN);
+    dm.Sfz.copyFrom(SfzN);
+    dm.dc.copyFrom(dcI);
+    dm.magSf.copyFrom(magSfN);
+    dm.ownerStart.copyFrom(ownerStart);
+    dm.losort.copyFrom(losort);
+    dm.losortStart.copyFrom(losortStart);
+    dm.bndCell.copyFrom(bndCell);
+    dm.bndGFace.copyFrom(bndGFace);
+    dm.bndPerm.copyFrom(bndPerm);
+    dm.bndCellStart.copyFrom(bndCellStart);
+    dm.bndIsEmpty.copyFrom(bndIsEmpty);
+    dm.dOwnX.copyFrom(dOwnX);
+    dm.dOwnY.copyFrom(dOwnY);
+    dm.dOwnZ.copyFrom(dOwnZ);
+    dm.dNeiX.copyFrom(dNeiX);
+    dm.dNeiY.copyFrom(dNeiY);
+    dm.dNeiZ.copyFrom(dNeiZ);
+    dm.dBndX.copyFrom(dBndX);
+    dm.dBndY.copyFrom(dBndY);
+    dm.dBndZ.copyFrom(dBndZ);
     dm.nonOrthDc.copyFrom(nodcI);
-    dm.corrVecX.copyFrom(corrX); dm.corrVecY.copyFrom(corrY); dm.corrVecZ.copyFrom(corrZ);
+    dm.corrVecX.copyFrom(corrX);
+    dm.corrVecY.copyFrom(corrY);
+    dm.corrVecZ.copyFrom(corrZ);
     return dm;
 }
 
 // Flatten a boundary field (per patch -> per face) into one device array in patch order (matches bndCell order).
-inline std::vector<scalar> flattenBoundary(const std::vector<std::vector<scalar>>& bnd) {
+inline std::vector<scalar> flattenBoundary(const std::vector<std::vector<scalar>>& bnd)
+{
     std::vector<scalar> out;
-    for (const auto& pb : bnd) out.insert(out.end(), pb.begin(), pb.end());
+    for (const auto& pb : bnd)
+        out.insert(out.end(), pb.begin(), pb.end());
     return out;
 }
 


### PR DESCRIPTION
AMGX-style formatting only for the 7 remaining device_*.cuh headers (structs + inline builders -> Allman, split crammed statements, ASCII comments, banners stripped). Prototypes left wrapped per house style. Token-equivalent to originals; full suite 158/158 green.