### PR TITLE
release: hand-written notes, and one shape for every solver row

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,12 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --title "brae $GITHUB_REF_NAME" --generate-notes
+        # Hand-written notes at docs/releases/<tag>.md win; without one, fall back to the commit list.
+        run: |
+          notes="docs/releases/${GITHUB_REF_NAME}.md"
+          if [ -f "$notes" ]; then
+              gh release create "$GITHUB_REF_NAME" --title "brae $GITHUB_REF_NAME" --notes-file "$notes"
+          else
+              echo "no $notes, generating notes from commits"
+              gh release create "$GITHUB_REF_NAME" --title "brae $GITHUB_REF_NAME" --generate-notes
+          fi

--- a/docs/releases/v0.3.0.md
+++ b/docs/releases/v0.3.0.md
@@ -1,0 +1,78 @@
+# brae 0.3.0 — transient pimpleFoam
+
+Brae now runs transient incompressible flow, and it runs it from the same command.
+
+## One command
+
+You always type `brae`. It reads the `application` entry your case already has in `controlDict` and runs the
+matching solver:
+
+```bash
+cd yourSteadyCase     && brae     # application simpleFoam  -> steady
+cd yourTransientCase  && brae     # application pimpleFoam  -> transient
+```
+
+A case asking for a solver brae does not implement yet stops at start-up, named, instead of being solved with the
+wrong one. Adding the next solver is one row in the registry.
+
+## New: transient incompressible PIMPLE
+
+Fully device-resident, sharing its momentum, pressure and turbulence phases with the validated steady solver:
+
+- **Time schemes:** `Euler`, `backward`, `CrankNicolson` (with off-centring coefficient)
+- **Implicit `fvm::ddt` on the turbulence transport too** — true URANS, not a quasi-steady turbulence field
+- **Turbulence:** laminar; k-epsilon, realizable k-epsilon, k-omega SST, k-omega SST-LM, Spalart-Allmaras;
+  and the hybrid set — SA-DDES, SA-IDDES, k-omega SST-DDES, k-omega SST-IDDES, Smagorinsky LES
+- **Seamless restart:** writes and re-reads `phi` and the `ddt0(...)` state, so `startFrom latestTime` continues
+  the same trajectory rather than restarting the history
+- **PIMPLE controls:** `nOuterCorrectors`, `nCorrectors`, `nNonOrthogonalCorrectors`, `relaxationFactors`
+- Standard OpenFOAM time directories out (`U`, `p`, `phi`, turbulence), ASCII or binary mesh in
+
+### Accuracy
+
+pitzDaily, k-omega SST, marched to steady: velocity within **0.07%** of OpenFOAM v2412 `pimpleFoam` on the same
+case.
+
+### Speed
+
+1× H100 80GB, pitzDaily developed then advanced at fixed `deltaT`, both solvers converged at the same tolerance:
+
+| cells | brae | SPUMA (OpenFOAM-GPU, best config) | |
+|---|---|---|---|
+| 4.9M | 56 s | 255 s | **4.5× faster** |
+| 15M | 179 s | did not finish in 40 min | — |
+
+Zero bytes move between CPU and GPU per time step.
+
+## Also in this release
+
+- `codedFixedValue` / `codedMixed` boundary conditions, compiled onto the device at run time, on both solvers
+- DES/LES models (SA-DDES/IDDES, SST-DDES/IDDES, Smagorinsky) available to the steady solver's shared core
+- The AMG-hierarchy cache is reused by the transient solver, so repeat runs start warm
+- `nNonOrthogonalCorrectors` documented correctly for `simpleFoam` — it was supported, the docs said otherwise
+
+## What the transient solver refuses
+
+It stops rather than quietly dropping physics:
+
+- `adjustTimeStep yes` — no Courant-limited dt yet; use a fixed `deltaT` under your target maxCo
+- `constant/MRFProperties` with an active zone — MRF is steady-only for now
+- `system/fvOptions` / `constant/fvOptions` — same
+
+Also not there yet: runtime function objects (probes, forces, fieldAverage) during the time loop.
+
+## Upgrading
+
+Nothing to change. Existing steady cases behave exactly as before. Rebuild as usual:
+
+```bash
+git pull && cmake --build build -j --target brae
+```
+
+`brae` now pulls the transient solver in as a build dependency and the installer places them side by side, so
+there is still one target to build and one command to run.
+
+---
+
+Full solver scope: [docs/solvers/pimplefoam.md](docs/solvers/pimplefoam.md) ·
+[docs/solvers/simplefoam.md](docs/solvers/simplefoam.md). ctest 261/261 on GB10; sm_80/sm_90 compile-checked.

--- a/src/applications/solvers/common/solver_dispatch.cuh
+++ b/src/applications/solvers/common/solver_dispatch.cuh
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdio>
+#include <cstdlib>   // getenv/setenv: the one-hand-over-per-run guard
 #include <cstring>
 #include <filesystem>
 #include <stdexcept>
