### PR TITLE
release 0.3.0: one command for steady and transient

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES})
         CACHE STRING "CUDA architectures cf is built for" FORCE)
 endif()
 
-project(brae VERSION 0.1.0 LANGUAGES CXX CUDA)
+project(brae VERSION 0.3.0 LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -953,6 +953,11 @@ target_link_libraries(brae PRIVATE brae_core)
 add_executable(brae_pimpleFoam src/applications/solvers/pimpleFoam/gpuPimpleFoam.cu)
 target_include_directories(brae_pimpleFoam PRIVATE ${BRAE_HEADER_DIRS} src/applications/solvers/simpleFoam)
 target_link_libraries(brae_pimpleFoam PRIVATE brae_core)
+
+# `brae` hands transient cases to brae_pimpleFoam at run time, so building brae must build it too: one target to
+# build, one command to run, and no way to end up with a brae that cannot solve half the cases it is handed.
+# Every solver added to the registry (solvers/common/solver_dispatch.cuh) belongs in this list.
+add_dependencies(brae brae_pimpleFoam)
 
 # End-to-end kOmegaSSTLM (Langtry-Menter transition) vs a SAVED OpenFOAM v2412 oracle (no OF needed at test time):
 # runs brae on a transition flat plate and checks U L2 < 3% and the gammaInt transition is captured.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <img alt="C++17" src="https://img.shields.io/badge/C%2B%2B-17-00599C">
   <img alt="GPU Ampere to Blackwell" src="https://img.shields.io/badge/GPU-Ampere%20%7C%20Ada%20%7C%20Hopper%20%7C%20Blackwell-76B900">
   <img alt="OpenFOAM v2412" src="https://img.shields.io/badge/OpenFOAM-v2412-brightgreen">
-  <img alt="ctest 158/158" src="https://img.shields.io/badge/ctest-158%2F158-brightgreen">
+  <img alt="ctest 261/261" src="https://img.shields.io/badge/ctest-261%2F261-brightgreen">
 </p>
 
 Brae keeps the whole CFD solve on one GPU. The mesh, the fields, and every linear solve stay on the device from the
@@ -105,11 +105,11 @@ cmake --build build -j --target brae
 
 ## 🚀 Get started
 
-Run brae from inside any OpenFOAM `simpleFoam` case, exactly as you would run `simpleFoam` itself:
+Run brae from inside any OpenFOAM case, exactly as you would run `simpleFoam` or `pimpleFoam` itself:
 
 ```bash
 cd yourCase                       # your OpenFOAM case (0/  constant/  system/)
-brae                              # solve in the current directory
+brae                              # solve in the current directory (steady or transient)
 brae -case /path/to/yourCase      # or run it from anywhere
 brae -partition -case yourCase    # optional: cache the mesh + AMG once, then later runs start warm
 brae --help                       # all options
@@ -138,6 +138,10 @@ Brae implements OpenFOAM's solvers one at a time, each fully device-resident and
 
 - [`simpleFoam`](docs/solvers/simplefoam.md) — steady incompressible
 - [`pimpleFoam`](docs/solvers/pimplefoam.md) — transient incompressible — **brae 4.5× faster than SPUMA**
+
+You always type `brae`. It reads the `application` entry your case already has in `controlDict` and runs the
+matching solver, so a transient case needs no different command. A case asking for a solver brae does not have
+stops at start-up, named, rather than being solved with the wrong one.
 
 Coming soon: compressible solver.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started
 
-Brae runs an existing OpenFOAM steady-incompressible case on one GPU. If you can run it with `simpleFoam`, you can
-usually run it with `brae`.
+Brae runs an existing OpenFOAM incompressible case on one GPU. If you can run it with `simpleFoam` (steady) or
+`pimpleFoam` (transient), you can usually run it with `brae`.
 
 ## 1. Prerequisites
 
@@ -19,7 +19,8 @@ cmake -B build -DCMAKE_CUDA_ARCHITECTURES=<arch>   # 121=GB10, 120=RTX 50xx, 100
 cmake --build build -j --target brae
 ```
 
-The solver is `build/brae`. Add it to your `PATH` if you like:
+The command is `build/brae`, and it is the only one you run — steady or transient. Add it to your `PATH` if you
+like:
 
 ```bash
 export PATH="$PWD/build:$PATH"
@@ -36,11 +37,13 @@ brae -case /path/to/yourCase
 
 What happens:
 
-1. Brae reads your mesh, fields, schemes, and solver settings.
-2. It **auto-partitions** the mesh and builds its multigrid hierarchy for your GPU (the `decomposePar` analogue ,
+1. Brae reads your `controlDict` `application` entry and picks the matching solver (`simpleFoam` -> steady,
+   `pimpleFoam` -> transient). A solver it does not have yet stops the run instead of being substituted.
+2. It reads your mesh, fields, schemes, and solver settings.
+3. It **auto-partitions** the mesh and builds its multigrid hierarchy for your GPU (the `decomposePar` analogue ,
    done once, cached). You can pre-build this cache with `brae -case yourCase -partition`.
-3. It runs the SIMPLE loop fully on the GPU until `endTime` or `residualControl` convergence.
-4. It writes standard time directories (`100/U`, `100/p`, …) you open with `paraFoam` or `postProcess`.
+4. It runs the solver loop fully on the GPU until `endTime` (or, steady, `residualControl` convergence).
+5. It writes standard time directories (`100/U`, `100/p`, …) you open with `paraFoam` or `postProcess`.
 
 ## 4. The fast path (on by default)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,11 @@
 # Roadmap
 
-Brae runs steady, incompressible, single-region flow on a single GPU today. Coming next:
+Brae runs steady and transient incompressible single-region flow on a single GPU today:
+[`simpleFoam`](solvers/simplefoam.md) and [`pimpleFoam`](solvers/pimplefoam.md). Coming next:
 
-- More steady single-phase solvers
+- Adaptive time stepping (`adjustTimeStep` / `maxCo`) and runtime function objects for the transient solver
+- MRF and `fvOptions` in the transient solver (the steady solver has them)
+- Compressible solvers
 - Multiphase solvers
 - Multi-region
 - Heat transfer

--- a/docs/solvers/simplefoam.md
+++ b/docs/solvers/simplefoam.md
@@ -28,7 +28,7 @@ Legend: ✓ supported & validated · ✗ not yet.
 | Pressure reference handling (closed domains, all-Neumann, `fixedFluxPressure`) | ✓ |
 | Under-relaxation, `residualControl` convergence | ✓ |
 | Non-orthogonal correction in the Laplacian (`corrected`) | ✓ |
-| `nNonOrthogonalCorrectors > 0` (extra pressure correctors) | ✗ |
+| `nNonOrthogonalCorrectors > 0` (extra pressure correctors) | ✓ (with a `corrected` laplacian scheme) |
 
 ## Turbulence (RAS), 5 models, all validated vs OpenFOAM v2412
 

--- a/install.sh
+++ b/install.sh
@@ -147,10 +147,14 @@ jobs=$(nproc 2>/dev/null || echo 4)
 say "building brae with $jobs jobs (this can take a few minutes)"
 cmake --build build -j "$jobs" --target brae || die "build failed"
 
-# ---- install the binary ----
+# ---- install the binaries ----
+# `brae` is the only command; the solvers it hands cases to (brae_pimpleFoam today) come along as build
+# dependencies and are looked up next to it, so they install side by side.
 mkdir -p "$BINDIR"
-install -m 0755 build/brae "$BINDIR/brae" 2>/dev/null || cp build/brae "$BINDIR/brae"
-say "installed  $BINDIR/brae"
+for b in brae brae_pimpleFoam; do
+    install -m 0755 "build/$b" "$BINDIR/$b" 2>/dev/null || cp "build/$b" "$BINDIR/$b"
+    say "installed  $BINDIR/$b"
+done
 
 # ---- PATH hint ----
 case ":$PATH:" in
@@ -159,6 +163,6 @@ case ":$PATH:" in
        printf '      echo '\''export PATH="%s:$PATH"'\'' >> ~/.profile && . ~/.profile\n' "$BINDIR" >&2 ;;
 esac
 
-printf '\n%s%sbrae is installed.%s  Run it inside any OpenFOAM case:\n\n' "$G" "$B" "$N"
+printf '\n%s%sbrae is installed.%s  Run it inside any OpenFOAM case, steady or transient:\n\n' "$G" "$B" "$N"
 printf '    cd yourCase && brae\n\n'
 printf '  docs: https://brae.sh   source: %s\n' "$DIR"


### PR DESCRIPTION
Build `brae` and you get the transient solver with it (add_dependencies), so the docs and the installer only ever name one target and one command -- the solver registry picks the rest from the case's controlDict `application`.

- CMake project version 0.1.0 -> 0.3.0 (it had never been bumped)
- README/getting-started: brae runs steady OR transient, chosen from the case, not the command line
- roadmap: pimpleFoam shipped; adaptive dt, transient MRF/fvOptions and compressible are next
- simplefoam.md: nNonOrthogonalCorrectors is supported (with a corrected laplacian), doc was stale
- install.sh installs the solvers side by side, since brae looks them up next to itself
- drop the empty case.foam ParaView stub from the repo root
