### PR TITLE
Fix final output time for adaptive transient steps

### DIFF
--- a/src/applications/solvers/pimpleFoam/gpuPimpleFoam.cu
+++ b/src/applications/solvers/pimpleFoam/gpuPimpleFoam.cu
@@ -780,6 +780,7 @@ try
     // ---- transient time loop ----
     const scalar tEnd = endTime + 0.5 * deltaT;
     long timeIndex = 0;
+    scalar lastSolvedTime = startTime;
     std::string lastWritten;
     // Time drives the functionObject lifecycle; the transient loop keeps its own time-valued
     // advancement, which is a genuinely different shape from the steady solvers' iteration index and is
@@ -891,6 +892,7 @@ try
         const bool anyMotion = meshMotion.active || vclMotion.active || acmiTimeScale;
         const DeviceSimpleResidual r =
             solver.pimpleStep(deltaT, nOuter, nCorr, anyMotion ? meshUpdate : std::function<void(int)>());
+        lastSolvedTime = t;
         // OF order: the Courant number is evaluated on the flux the step just produced, and deltaT for
         // the NEXT step follows from it (CourantNo.H then setDeltaT.H, both at the top of the loop).
         if (timeControls.adjustTimeStep)
@@ -913,8 +915,8 @@ try
     }
     time.end();   // OF Time.C:790-802: a final execute() so the last step is seen, then end()
     {
-        const std::string tn = timeName(startTime + deltaT * (scalar)timeIndex);
-        if (tn != lastWritten) { writeTimeDir(tn); sampleForces(startTime + deltaT * (scalar)timeIndex); }
+        const std::string tn = timeName(lastSolvedTime);
+        if (tn != lastWritten) { writeTimeDir(tn); sampleForces(lastSolvedTime); }
     }
     return 0;
 }


### PR DESCRIPTION
With adaptive timesteps, Brae can write its final fields under a time the solver never reached. A restart using `startFrom latestTime` then treats those fields as belonging to the wrong physical time. Post-processing also receives an incorrect timestamp, and an already-written final state can appear again as a spurious later checkpoint.

For example, pitzDaily last solved at `0.000306935`, but wrote a final directory named `0.000324928`.

The cause is reconstructing final time as `startTime + deltaT * timeIndex`. Adaptive steps have different durations, and the final `deltaT` has already been selected for the next, unexecuted step.

Save the completed step time and use it for final output and force sampling. Preserve the start time when no step runs. No solver equations or convergence controls change.

Validation on A100 80 GB, CUDA 13.0, sm80:

- Passed fixed/adaptive timestep checks, scheduled/forced final writes, zero-step output, and force-sampling timestamps.
- Confirmed that an already-written final state produces no extra checkpoint.
- Passed transient-run, solver-dispatch, and help-without-visible-GPU checks.
- Exercised all 235 configured CTest entries. The patch introduced no new failures; the same eight pre-existing failures occurred on unchanged upstream and the patched build.

The pre-existing failures include missing scripts, cluster tests, numerical checks, and an absent optional agent executable.

Field comparisons were not bit-identical, but even the same upstream binary, with the same input, produced different fields across repeated runs. Velocity relative L2 difference was `3.99e-10` between unchanged-upstream runs, compared with `3.76e-10` across this patch on the same fixed-timestep case. Unordered floating-point atomic accumulation is a plausible cause of this variability; the exact cause was not isolated.

Generated with GPT-6 Astra, code reviewed by Astra and Claude Fable 5.1