@@ -32,19 +33,32 @@ namespace brae {
 struct BraeSolver
 {
     const char* application;   // OF controlDict `application` this row claims
-    const char* exe;           // brae executable that runs it; nullptr = the steady driver itself (in-process)
+    const char* exe;           // brae executable that runs it
     bool        transient;     // marches in time (ddtSchemes.default != steadyState)
     const char* what;          // one-line description, shown when a case asks for a solver brae lacks
 };
 
-// The registry. `brae` is the steady driver, so its row carries exe = nullptr and is run in-process.
+// The registry. Every row has the same shape, including the steady one: `brae` is the launcher AND the steady
+// solver's executable, which is a fact about today's build, not a rule the dispatcher should know. It finds out
+// by comparing the chosen row's executable with the binary that is actually running (selfExecutableName below)
+// -- so the steady case costs no extra process, and the day the steady solver moves into its own binary, only
+// this table changes.
 inline const std::vector<BraeSolver>& braeSolvers()
 {
     static const std::vector<BraeSolver> reg = {
-        {"simpleFoam", nullptr,           false, "steady incompressible, RAS/laminar"},
+        {"simpleFoam", "brae",            false, "steady incompressible, RAS/laminar"},
         {"pimpleFoam", "brae_pimpleFoam", true,  "transient incompressible, URANS/DES/LES/laminar"},
     };
     return reg;
+}
+
+// Filename of the running binary, "" if it cannot be determined (then nothing matches and the chosen solver is
+// exec'd, which is the safe direction -- the loop guard in execSolver catches a misconfiguration).
+inline std::string selfExecutableName()
+{
+    std::error_code ec;
+    const std::filesystem::path self = std::filesystem::read_symlink("/proc/self/exe", ec);
+    return ec ? std::string() : self.filename().string();
 }
 
 // ddtSchemes.default as written in system/fvSchemes, "" if the case has no readable ddtSchemes block.
@@ -87,6 +101,14 @@ inline std::string braeSolverList()
 // solvers and an install runs the installed set; fall back to PATH. Never returns on success.
 [[noreturn]] inline void execSolver(const BraeSolver& s, int argc, char** argv, const std::string& why)
 {
+    // One hand-over per run. If the exec'd solver dispatches again we are in a loop (a renamed binary, or a
+    // registry row pointing at the wrong executable), so stop with something readable instead of forking forever.
+    if (const char* from = std::getenv("BRAE_DISPATCHED_FROM"))
+        throw std::runtime_error(
+            std::string("solver dispatch loop: already handed over from '") + from + "' and now asked for '" +
+            s.exe + "'. Check that " + s.exe + " is the binary the registry names.");
+    setenv("BRAE_DISPATCHED_FROM", s.application, 1);
+
     std::string exe = s.exe;
     std::error_code ec;
     const std::filesystem::path self = std::filesystem::read_symlink("/proc/self/exe", ec);
@@ -107,8 +129,8 @@ inline std::string braeSolverList()
         ". Build it with: cmake --build build --target " + s.exe);
 }
 
-// Route the case to its solver. Returns only when THIS executable (the steady driver) owns the case; otherwise
-// it has already exec'd the right one, or thrown because brae does not have it.
+// Route the case to its solver. Returns only when the running binary IS the chosen solver; otherwise it has
+// already exec'd the right one, or thrown because brae does not have it.
 inline void dispatchSolver(const std::string& caseDir, int argc, char** argv)
 {
     const FoamDict controlDict = readDict(caseDir + "/system/controlDict");
@@ -150,8 +172,8 @@ inline void dispatchSolver(const std::string& caseDir, int argc, char** argv)
         why = "no controlDict application, ddtSchemes.default = " + (ddt.empty() ? std::string("(none)") : ddt);
     }
 
-    if (!chosen->exe) return;                  // this executable owns it: carry on with the steady solve
-    execSolver(*chosen, argc, argv, why);      // does not return
+    if (selfExecutableName() == chosen->exe) return;   // already the right binary: solve in this process
+    execSolver(*chosen, argc, argv, why);              // does not return
 }
 
 }  // namespace brae

--- a/tests/solver_dispatch.sh
+++ b/tests/solver_dispatch.sh
@@ -58,5 +58,16 @@ fi
 mkcase "$WORK/pimple" "application     pimpleFoam;" "backward"
 check application_pimplefoam "$WORK/pimple" "controlDict application pimpleFoam -> pimpleFoam"
 
+# 6. application simpleFoam: the registry names `brae` for it, which IS the running binary, so it must solve in
+#    this process -- no hand-over, and above all no exec loop (the guard would report one).
+mkcase "$WORK/simple" "application     simpleFoam;" "steadyState"
+"$BIN" -case "$WORK/simple" > "$WORK/application_simplefoam.log" 2>&1
+if grep -qE -e "-> simpleFoam|dispatch loop" "$WORK/application_simplefoam.log"; then
+    echo "FAIL: application_simplefoam -- brae handed the steady case to another process"
+    sed -n '1,10p' "$WORK/application_simplefoam.log"; fail=1
+else
+    echo "ok:   application_simplefoam"
+fi
+
 [ "$fail" -eq 0 ] && echo "PASS: solver selection routes and refuses correctly"
 exit "$fail"


### PR DESCRIPTION
The registry had one row carrying nullptr ("this executable") and the rest carrying a binary name, so the steady solver was a special case in a table meant to make solvers uniform. Every row now names its executable, including simpleFoam -> brae, and the dispatcher works out whether it is already that binary by comparing against the running one. Adding a solver is the same one row it always should have been, and if the steady solver ever moves into its own binary, only the table changes.

Also: one hand-over per run. A second dispatch means a renamed binary or a row pointing at the wrong executable, so it stops with a readable error instead of forking forever.

release.yml prefers docs/releases/<tag>.md when it exists and falls back to --generate-notes, so a release can have notes written for people rather than a list of commit subjects. v0.3.0's are in.

solver_dispatch gains the case the refactor could have broken: `application simpleFoam` must solve in-process, with no hand-over and no loop.