### PR TITLE
Add an AdaptiveCpp/PCUDA backend alongside CUD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,44 @@
 cmake_minimum_required(VERSION 3.24)
 
-# Target NVIDIA GB10 / Grace Blackwell (sm_121). Override with
-# -DCMAKE_CUDA_ARCHITECTURES=90 etc. on older toolkits. Phase 1 is host code in .cu
-# files (compiled by nvcc); the arch matters once kernels land in the G-phases.
-set(BRAE_DEFAULT_CUDA_ARCH 121)
-if(NOT DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES})
-    set(CMAKE_CUDA_ARCHITECTURES ${BRAE_DEFAULT_CUDA_ARCH}
-        CACHE STRING "CUDA architectures cf is built for" FORCE)
+# BRAE_BACKEND: CUDA (default, full solver) or ACPP (AdaptiveCpp/PCUDA, partial -- see BRAE_CUDA_ONLY_SOURCES
+# below for what's excluded). Must be set before project(), since it picks which languages get enabled.
+if(NOT DEFINED CACHE{BRAE_BACKEND})
+    set(BRAE_BACKEND "CUDA" CACHE STRING "Compute backend: CUDA (nvcc, full solver) or ACPP (AdaptiveCpp/SYCL, portable subset)")
+endif()
+set_property(CACHE BRAE_BACKEND PROPERTY STRINGS CUDA ACPP)
+if(NOT BRAE_BACKEND STREQUAL "CUDA" AND NOT BRAE_BACKEND STREQUAL "ACPP")
+    message(FATAL_ERROR "BRAE_BACKEND must be CUDA or ACPP, got '${BRAE_BACKEND}'")
 endif()
 
-project(brae VERSION 0.3.1 LANGUAGES CXX CUDA)
+if(BRAE_BACKEND STREQUAL "CUDA")
+    # Target NVIDIA GB10 / Grace Blackwell (sm_121). Override with
+    # -DCMAKE_CUDA_ARCHITECTURES=90 etc. on older toolkits. Phase 1 is host code in .cu
+    # files (compiled by nvcc); the arch matters once kernels land in the G-phases.
+    set(BRAE_DEFAULT_CUDA_ARCH 121)
+    if(NOT DEFINED CACHE{CMAKE_CUDA_ARCHITECTURES})
+        set(CMAKE_CUDA_ARCHITECTURES ${BRAE_DEFAULT_CUDA_ARCH}
+            CACHE STRING "CUDA architectures cf is built for" FORCE)
+    endif()
+    project(brae VERSION 0.3.1 LANGUAGES CXX CUDA)
+else()
+    # acpp/syclcc is invoked as a CXX compiler (see brae_route_target_through_acpp() below), so no CUDA toolkit needed.
+    project(brae VERSION 0.3.1 LANGUAGES CXX)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-# Per-thread default stream: makes the implicit <<<>>> stream a regular (capturable) per-thread stream, so the
-# AMG V-cycle can be recorded into a CUDA graph and replayed (kills host launch overhead). cf's GPU path is
-# single-threaded, so this is semantically identical to the legacy default stream. Applied to ALL TUs (no mixing).
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --default-stream per-thread")
+
+if(BRAE_BACKEND STREQUAL "CUDA")
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+    # Per-thread default stream: makes the implicit <<<>>> stream a regular (capturable) per-thread stream, so the
+    # AMG V-cycle can be recorded into a CUDA graph and replayed (kills host launch overhead). cf's GPU path is
+    # single-threaded, so this is semantically identical to the legacy default stream. Applied to ALL TUs (no mixing).
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --default-stream per-thread")
+    # --extended-lambda: required for pcudaParallelFor's trampoline kernel (pcuda_compat.cuh).
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --extended-lambda")
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
@@ -35,13 +54,23 @@ find_package(ZLIB REQUIRED)
 # nCells x nWallFaces; on complex geometries like motorBike the bike surface has ~40k faces -> minutes single-
 # threaded). Optional: if OpenMP is absent the #pragma omp lines are ignored and the loops run serially (no-op).
 find_package(OpenMP)
-if(OpenMP_CXX_FOUND)
+if(OpenMP_CXX_FOUND AND BRAE_BACKEND STREQUAL "CUDA")
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=-fopenmp")
 endif()
 
-# CUDAToolkit: the NVRTC runtime compiler (CUDA::nvrtc) + the driver API (CUDA::cuda_driver) for the device-resident
-# runtime-compiled boundary conditions (device_coded_bc.cu: nvrtc -> PTX -> cuModuleLoadData -> cuLaunchKernel).
-find_package(CUDAToolkit REQUIRED)
+if(BRAE_BACKEND STREQUAL "CUDA")
+    # CUDAToolkit: the NVRTC runtime compiler (CUDA::nvrtc) + the driver API (CUDA::cuda_driver) for the
+    # device-resident runtime-compiled boundary conditions (device_coded_bc.cu: nvrtc -> PTX ->
+    # cuModuleLoadData -> cuLaunchKernel). No PCUDA equivalent; excluded from the ACPP build below.
+    find_package(CUDAToolkit REQUIRED)
+else()
+    # AdaptiveCpp_DIR must point at <acpp-install>/lib/cmake/AdaptiveCpp; PCUDA needs --acpp-targets=generic.
+    if(NOT DEFINED CACHE{ACPP_EXTRA_ARGS})
+        set(ACPP_EXTRA_ARGS "--acpp-targets=generic --acpp-pcuda --acpp-pcuda-chevron-launch"
+            CACHE STRING "Arguments to pass through directly to acpp.")
+    endif()
+    find_package(AdaptiveCpp CONFIG REQUIRED)
+endif()
 
 # SCOTCH, cell-graph partitioner (the decomposePar-equivalent), matching OpenFOAM.
 find_path(SCOTCH_INCLUDE_DIR NAMES scotch.h PATH_SUFFIXES scotch REQUIRED)
@@ -62,7 +91,7 @@ list(REMOVE_DUPLICATES BRAE_HEADER_DIRS)
 # ---------------------------------------------------------------------------
 # brae_core, Phase 1 substrate (comm seam + interfaces). Grows as modules land.
 # ---------------------------------------------------------------------------
-add_library(brae_core STATIC
+set(BRAE_CORE_SOURCES
     src/parallel/pstream/cf_pstream.cu
     src/parallel/pstream/device_halo.cu
     src/parallel/pstream/device_reduce.cu
@@ -100,7 +129,6 @@ add_library(brae_core STATIC
     src/cuda/device_smagorinsky.cu
     src/cuda/device_deshybrid.cu
     src/cuda/device_generalized_newtonian.cu
-    src/cuda/device_coded_bc.cu
     src/cuda/device_energy.cu
     src/thermophysicalModels/device_thermo.cu
     src/finiteVolume/cfdTools/MRF/device_mrf.cu
@@ -113,15 +141,32 @@ add_library(brae_core STATIC
     src/cuda/device_amg_gauss_seidel.cu
     src/cuda/device_amg_vcycle.cu
     src/cuda/device_amg_pcg.cu
-    src/cuda/device_cluster.cu
     src/cuda/device_cyclic.cu
     src/cuda/device_ami.cu
     src/applications/solvers/simpleFoam/device_simple_foam.cu
 )
+
+# No PCUDA equivalent, excluded from the ACPP build:
+#   device_coded_bc.cu   NVRTC + driver API (JIT-compiled user BC snippets)
+#   device_cluster.cu    thread-block clusters + DSM (sm_90+ only)
+set(BRAE_CUDA_ONLY_SOURCES
+    src/cuda/device_coded_bc.cu
+    src/cuda/device_cluster.cu
+)
+if(BRAE_BACKEND STREQUAL "CUDA")
+    list(APPEND BRAE_CORE_SOURCES ${BRAE_CUDA_ONLY_SOURCES})
+else()
+    list(APPEND BRAE_CORE_SOURCES src/cuda/device_coded_bc_acpp_stub.cpp)
+endif()
+
+add_library(brae_core STATIC ${BRAE_CORE_SOURCES})
 target_include_directories(brae_core PUBLIC ${BRAE_HEADER_DIRS} ${MPI_CXX_INCLUDE_DIRS} ${SCOTCH_INCLUDE_DIR})
 # Link MPI libraries directly (not the imported target) so its CXX compile flags do not
 # reach nvcc, which would reject them.
-target_link_libraries(brae_core PUBLIC ${MPI_CXX_LIBRARIES} ${SCOTCH_LIBRARY} ${SCOTCH_ERR_LIBRARY} ZLIB::ZLIB CUDA::nvrtc CUDA::cuda_driver)
+target_link_libraries(brae_core PUBLIC ${MPI_CXX_LIBRARIES} ${SCOTCH_LIBRARY} ${SCOTCH_ERR_LIBRARY} ZLIB::ZLIB)
+if(BRAE_BACKEND STREQUAL "CUDA")
+    target_link_libraries(brae_core PUBLIC CUDA::nvrtc CUDA::cuda_driver)
+endif()
 # OpenMP runtime (libgomp) linked directly, like MPI above, the imported target's CXX compile flags would reach nvcc.
 if(OpenMP_CXX_FOUND)
     target_link_libraries(brae_core PUBLIC ${OpenMP_CXX_LIBRARIES})
@@ -135,6 +180,9 @@ endif()
 # Override the location with -DNVSHMEM_HOME=... or the NVSHMEM_HOME env var.
 # ---------------------------------------------------------------------------
 option(BRAE_WITH_NVSHMEM "Build the NVSHMEM device transport for multi-GPU" ON)
+if(BRAE_BACKEND STREQUAL "ACPP")
+    set(BRAE_WITH_NVSHMEM OFF)
+endif()
 if(BRAE_WITH_NVSHMEM)
     find_path(NVSHMEM_INCLUDE_DIR NAMES nvshmem.h
         HINTS $ENV{NVSHMEM_HOME} ${NVSHMEM_HOME}
@@ -1815,6 +1863,45 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/demo/amgpcg/trace_brae.cu")
     add_executable(trace_brae demo/amgpcg/trace_brae.cu)
     target_include_directories(trace_brae PRIVATE ${BRAE_HEADER_DIRS})
     target_link_libraries(trace_brae PRIVATE brae_core)
+endif()
+
+# ---------------------------------------------------------------------------
+# ACPP backend routing: retrofit every .cu-source target (LANGUAGE -> CXX + AdaptiveCpp's compiler-launch rule).
+# Test targets aren't ACPP-audited -- build a specific target (`--target brae`), not `all`.
+# ---------------------------------------------------------------------------
+if(BRAE_BACKEND STREQUAL "ACPP")
+    function(brae_route_target_through_acpp _target)
+        get_target_property(_srcs ${_target} SOURCES)
+        if(NOT _srcs)
+            return()
+        endif()
+        set(_has_cuda_src FALSE)
+        foreach(_src ${_srcs})
+            if(_src MATCHES "\\.cuh?$")
+                set(_has_cuda_src TRUE)
+                set_source_files_properties("${_src}" PROPERTIES LANGUAGE CXX)
+            endif()
+        endforeach()
+        if(_has_cuda_src)
+            set_target_properties(${_target} PROPERTIES
+                RULE_LAUNCH_COMPILE "${ACPP_COMPILER_LAUNCH_RULE}"
+                RULE_LAUNCH_LINK    "${ACPP_COMPILER_LAUNCH_RULE}")
+            target_link_libraries(${_target} PRIVATE AdaptiveCpp::acpp-rt)
+            target_compile_definitions(${_target} PRIVATE BRAE_ACPP)
+            # Force-includes acpp_pcuda_compat.cuh (cuda_runtime.h + the nvcc-isms PCUDA doesn't predefine).
+            # One -include, not two -- CMake's Makefile generator collapses a second one into the first.
+            target_compile_options(${_target} PRIVATE
+                -include "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/acpp_pcuda_compat.cuh")
+        endif()
+    endfunction()
+
+    get_property(_brae_all_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
+    foreach(_t ${_brae_all_targets})
+        get_target_property(_t_type ${_t} TYPE)
+        if(_t_type STREQUAL "EXECUTABLE" OR _t_type STREQUAL "STATIC_LIBRARY")
+            brae_route_target_through_acpp(${_t})
+        endif()
+    endforeach()
 endif()
 
 # ---- install ---------------------------------------------------------------------------------------------------

--- a/src/cuda/acpp_pcuda_compat.cuh
+++ b/src/cuda/acpp_pcuda_compat.cuh
@@ -1,0 +1,25 @@
+#pragma once
+// ACPP/PCUDA compat shim (BRAE_BACKEND=ACPP only): nvcc predefines a few things PCUDA doesn't (doc/pcuda.md
+// upstream). Force-included ahead of every .cu TU as the sole -include, so cuda_runtime.h is pulled in here.
+#include <cuda_runtime.h>
+
+#ifndef __forceinline__
+#define __forceinline__ inline   // PCUDA has no forced-inline attribute; a hint only, so this is a no-op
+#endif
+
+#ifndef cudaStreamPerThread
+// PCUDA's default stream already behaves as CUDA's per-thread default (doc/pcuda.md), so map straight to it.
+#define cudaStreamPerThread cudaStream_t{}
+#endif
+
+// Bit-reinterpret intrinsics, not in PCUDA's device library: used by the atomicCAS-based double atomicMax/Min.
+__host__ __device__ inline long long __double_as_longlong(double v)
+{
+    union { double d; long long l; } u; u.d = v; return u.l;
+}
+__host__ __device__ inline double __longlong_as_double(long long v)
+{
+    union { double d; long long l; } u; u.l = v; return u.d;
+}
+
+__host__ __device__ inline double __dmul_rn(double a, double b) { return a * b; }   // round-to-nearest-even is the only IEEE-754 mode for `*` anyway

--- a/src/cuda/amg_kernels.cuh
+++ b/src/cuda/amg_kernels.cuh
@@ -8,6 +8,7 @@
 // come from device_amg_detail.cuh (inlined per TU). The non-template single-precision K kernels stay in device_amg.cu.
 // ---------------------------------------------------------------------------------------------------------------
 #include "device_amg_detail.cuh"  // safeDiag<T>, OMEGA, and cf_types (scalar/label)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -15,7 +16,7 @@ namespace brae {
 // V-cycle / FP32 GS. T(OMEGA) and T(0) reproduce the FP64 and FP32 constants exactly, so each instantiation is
 // byte-identical to the hand-written twin it replaces.
 template <typename T>
-__global__
+__device__
 void zeroT(
     int n,
     T* x)
@@ -23,9 +24,14 @@ void zeroT(
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
     if (i < n) x[i] = T(0);
 }
+template <typename T>
+inline void zeroTLaunch(int n, T* x)
+{
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { zeroT<T>(n, x); });
+}
 // weighted-Jacobi update: x += omega*(b - Ax)/diag
 template <typename T>
-__global__
+__device__
 void smoothT(
     int n,
     const T* __restrict__ b,
@@ -37,7 +43,12 @@ void smoothT(
     if (i < n) x[i] += T(OMEGA)*(b[i]-Ax[i])/safeDiag(diag[i]);   // safeDiag: floor the (FP32) diagonal, never divide by ~0 -> no Inf/NaN preconditioner
 }
 template <typename T>
-__global__
+inline void smoothTLaunch(int n, const T* b, const T* Ax, const T* diag, T* x)
+{
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { smoothT<T>(n, b, Ax, diag, x); });
+}
+template <typename T>
+__device__
 void residualT(
     int n,
     const T* __restrict__ b,
@@ -47,10 +58,15 @@ void residualT(
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
     if (i < n) r[i] = b[i]-Ax[i];
 }
+template <typename T>
+inline void residualTLaunch(int n, const T* b, const T* Ax, T* r)
+{
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { residualT<T>(n, b, Ax, r); });
+}
 // One color of in-place Gauss-Seidel: cells in [lo,hi) share no face, so the writes never race and the
 // off-diagonal reads pick up already-swept colors -> true GS, not Jacobi. Same LDU gather as the SpMV.
 template <typename T>
-__global__
+__device__
 void gsColorT(
     int lo,
     int hi,
@@ -79,9 +95,18 @@ void gsColorT(
     }
     x[c] = (b[c] - off) / safeDiag(diag[c]);   // safeDiag: floor the (FP32) diagonal, never divide by ~0
 }
+template <typename T>
+inline void gsColorTLaunch(int lo, int hi, const label* cells, const T* b, const T* diag,
+    const label* ownerStart, const label* nei, const T* upper,
+    const label* losortStart, const label* losort, const label* owner, const T* lower, T* x)
+{
+    const int n = hi - lo;
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        gsColorT<T>(lo, hi, cells, b, diag, ownerStart, nei, upper, losortStart, losort, owner, lower, x); });
+}
 
 template <typename T>
-__global__
+__device__
 void restrictT(
     int nF,
     const label* __restrict__ map,
@@ -92,7 +117,12 @@ void restrictT(
     if (c < nF) atomicAdd(&rc[map[c]], r[c]);
 }
 template <typename T>
-__global__
+inline void restrictTLaunch(int nF, const label* map, const T* r, T* rc)
+{
+    pcudaParallelFor(nBlocks(nF), TPB, [=] __device__ () { restrictT<T>(nF, map, r, rc); });
+}
+template <typename T>
+__device__
 void prolongT(
     int nF,
     const label* __restrict__ map,
@@ -101,6 +131,11 @@ void prolongT(
 {
     const int c = blockIdx.x*blockDim.x + threadIdx.x;
     if (c < nF) x[c] += xc[map[c]];   // injection correction
+}
+template <typename T>
+inline void prolongTLaunch(int nF, const label* map, const T* xc, T* x)
+{
+    pcudaParallelFor(nBlocks(nF), TPB, [=] __device__ () { prolongT<T>(nF, map, xc, x); });
 }
 
 } // namespace brae

--- a/src/cuda/blas1.cu
+++ b/src/cuda/blas1.cu
@@ -2,6 +2,7 @@
 // (coefficient by pointer, no host sync), the single-thread scalar-recurrence ops, and the FUSED multi-term Krylov
 // updates (one pass, bit-identical FP sequence). Split from device_blas.cu (reductions in reductions.cu).
 #include "device_blas.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -11,7 +12,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void axpyKernel(scalar a, const scalar* __restrict__ x, scalar* __restrict__ y, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -19,7 +20,7 @@ void axpyKernel(scalar a, const scalar* __restrict__ x, scalar* __restrict__ y, 
 }
 
 
-__global__
+__device__
 void scaleKernel(scalar a, scalar* __restrict__ x, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -27,7 +28,7 @@ void scaleKernel(scalar a, scalar* __restrict__ x, int n)
 }
 
 
-__global__
+__device__
 void jacobiKernel(const scalar* __restrict__ r, const scalar* __restrict__ diag, scalar* __restrict__ z, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -35,7 +36,7 @@ void jacobiKernel(const scalar* __restrict__ r, const scalar* __restrict__ diag,
 }
 
 
-__global__
+__device__
 void hadamardKernel(const scalar* __restrict__ a, const scalar* __restrict__ b, scalar* __restrict__ out, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -44,7 +45,7 @@ void hadamardKernel(const scalar* __restrict__ a, const scalar* __restrict__ b, 
 
 
 // device-resident-scalar variants: the coefficient lives in device memory (read by pointer), never on the host.
-__global__
+__device__
 void axpyDevKernel(const scalar* __restrict__ a, const scalar* __restrict__ x, scalar* __restrict__ y, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -52,7 +53,7 @@ void axpyDevKernel(const scalar* __restrict__ a, const scalar* __restrict__ x, s
 }
 
 
-__global__
+__device__
 void scaleDevKernel(const scalar* __restrict__ a, scalar* __restrict__ x, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -61,7 +62,7 @@ void scaleDevKernel(const scalar* __restrict__ a, scalar* __restrict__ x, int n)
 
 
 // single-thread scalar recurrence ops (cheap launch, NO host sync, same IEEE double op as the host did).
-__global__
+__device__
 void scalarDivK(const scalar* num, const scalar* den, scalar* out)
 {
     // Guard the pressure-PCG divide (den = pAp / wArAold): a near-zero/breakdown denominator yields 0 (no update this
@@ -70,28 +71,28 @@ void scalarDivK(const scalar* num, const scalar* den, scalar* out)
 }
 
 
-__global__
+__device__
 void scalarDivNegK(const scalar* num, const scalar* den, scalar* out, scalar* outNeg)
 {
     if (threadIdx.x == 0 && blockIdx.x == 0) { const scalar d = *den; const scalar q = (fabs(d) > scalar(1e-300)) ? (*num) / d : scalar(0); *out = q; *outNeg = -q; }
 }
 
 
-__global__
+__device__
 void scalarCopyK(const scalar* src, scalar* dst)
 {
     if (threadIdx.x == 0 && blockIdx.x == 0) *dst = *src;
 }
 
 
-__global__
+__device__
 void scalarDivConstK(const scalar* num, scalar denom, scalar* out)
 {
     if (threadIdx.x == 0 && blockIdx.x == 0) *out = (*num) / denom;
 }
 
 
-__global__
+__device__
 void scalarAdd2K(const scalar* a, const scalar* b, scalar c, scalar* out)
 {
     if (threadIdx.x == 0 && blockIdx.x == 0) *out = (*a) + (*b) + c;   // matches host (a+b)+c associativity
@@ -102,7 +103,7 @@ void scalarAdd2K(const scalar* a, const scalar* b, scalar c, scalar* out)
 // sequence of the separate kernels it replaces (fma() where axpy/axpyDev contract under --fmad=true; __dmul_rn for a
 // scale so a new mul+add does NOT contract) -> BIT-IDENTICAL, not just machine-precision. Device-scalar coeffs by ptr.
 // pA = rA + beta*(pA - omega*AyA)   [replaces axpyDev(negOmega,AyA,pA) + scaleDev(beta,pA) + axpy(1,rA,pA)]
-__global__
+__device__
 void fusedBicgPK(
     const scalar* __restrict__ rA,
     scalar* __restrict__ pA,
@@ -120,7 +121,7 @@ void fusedBicgPK(
 
 
 // out = src + a*x   [replaces copy(src->out) + axpyDev(a,x,out)]
-__global__
+__device__
 void fusedSxpyK(
     scalar* __restrict__ out,
     const scalar* __restrict__ src,
@@ -134,7 +135,7 @@ void fusedSxpyK(
 
 
 // y += a*x1 + b*x2   [replaces axpyDev(a,x1,y) + axpyDev(b,x2,y)]
-__global__
+__device__
 void fusedAxpy2K(
     scalar* __restrict__ y,
     const scalar* __restrict__ a,
@@ -152,7 +153,7 @@ void fusedAxpy2K(
 
 
 // p = b*p + w   [replaces scaleDev(b,p) + axpy(1,w,p)]
-__global__
+__device__
 void fusedScaleAxpyK(scalar* __restrict__ p, const scalar* __restrict__ b, const scalar* __restrict__ w, int n)
 {
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
@@ -164,7 +165,9 @@ void fusedScaleAxpyK(scalar* __restrict__ p, const scalar* __restrict__ b, const
 void deviceAxpy(scalar a, const DeviceBuffer<scalar>& x, DeviceBuffer<scalar>& y)
 {
     const int n = static_cast<int>(x.size());
-    axpyKernel<<<nBlocks(n), TPB>>>(a, x.data(), y.data(), n);
+    const scalar* xd = x.data();
+    scalar* yd = y.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { axpyKernel(a, xd, yd, n); });
     cudaCheck(cudaGetLastError(), "axpy");
 }
 
@@ -172,7 +175,8 @@ void deviceAxpy(scalar a, const DeviceBuffer<scalar>& x, DeviceBuffer<scalar>& y
 void deviceScale(DeviceBuffer<scalar>& x, scalar a)
 {
     const int n = static_cast<int>(x.size());
-    scaleKernel<<<nBlocks(n), TPB>>>(a, x.data(), n);
+    scalar* xd = x.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { scaleKernel(a, xd, n); });
     cudaCheck(cudaGetLastError(), "scale");
 }
 
@@ -192,7 +196,9 @@ void deviceJacobi(DeviceBuffer<scalar>& z, const DeviceBuffer<scalar>& r, const 
 {
     const int n = static_cast<int>(r.size());
     z.resize(n);
-    jacobiKernel<<<nBlocks(n), TPB>>>(r.data(), diag, z.data(), n);
+    const scalar* rd = r.data();
+    scalar* zd = z.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { jacobiKernel(rd, diag, zd, n); });
     cudaCheck(cudaGetLastError(), "jacobi");
 }
 
@@ -200,7 +206,7 @@ void deviceJacobi(DeviceBuffer<scalar>& z, const DeviceBuffer<scalar>& r, const 
 // out = a ./ b. A zero denominator yields zero rather than a NaN: the only caller is the transonic
 // pressure equation, where a face with rho_f = 0 has no flux to carry anyway, and a NaN there would
 // propagate silently into the whole matrix.
-__global__
+__device__
 void divideKernel(const scalar* __restrict__ a, const scalar* __restrict__ b, scalar* __restrict__ out, int n)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -213,7 +219,10 @@ void deviceDivide(DeviceBuffer<scalar>& out, const DeviceBuffer<scalar>& a, cons
 {
     const int n = static_cast<int>(a.size());
     out.resize(n);
-    divideKernel<<<nBlocks(n), TPB>>>(a.data(), b.data(), out.data(), n);
+    const scalar* ad = a.data();
+    const scalar* bd = b.data();
+    scalar* od = out.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { divideKernel(ad, bd, od, n); });
     cudaCheck(cudaGetLastError(), "divide");
 }
 
@@ -222,7 +231,10 @@ void deviceHadamard(DeviceBuffer<scalar>& out, const DeviceBuffer<scalar>& a, co
 {
     const int n = static_cast<int>(a.size());
     out.resize(n);
-    hadamardKernel<<<nBlocks(n), TPB>>>(a.data(), b.data(), out.data(), n);
+    const scalar* ad = a.data();
+    const scalar* bd = b.data();
+    scalar* od = out.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { hadamardKernel(ad, bd, od, n); });
     cudaCheck(cudaGetLastError(), "hadamard");
 }
 
@@ -236,7 +248,10 @@ void deviceFusedBicgP(
     const scalar* negOmega)
 {
     const int n = static_cast<int>(pA.size());
-    fusedBicgPK<<<nBlocks(n), TPB>>>(rA.data(), pA.data(), AyA.data(), beta, negOmega, n);
+    const scalar* rAd = rA.data();
+    scalar* pAd = pA.data();
+    const scalar* AyAd = AyA.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fusedBicgPK(rAd, pAd, AyAd, beta, negOmega, n); });
     cudaCheck(cudaGetLastError(), "fusedBicgP");
 }
 
@@ -245,7 +260,10 @@ void deviceFusedSxpy(DeviceBuffer<scalar>& out, const DeviceBuffer<scalar>& src,
 {
     const int n = static_cast<int>(src.size());
     out.resize(n);
-    fusedSxpyK<<<nBlocks(n), TPB>>>(out.data(), src.data(), a, x.data(), n);
+    scalar* outd = out.data();
+    const scalar* srcd = src.data();
+    const scalar* xd = x.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fusedSxpyK(outd, srcd, a, xd, n); });
     cudaCheck(cudaGetLastError(), "fusedSxpy");
 }
 
@@ -253,7 +271,10 @@ void deviceFusedSxpy(DeviceBuffer<scalar>& out, const DeviceBuffer<scalar>& src,
 void deviceFusedAxpy2(DeviceBuffer<scalar>& y, const scalar* a, const DeviceBuffer<scalar>& x1, const scalar* b, const DeviceBuffer<scalar>& x2)
 {
     const int n = static_cast<int>(y.size());
-    fusedAxpy2K<<<nBlocks(n), TPB>>>(y.data(), a, x1.data(), b, x2.data(), n);
+    scalar* yd = y.data();
+    const scalar* x1d = x1.data();
+    const scalar* x2d = x2.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fusedAxpy2K(yd, a, x1d, b, x2d, n); });
     cudaCheck(cudaGetLastError(), "fusedAxpy2");
 }
 
@@ -261,7 +282,9 @@ void deviceFusedAxpy2(DeviceBuffer<scalar>& y, const scalar* a, const DeviceBuff
 void deviceFusedScaleAxpy(DeviceBuffer<scalar>& p, const scalar* b, const DeviceBuffer<scalar>& w)
 {
     const int n = static_cast<int>(p.size());
-    fusedScaleAxpyK<<<nBlocks(n), TPB>>>(p.data(), b, w.data(), n);
+    scalar* pd = p.data();
+    const scalar* wd = w.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fusedScaleAxpyK(pd, b, wd, n); });
     cudaCheck(cudaGetLastError(), "fusedScaleAxpy");
 }
 
@@ -269,7 +292,9 @@ void deviceFusedScaleAxpy(DeviceBuffer<scalar>& p, const scalar* b, const Device
 void deviceAxpyDev(const scalar* dA, const DeviceBuffer<scalar>& x, DeviceBuffer<scalar>& y)
 {
     const int n = static_cast<int>(x.size());
-    axpyDevKernel<<<nBlocks(n), TPB>>>(dA, x.data(), y.data(), n);
+    const scalar* xd = x.data();
+    scalar* yd = y.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { axpyDevKernel(dA, xd, yd, n); });
     cudaCheck(cudaGetLastError(), "axpyDev");
 }
 
@@ -277,42 +302,43 @@ void deviceAxpyDev(const scalar* dA, const DeviceBuffer<scalar>& x, DeviceBuffer
 void deviceScaleDev(const scalar* dA, DeviceBuffer<scalar>& x)
 {
     const int n = static_cast<int>(x.size());
-    scaleDevKernel<<<nBlocks(n), TPB>>>(dA, x.data(), n);
+    scalar* xd = x.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { scaleDevKernel(dA, xd, n); });
     cudaCheck(cudaGetLastError(), "scaleDev");
 }
 
 
 void deviceScalarDiv(const scalar* num, const scalar* den, scalar* out)
 {
-    scalarDivK<<<1, 1>>>(num, den, out);
+    pcudaParallelFor(1, 1, [=] __device__ () { scalarDivK(num, den, out); });
     cudaCheck(cudaGetLastError(), "scalarDiv");
 }
 
 
 void deviceScalarDivNeg(const scalar* num, const scalar* den, scalar* out, scalar* outNeg)
 {
-    scalarDivNegK<<<1, 1>>>(num, den, out, outNeg);
+    pcudaParallelFor(1, 1, [=] __device__ () { scalarDivNegK(num, den, out, outNeg); });
     cudaCheck(cudaGetLastError(), "scalarDivNeg");
 }
 
 
 void deviceScalarCopy(const scalar* src, scalar* dst)
 {
-    scalarCopyK<<<1, 1>>>(src, dst);
+    pcudaParallelFor(1, 1, [=] __device__ () { scalarCopyK(src, dst); });
     cudaCheck(cudaGetLastError(), "scalarCopy");
 }
 
 
 void deviceScalarDivConst(const scalar* num, scalar denom, scalar* out)
 {
-    scalarDivConstK<<<1, 1>>>(num, denom, out);
+    pcudaParallelFor(1, 1, [=] __device__ () { scalarDivConstK(num, denom, out); });
     cudaCheck(cudaGetLastError(), "scalarDivConst");
 }
 
 
 void deviceScalarAdd2(const scalar* a, const scalar* b, scalar c, scalar* out)
 {
-    scalarAdd2K<<<1, 1>>>(a, b, c, out);
+    pcudaParallelFor(1, 1, [=] __device__ () { scalarAdd2K(a, b, c, out); });
     cudaCheck(cudaGetLastError(), "scalarAdd2");
 }
 

--- a/src/cuda/device_amg.cu
+++ b/src/cuda/device_amg.cu
@@ -9,7 +9,9 @@
 #include "amg_kernels.cuh"        // mixed-precision V-cycle template kernels (zeroT/smoothT/residualT/gsColorT/restrictT/prolongT)
 #include "device_amg_internal.cuh"// shared AMG-core infra: LduF/lduF/cast_ (FP32 stack), Coloring/greedyColor/gsSweep, gsScaleInvK
 #include <cuda_runtime.h>
-#include <cooperative_groups.h>
+#ifndef BRAE_ACPP
+#include <cooperative_groups.h>   // unused in this file (no cg:: calls) but kept for the CUDA build as-is
+#endif
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
@@ -21,7 +23,9 @@
 #include <vector>
 #include <mutex>
 
+#ifndef BRAE_ACPP
 namespace cg = cooperative_groups;
+#endif
 
 namespace brae {
 
@@ -32,20 +36,24 @@ void amgCastFP32(AMGData& amg, const DeviceLduView& A);
 
 AMGGraphCache::~AMGGraphCache()
 {
+#ifndef BRAE_ACPP
     if (exec) cudaGraphExecDestroy(exec);
     if (graph) cudaGraphDestroy(graph);
+#endif
 }
 
 PCGGraphCache::~PCGGraphCache()
 {
+#ifndef BRAE_ACPP
     if (exec) cudaGraphExecDestroy(exec);
     if (graph) cudaGraphDestroy(graph);
+#endif
 }
 
 namespace {
 // General Galerkin RAP scatter (BRAE_AMG_SA): A_c[dst] += w * A_fine[src] over a precomputed triple list.
 // srcKind/dstKind: 0=diag 1=upper 2=lower. One thread per triple into the zeroed coarse LDU; the SA twin of galDiagK/galFaceK.
-__global__
+__device__
 void rapScatterK(
     int nT,
     const label* __restrict__ srcKind,
@@ -71,7 +79,7 @@ void rapScatterK(
     else atomicAdd(&cLo[di], v);
 }
 // Injection Galerkin scatter (default path): coarse LDU from fine diag/upper/lower via faceRestrict/faceFlip.
-__global__
+__device__
 void galDiagK(
     int nF,
     const label* __restrict__ map,
@@ -81,7 +89,7 @@ void galDiagK(
     const int c = blockIdx.x*blockDim.x + threadIdx.x;
     if (c < nF) atomicAdd(&cDiag[map[c]], fineDiag[c]);
 }
-__global__
+__device__
 void galFaceK(
     int nFaces,
     const label* __restrict__ fr,
@@ -917,17 +925,31 @@ void amgGalerkin(
             fl = A.level[k-1].cLower.data();
             nFaces = A.level[k-1].nCoarseFaces;
         }
-        zeroT<scalar><<<nBlocks(L.nCoarse),TPB>>>(L.nCoarse, L.cDiag.data());
-        zeroT<scalar><<<nBlocks(L.nCoarseFaces),TPB>>>(L.nCoarseFaces, L.cUpper.data());
-        zeroT<scalar><<<nBlocks(L.nCoarseFaces),TPB>>>(L.nCoarseFaces, L.cLower.data());
+        zeroTLaunch<scalar>(L.nCoarse, L.cDiag.data());
+        zeroTLaunch<scalar>(L.nCoarseFaces, L.cUpper.data());
+        zeroTLaunch<scalar>(L.nCoarseFaces, L.cLower.data());
         if (A.saSmooth)                                          // general Galerkin A_c = P^T A P (precomputed RAP recipe)
-            rapScatterK<<<nBlocks(L.nTriples),TPB>>>(L.nTriples, L.rapSrcKind.data(), L.rapSrcIdx.data(), L.rapW.data(),
-                L.rapDstKind.data(), L.rapDstIdx.data(), fd, fu, fl, L.cDiag.data(), L.cUpper.data(), L.cLower.data());
+        {
+            const int nT = L.nTriples;
+            const label* srcKind = L.rapSrcKind.data(); const label* srcIdx = L.rapSrcIdx.data();
+            const scalar* w = L.rapW.data();
+            const label* dstKind = L.rapDstKind.data(); const label* dstIdx = L.rapDstIdx.data();
+            scalar* cDiag = L.cDiag.data(); scalar* cUp = L.cUpper.data(); scalar* cLo = L.cLower.data();
+            pcudaParallelFor(nBlocks(nT), TPB, [=] __device__ () {
+                rapScatterK(nT, srcKind, srcIdx, w, dstKind, dstIdx, fd, fu, fl, cDiag, cUp, cLo); });
+        }
         else                                                  // injection Galerkin (default): face-restrict scatter
         {
-            galDiagK<<<nBlocks(L.nFine),TPB>>>(L.nFine, L.map.data(), fd, L.cDiag.data());
-            galFaceK<<<nBlocks(nFaces),TPB>>>(nFaces, L.faceRestrict.data(), L.faceFlip.data(), fu, fl,
-                                              L.cDiag.data(), L.cUpper.data(), L.cLower.data());
+            {
+                const int nF = L.nFine; const label* map = L.map.data(); scalar* cDiag = L.cDiag.data();
+                pcudaParallelFor(nBlocks(nF), TPB, [=] __device__ () { galDiagK(nF, map, fd, cDiag); });
+            }
+            {
+                const label* fr = L.faceRestrict.data(); const label* flip = L.faceFlip.data();
+                scalar* cDiag = L.cDiag.data(); scalar* cUp = L.cUpper.data(); scalar* cLo = L.cLower.data();
+                pcudaParallelFor(nBlocks(nFaces), TPB, [=] __device__ () {
+                    galFaceK(nFaces, fr, flip, fu, fl, cDiag, cUp, cLo); });
+            }
         }
     }
     cudaCheck(cudaGetLastError(), "galerkin");

--- a/src/cuda/device_amg.cuh
+++ b/src/cuda/device_amg.cuh
@@ -18,7 +18,11 @@ namespace brae {
 // Cached CUDA graph of the V-cycle: captured once and replayed across solves while the fine-matrix buffer
 // pointer (key) is unchanged. Owned via unique_ptr so AMGData stays movable and the graph is freed on destruct.
 struct AMGGraphCache {
+#ifndef BRAE_ACPP
+    // See the matching guard in device_pcg.cuh's BiCGGraphCache: no PCUDA/SYCL graph-replay equivalent, and
+    // the only code touching these fields is excluded from the ACPP build.
     cudaGraphExec_t exec = nullptr; cudaGraph_t graph = nullptr; const void* key = nullptr;
+#endif
     ~AMGGraphCache();
 };
 
@@ -27,8 +31,12 @@ struct AMGGraphCache {
 // later solver whose pressure buffer lands at the recycled address would hit the stale entry and replay a graph
 // baked against freed buffers (illegal memory access). Holds the graph-referenced persistent work buffers.
 struct PCGGraphCache {
+#ifndef BRAE_ACPP
+    // See the matching guard in device_pcg.cuh's BiCGGraphCache: no PCUDA/SYCL graph-replay equivalent, and
+    // the only code touching these fields is excluded from the ACPP build.
     cudaGraphExec_t exec = nullptr; cudaGraph_t graph = nullptr;
     cudaGraphConditionalHandle handle{}; const void* key = nullptr;
+#endif
     // tol/relTol/maxIter are baked into the captured pcgSetCondK node, so they are part of the
     // cache identity: replaying with a changed convergence control would silently keep the stale
     // bound. They stay constant per field in the SIMPLE loop (no extra re-capture there), so

--- a/src/cuda/device_amg_coarse.cu
+++ b/src/cuda/device_amg_coarse.cu
@@ -9,19 +9,25 @@
 #include "device_amg_coarse.cuh"   // deviceCoarsePCG/JacobiSingleBlock internal decls (match defs here)
 #include "device_ldu.cuh"
 #include <cuda_runtime.h>
+#ifndef BRAE_ACPP
 #include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#endif
 #include <mutex>
 #include <cstddef>
-
-namespace cg = cooperative_groups;
+#include <cstdlib>
 
 namespace brae {
 
 namespace {
+#ifndef BRAE_ACPP
 // All nSweeps of coarse weighted-Jacobi in ONE cluster kernel. The coarse vector is held in distributed shared
 // memory: block 'rank' owns cells [rank*cpb, rank*cpb+myCount); a cell's SpMV reads neighbour values from the
 // owning sibling block via cluster.map_shared_rank. Ping-pong (rd/wr) gives proper Jacobi (all-old-x per sweep);
 // cluster.sync() between sweeps makes every block's update visible. Same arithmetic/order as deviceAmul+smoothK.
+//
+// Excluded from the ACPP build: thread-block clusters + DSM are Hopper/Blackwell-only, no PCUDA equivalent.
+// deviceCoarseFitsCluster() always returns false under ACPP, so vcycleAt never dispatches here.
 __global__
 void coarseJacobiFusedKernel(
     int nC,
@@ -87,11 +93,12 @@ void coarseJacobiFusedKernel(
         xc[base + i] = rd[i];
 #endif
 }
+#endif // !BRAE_ACPP
 
 // SINGLE-BLOCK coarsest Jacobi: the whole (tiny) coarse vector lives in shared memory, nSweeps of ping-pong Jacobi
 // with cheap __syncthreads() between them (NOT cluster.sync, the latter's per-sweep cost dominates at the high
 // sweep counts a well-solved coarsest needs). Same arithmetic as deviceAmul+smoothK. Used for nC <= SB_MAX.
-__global__
+__device__
 void coarseJacobiSingleBlockKernel(
     int nC,
     int nSweeps,
@@ -140,7 +147,7 @@ void coarseJacobiSingleBlockKernel(
 // O(kappa), so a handful of iterations solve the tiny coarsest as well as hundreds of Jacobi sweeps. The whole CG
 // (vectors + dot reductions) lives in shared memory in one block -> no host sync, capturable in the V-cycle graph.
 // Fixed iteration count (deterministic, graph-safe); alpha/beta guarded so an early-converged solve can't NaN.
-__global__
+__device__
 void coarsePCGKernel(
     int nC,
     int nIters,
@@ -210,6 +217,10 @@ void coarsePCGKernel(
 
 bool deviceCoarseFitsCluster(int nCoarse)
 {
+#ifdef BRAE_ACPP
+    (void)nCoarse;
+    return false;   // no thread-block-cluster support under ACPP (see the Phase 0 portability audit)
+#else
     static const bool clusterOK = []()
     {
         int v = 0, dev = 0;
@@ -220,8 +231,17 @@ bool deviceCoarseFitsCluster(int nCoarse)
     if (!clusterOK) return false;                                            // pre-Hopper: no cluster launch -> global-mem Jacobi fallback
     const int cpb = (nCoarse + CCL - 1) / CCL;
     return 2 * static_cast<std::size_t>(cpb) * sizeof(scalar) <= 99 * 1024;   // GB10 opt-in DSM/block
+#endif
 }
 
+#ifdef BRAE_ACPP
+void deviceCoarseJacobiFused(const DeviceLduView&, const DeviceBuffer<scalar>&, DeviceBuffer<scalar>&, int)
+{
+    // Unreachable under ACPP: deviceCoarseFitsCluster() always returns false above, so vcycleAt's dispatch
+    // never calls this. Exists only to satisfy the linker (see the BRAE_ACPP guard on coarseJacobiFusedKernel).
+    std::abort();
+}
+#else
 void deviceCoarseJacobiFused(
     const DeviceLduView& cv,
     const DeviceBuffer<scalar>& rc,
@@ -256,6 +276,7 @@ void deviceCoarseJacobiFused(
         "coarseJacobiFused");
     cudaCheck(cudaGetLastError(), "coarseJacobiFused launch");
 }
+#endif // !BRAE_ACPP
 
 // Single-block coarsest solve (nC <= SB_MAX): nSweeps of in-shared-memory ping-pong Jacobi, cheap __syncthreads.
 void deviceCoarseJacobiSingleBlock(
@@ -266,8 +287,16 @@ void deviceCoarseJacobiSingleBlock(
 {
     const int nC = cv.nCells;
     const std::size_t shBytes = 2 * static_cast<std::size_t>(nC) * sizeof(scalar);
-    coarseJacobiSingleBlockKernel<<<1, TPB, shBytes, cudaStreamPerThread>>>(nC, nSweeps, OMEGA,
-        rc.data(), cv.diag, cv.ownerStart, cv.nei, cv.upper, cv.losortStart, cv.losort, cv.owner, cv.lower, xc.data());
+    {
+        const int nSw = nSweeps; const scalar omega = OMEGA;
+        const scalar* rcd = rc.data(); const scalar* diag = cv.diag;
+        const label* ownerStart = cv.ownerStart; const label* nei = cv.nei; const scalar* upper = cv.upper;
+        const label* losortStart = cv.losortStart; const label* losort = cv.losort; const label* owner = cv.owner;
+        const scalar* lower = cv.lower; scalar* xcd = xc.data();
+        pcudaParallelFor(dim3(1), dim3(TPB), shBytes, cudaStreamPerThread, [=] __device__ () {
+            coarseJacobiSingleBlockKernel(nC, nSw, omega, rcd, diag, ownerStart, nei, upper,
+                                           losortStart, losort, owner, lower, xcd); });
+    }
     cudaCheck(cudaGetLastError(), "coarseJacobiSingleBlock launch");
 }
 
@@ -282,9 +311,22 @@ void deviceCoarsePCG(
 {
     const int nC = cv.nCells;
     const int bs = nC >= TPB ? TPB : ((nC + 31) / 32) * 32;     // warp-rounded, in [32, TPB]
+#ifdef BRAE_ACPP
+    // ACPP's blockDot (device_amg_detail.cuh) reduces across the WHOLE block via red[], not per-warp (no
+    // warp-shuffle under PCUDA), so it needs bs slots, not just bs/32.
+    const std::size_t shBytes = (5 * static_cast<std::size_t>(nC) + static_cast<std::size_t>(bs)) * sizeof(scalar);
+#else
     const std::size_t shBytes = (5 * static_cast<std::size_t>(nC) + 32) * sizeof(scalar);   // red[] needs <= bs/32 slots
-    coarsePCGKernel<<<1, bs, shBytes, cudaStreamPerThread>>>(nC, nIters,
-        rc.data(), cv.diag, cv.ownerStart, cv.nei, cv.upper, cv.losortStart, cv.losort, cv.owner, cv.lower, xc.data());
+#endif
+    {
+        const int nIt = nIters;
+        const scalar* rcd = rc.data(); const scalar* diag = cv.diag;
+        const label* ownerStart = cv.ownerStart; const label* nei = cv.nei; const scalar* upper = cv.upper;
+        const label* losortStart = cv.losortStart; const label* losort = cv.losort; const label* owner = cv.owner;
+        const scalar* lower = cv.lower; scalar* xcd = xc.data();
+        pcudaParallelFor(dim3(1), dim3(bs), shBytes, cudaStreamPerThread, [=] __device__ () {
+            coarsePCGKernel(nC, nIt, rcd, diag, ownerStart, nei, upper, losortStart, losort, owner, lower, xcd); });
+    }
     cudaCheck(cudaGetLastError(), "coarsePCG launch");
 }
 
@@ -302,7 +344,7 @@ void deviceCoarseJacobiLoop(
     for (int s = 0; s < nSweeps; ++s)
     {
         deviceAmul(cv, xc, Axc);
-        smoothT<scalar><<<nBlocks(nC),TPB>>>(nC, rc.data(), Axc.data(), cv.diag, xc.data());
+        smoothTLaunch<scalar>(nC, rc.data(), Axc.data(), cv.diag, xc.data());
     }
 }
 

--- a/src/cuda/device_amg_detail.cuh
+++ b/src/cuda/device_amg_detail.cuh
@@ -125,6 +125,37 @@ T safeDiag(T d)
 // Block-wide dot product a.b, warp-shuffle reduce: each warp reduces its lanes with __shfl_down (no barrier), then
 // warp 0 reduces the per-warp partials. Three barriers per dot instead of ~log2(blockDim), which matters because the
 // single-block coarsest CG runs many sequential dots on one SM. red[] holds the per-warp partials; all threads return the sum.
+#ifdef BRAE_ACPP
+// PCUDA has no warp-shuffle, so this is a shared-memory tree reduction across the whole block instead;
+// red[] needs blockDim.x scalars (deviceCoarsePCG sizes it accordingly), reduced from the next power of two.
+//
+// NOTE: this changes FP summation order vs the CUDA path -- both valid IEEE sums, not bit-identical.
+static __device__
+scalar blockDot(
+    const scalar* a,
+    const scalar* b,
+    int n,
+    scalar* red)
+{
+    const int tid = threadIdx.x;
+    scalar v = 0.0;
+    for (int i = tid; i < n; i += blockDim.x)
+        v += a[i]*b[i];
+    red[tid] = v;
+    __syncthreads();
+    int s = 1;
+    while (s < (int)blockDim.x) s <<= 1;
+    s >>= 1;
+    for (; s > 0; s >>= 1)
+    {
+        if (tid < s && tid + s < (int)blockDim.x) red[tid] += red[tid + s];
+        __syncthreads();
+    }
+    const scalar r = red[0];
+    __syncthreads();
+    return r;
+}
+#else
 static __device__ __forceinline__
 scalar warpReduceSum(scalar v)
 {
@@ -160,5 +191,6 @@ scalar blockDot(
     __syncthreads();                  // (3) red[] free to reuse next call
     return r;
 }
+#endif // !BRAE_ACPP
 
 } // namespace brae

--- a/src/cuda/device_amg_gauss_seidel.cu
+++ b/src/cuda/device_amg_gauss_seidel.cu
@@ -9,6 +9,7 @@
 #include "amg_kernels.cuh"         // gsColorT<> (the multicolor GS kernel)
 #include "device_ldu.cuh"          // DeviceLduView / deviceAmul
 #include "device_blas.cuh"         // deviceCopy / deviceAxpy / deviceSumMagInto
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <map>
 #include <vector>
@@ -57,7 +58,7 @@ static const GridColoring& gsColoringFor(const DeviceLduView& A)
 // epsilon get independent graph instances. normFactor is a device-resident scalar; tol/relTol/maxIter are baked in at
 // capture. WHILE nodes require CUDA >= 13; on older toolkits this path compiles out and the host loop below is used.
 #if CUDART_VERSION >= 13000
-__global__
+__device__
 void gsSetCondK(
     cudaGraphConditionalHandle h,
     const scalar* res,
@@ -126,7 +127,7 @@ static scalar deviceSymGaussSeidelGraph(
     deviceCopy(c.r, c.gsB);
     deviceAxpy(-1.0, c.Ax, c.r);
     deviceSumMagInto(c.r, c.gInit.data());
-    gsScaleInvK<<<1,1,0,cudaStreamPerThread>>>(c.gInit.data(), c.gNormF.data());     // gInit = sum|r| / normFactor
+    gsScaleInvLaunch(c.gInit.data(), c.gNormF.data(), cudaStreamPerThread);     // gInit = sum|r| / normFactor
     scalar initRes;
     cudaCheck(cudaMemcpyAsync(&initRes, c.gInit.data(), sizeof(scalar), cudaMemcpyDeviceToHost, cudaStreamPerThread), "gs init D2H");
     cudaStreamSynchronize(cudaStreamPerThread);                                       // the ONE host sync / solve (OF initialResidual)
@@ -165,8 +166,14 @@ static scalar deviceSymGaussSeidelGraph(
         deviceCopy(c.r, c.gsB);
         deviceAxpy(-1.0, c.Ax, c.r);  // r = b - A*psi
         deviceSumMagInto(c.r, c.gRes.data());
-        gsScaleInvK<<<1,1,0,cudaStreamPerThread>>>(c.gRes.data(), c.gNormF.data());      // finalRes = sum|r| / normFactor
-        gsSetCondK<<<1,1,0,cudaStreamPerThread>>>(c.handle, c.gRes.data(), tol, c.gInit.data(), relTol, c.gIter.data(), maxIter);
+        gsScaleInvLaunch(c.gRes.data(), c.gNormF.data(), cudaStreamPerThread);      // finalRes = sum|r| / normFactor
+        {
+            const cudaGraphConditionalHandle h = c.handle; const scalar* res = c.gRes.data(); const scalar tolD = tol;
+            const scalar* init = c.gInit.data(); const scalar relTolD = relTol; int* iter = c.gIter.data();
+            const int maxI = maxIter;
+            pcudaParallelFor(dim3(1), dim3(1), size_t(0), cudaStreamPerThread, [=] __device__ () {
+                gsSetCondK(h, res, tolD, init, relTolD, iter, maxI); });
+        }
         cudaGraph_t tmp;
         cudaCheck(cudaStreamEndCapture(cudaStreamPerThread, &tmp), "gs capture end");
         cudaCheck(cudaGraphInstantiate(&c.exec, c.graph, 0), "gs graph instantiate");
@@ -237,7 +244,7 @@ scalar deviceSymGaussSeidel(
             for (; iter < maxIter; ++iter)
             {
                 deviceAmul(A, psi, Ax);                                                // Ax = A psi
-                smoothT<scalar><<<nBlocks(A.nCells),TPB>>>(A.nCells, b.data(), Ax.data(), A.diag, psi.data());   // psi += w*(b-Ax)/diag
+                smoothTLaunch<scalar>(A.nCells, b.data(), Ax.data(), A.diag, psi.data());   // psi += w*(b-Ax)/diag
                 deviceAmul(A, psi, Ax);
                 deviceCopy(r, b);
                 deviceAxpy(-1.0, Ax, r);
@@ -317,7 +324,7 @@ static void gsSweepF(
         const int lo = gc.startH[col], hi = gc.startH[col+1];
         const int nc = hi - lo;
         if (nc <= 0) continue;
-        gsColorT<float><<<nBlocks(nc),TPB>>>(lo, hi, gc.cells.data(), b, A.diag, A.ownerStart, A.nei, A.upper,
+        gsColorTLaunch<float>(lo, hi, gc.cells.data(), b, A.diag, A.ownerStart, A.nei, A.upper,
                                        A.losortStart, A.losort, A.owner, A.lower, x);
     }
 }
@@ -347,20 +354,20 @@ static scalar deviceSymGaussSeidelF32(
     c.AxF.resize(nC);
     c.rF.resize(nC);
     c.rD.resize(nC);
-    cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, A.diag, c.dF.data());
+    castLaunch<scalar,float>(nC, A.diag, c.dF.data());
     if (nF > 0)
     {
-        cast_<scalar,float><<<nBlocks(nF),TPB>>>(nF, A.upper, c.uF.data());
-        cast_<scalar,float><<<nBlocks(nF),TPB>>>(nF, A.lower, c.lF.data());
+        castLaunch<scalar,float>(nF, A.upper, c.uF.data());
+        castLaunch<scalar,float>(nF, A.lower, c.lF.data());
     }
-    cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, b.data(),   c.bF.data());
-    cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, psi.data(), c.xF.data());
+    castLaunch<scalar,float>(nC, b.data(),   c.bF.data());
+    castLaunch<scalar,float>(nC, psi.data(), c.xF.data());
     const LduF sA{ c.dF.data(), c.uF.data(), c.lF.data(), A.nei, A.owner, A.ownerStart, A.losort, A.losortStart, nC, nF };
     auto residNorm = [&]() -> scalar       // r = b - A x (FP32), |r|_1 in FP64
     {
         amulF(sA, c.xF.data(), c.AxF.data());
-        residualT<float><<<nBlocks(nC),TPB>>>(nC, c.bF.data(), c.AxF.data(), c.rF.data());
-        cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, c.rF.data(), c.rD.data());
+        residualTLaunch<float>(nC, c.bF.data(), c.AxF.data(), c.rF.data());
+        castLaunch<float,scalar>(nC, c.rF.data(), c.rD.data());
         return deviceSumMag(c.rD) / normFactor;
     };
     const scalar initRes = residNorm();
@@ -377,7 +384,7 @@ static scalar deviceSymGaussSeidelF32(
         }
         if (std::getenv("BRAE_GS_DEBUG")) std::printf("    GS[fp32] init=%.4e final=%.4e iters=%d\n", initRes, finalRes, iter+1);
     }
-    cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, c.xF.data(), psi.data());         // FP32 field -> FP64
+    castLaunch<float,scalar>(nC, c.xF.data(), psi.data());         // FP32 field -> FP64
     return initRes;
 }
 

--- a/src/cuda/device_amg_internal.cuh
+++ b/src/cuda/device_amg_internal.cuh
@@ -15,6 +15,7 @@
 #include "device_ldu.cuh"     // DeviceLduView
 #include "device_buffer.cuh"  // DeviceBuffer
 #include "device_amg_detail.cuh"  // nBlocks / TPB (for the inline FP32 matvec launch)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <vector>
 
@@ -64,14 +65,24 @@ inline LduF lduF(const DeviceLduView& t, const DeviceBuffer<float>& d,
 }
 // cast_<scalar,float> = FP64->FP32 (down), cast_<float,scalar> = FP32->FP64 (up).
 template <class S, class D>
-__global__
+__device__
 void cast_(int n, const S* __restrict__ s, D* __restrict__ d)
 {
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
     if (i < n) d[i] = (D)s[i];
 }
+template <class S, class D>
+inline void castLaunch(int n, const S* s, D* d)
+{
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { cast_<S,D>(n, s, d); });
+}
+template <class S, class D>
+inline void castLaunch(int n, const S* s, D* d, cudaStream_t stream)
+{
+    pcudaParallelFor(nBlocks(n), TPB, size_t(0), stream, [=] __device__ () { cast_<S,D>(n, s, d); });
+}
 // FP32 SpMV: Apsi = A psi (shared FP64 topology + FP32 values). Used by the FP32 V-cycle and the FP32 GS solver.
-static __global__
+static __device__
 void amulFK(int nC, const float* __restrict__ diag, const float* __restrict__ upper, const float* __restrict__ lower,
            const label* __restrict__ nei, const label* __restrict__ owner, const label* __restrict__ ownerStart,
            const label* __restrict__ losort, const label* __restrict__ losortStart,
@@ -91,14 +102,22 @@ void amulFK(int nC, const float* __restrict__ diag, const float* __restrict__ up
 }
 inline void amulF(const LduF& A, const float* x, float* y)
 {
-    amulFK<<<nBlocks(A.nCells),TPB>>>(A.nCells, A.diag, A.upper, A.lower, A.nei, A.owner,
-                                      A.ownerStart, A.losort, A.losortStart, x, y);
+    const int nC = A.nCells;
+    const float* diag = A.diag; const float* upper = A.upper; const float* lower = A.lower;
+    const label* nei = A.nei; const label* owner = A.owner; const label* ownerStart = A.ownerStart;
+    const label* losort = A.losort; const label* losortStart = A.losortStart;
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        amulFK(nC, diag, upper, lower, nei, owner, ownerStart, losort, losortStart, x, y); });
 }
 // finalRes = sumMag(r) / normFactor -- residual normalisation on-device; shared by the GS solver + AMG-PCG drivers.
-static __global__
+static __device__
 void gsScaleInvK(scalar* a, const scalar* b)
 {
     if (threadIdx.x==0 && blockIdx.x==0) *a = (*a) / (*b);
+}
+inline void gsScaleInvLaunch(scalar* a, const scalar* b, cudaStream_t stream)
+{
+    pcudaParallelFor(dim3(1), dim3(1), size_t(0), stream, [=] __device__ () { gsScaleInvK(a, b); });
 }
 
 } // namespace brae

--- a/src/cuda/device_amg_pcg.cu
+++ b/src/cuda/device_amg_pcg.cu
@@ -25,10 +25,25 @@ void vcycleAt(int g, AMGData& amg, const DeviceLduView& Ag, const DeviceBuffer<s
 void vcycleAtF(int g, AMGData& amg, const DeviceLduView& topoG, const LduF& Ag, const float* bg, float* xg);
 void amgCastFP32(AMGData& amg, const DeviceLduView& A);
 
+#ifdef BRAE_ACPP
+// No CUDA-graph capture under ACPP, so applyPrecond() always takes the direct-launch path. Warn once if a
+// case actually asked for captureVcycle, so the request isn't silently dropped.
+static void warnAcppNoGraphCapture(bool requested)
+{
+    static bool warned = false;
+    if (requested && !warned)
+    {
+        warned = true;
+        std::fprintf(stderr, "brae: captureVcycle requested but unavailable in the ACPP build (no CUDA-graph "
+                              "capture); using direct per-iteration V-cycle launches instead\n");
+    }
+}
+#endif
+
 namespace {
 // Flexible-CG beta (Polak-Ribiere+): beta = max(0, (z.r_new - z.r_old)/rho_old), guarded division. Robust for the
 // nonlinear scaled V-cycle preconditioner; reduces to Fletcher-Reeves when the precond is linear (z.r_old == 0).
-__global__
+__device__
 void flexBetaK(
     const scalar* __restrict__ zrNew,
     const scalar* __restrict__ zrOld,
@@ -56,7 +71,7 @@ void flexBetaK(
 // (the V-cycle graph already keys on A.diag), so no matrix copy is needed; the graph references A, psi, amg.rA/wA and
 // the cache's persistent pA/Ax directly. Non-corrScaling only (flexible-CG falls back to the host loop); normFactor
 // is a device-resident scalar.
-__global__
+__device__
 void pcgSetCondK(
     cudaGraphConditionalHandle h,
     const scalar* res,
@@ -114,9 +129,9 @@ static DeviceSolverPerf deviceAMGPCGGraph(
     {
         if (fp32)
         {
-            cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, rA.data(), amg.vBF[0].data());
+            castLaunch<scalar,float>(nC, rA.data(), amg.vBF[0].data());
             vcycleAtF(0, amg, A, A0, amg.vBF[0].data(), amg.vXF[0].data());
-            cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, amg.vXF[0].data(), wA.data());
+            castLaunch<float,scalar>(nC, amg.vXF[0].data(), wA.data());
         }
         else vcycleAt(0, amg, A, rA, wA);
     };
@@ -126,7 +141,7 @@ static DeviceSolverPerf deviceAMGPCGGraph(
     deviceAxpy(-1.0, c.Ax, rA);
     DeviceSolverPerf perf;
     deviceSumMagInto(rA, c.sInit.data());
-    gsScaleInvK<<<1,1,0,cudaStreamPerThread>>>(c.sInit.data(), c.sNormF.data());
+    gsScaleInvLaunch(c.sInit.data(), c.sNormF.data(), cudaStreamPerThread);
     scalar initRes;
     cudaCheck(cudaMemcpyAsync(&initRes, c.sInit.data(), sizeof(scalar), cudaMemcpyDeviceToHost, cudaStreamPerThread), "pcg init D2H");
     cudaStreamSynchronize(cudaStreamPerThread);
@@ -148,7 +163,7 @@ static DeviceSolverPerf deviceAMGPCGGraph(
     deviceAxpyDev(dAlpha, c.pA, psi);
     deviceAxpyDev(dNegAlpha, wA, rA);
     deviceSumMagInto(rA, c.sRes.data());
-    gsScaleInvK<<<1,1,0,cudaStreamPerThread>>>(c.sRes.data(), c.sNormF.data());
+    gsScaleInvLaunch(c.sRes.data(), c.sNormF.data(), cudaStreamPerThread);
     scalar res1;
     cudaCheck(cudaMemcpyAsync(&res1, c.sRes.data(), sizeof(scalar), cudaMemcpyDeviceToHost, cudaStreamPerThread), "pcg it0 D2H");
     cudaStreamSynchronize(cudaStreamPerThread);
@@ -194,8 +209,14 @@ static DeviceSolverPerf deviceAMGPCGGraph(
         deviceAxpyDev(dAlpha, c.pA, psi);
         deviceAxpyDev(dNegAlpha, wA, rA);
         deviceSumMagInto(rA, c.sRes.data());
-        gsScaleInvK<<<1,1,0,cudaStreamPerThread>>>(c.sRes.data(), c.sNormF.data());   // normalized residual
-        pcgSetCondK<<<1,1,0,cudaStreamPerThread>>>(c.handle, c.sRes.data(), tol, c.sInit.data(), relTol, c.sIter.data(), maxIter-1, minIter-1);   // -1: iteration 0 ran outside the loop
+        gsScaleInvLaunch(c.sRes.data(), c.sNormF.data(), cudaStreamPerThread);   // normalized residual
+        {
+            const cudaGraphConditionalHandle h = c.handle; const scalar* res = c.sRes.data(); const scalar tolD = tol;
+            const scalar* init = c.sInit.data(); const scalar relTolD = relTol; int* iter = c.sIter.data();
+            const int maxI = maxIter-1, minI = minIter-1;
+            pcudaParallelFor(dim3(1), dim3(1), size_t(0), cudaStreamPerThread, [=] __device__ () {
+                pcgSetCondK(h, res, tolD, init, relTolD, iter, maxI, minI); });   // -1: iteration 0 ran outside the loop
+        }
         cudaGraph_t tmp;
         cudaCheck(cudaStreamEndCapture(cudaStreamPerThread, &tmp), "pcg capture end");
         cudaCheck(cudaGraphInstantiate(&c.exec, c.graph, 0), "pcg graph instantiate");
@@ -259,9 +280,9 @@ DeviceSolverPerf deviceParallelAMGPCGGraph(
     {
         if (fp32)
         {
-            cast_<scalar,float><<<nBlocks(nC),TPB,0,strm>>>(nC, rA.data(), amg.vBF[0].data());
+            castLaunch<scalar,float>(nC, rA.data(), amg.vBF[0].data(), strm);
             vcycleAtF(0, amg, A, A0, amg.vBF[0].data(), amg.vXF[0].data());
-            cast_<float,scalar><<<nBlocks(nC),TPB,0,strm>>>(nC, amg.vXF[0].data(), wA.data());
+            castLaunch<float,scalar>(nC, amg.vXF[0].data(), wA.data(), strm);
         }
         else vcycleAt(0, amg, A, rA, wA);
     };
@@ -280,7 +301,7 @@ DeviceSolverPerf deviceParallelAMGPCGGraph(
     deviceAxpy(-1.0, c.Ax, rA);
     DeviceSolverPerf perf;
     gsum(rA, c.sInit.data());
-    gsScaleInvK<<<1,1,0,strm>>>(c.sInit.data(), c.sNormF.data());
+    gsScaleInvLaunch(c.sInit.data(), c.sNormF.data(), strm);
     scalar initRes;
     cudaCheck(cudaMemcpyAsync(&initRes, c.sInit.data(), sizeof(scalar), cudaMemcpyDeviceToHost, strm), "pgraph init D2H");
     cudaStreamSynchronize(strm);
@@ -297,7 +318,7 @@ DeviceSolverPerf deviceParallelAMGPCGGraph(
     deviceAxpyDev(dAlpha, c.pA, psi);
     deviceAxpyDev(dNegAlpha, wA, rA);
     gsum(rA, c.sRes.data());
-    gsScaleInvK<<<1,1,0,strm>>>(c.sRes.data(), c.sNormF.data());
+    gsScaleInvLaunch(c.sRes.data(), c.sNormF.data(), strm);
     scalar res1;
     cudaCheck(cudaMemcpyAsync(&res1, c.sRes.data(), sizeof(scalar), cudaMemcpyDeviceToHost, strm), "pgraph it0 D2H");
     cudaStreamSynchronize(strm);
@@ -330,10 +351,16 @@ DeviceSolverPerf deviceParallelAMGPCGGraph(
         deviceAxpyDev(dAlpha, c.pA, psi);
         deviceAxpyDev(dNegAlpha, wA, rA);
         gsum(rA, c.sRes.data());
-        gsScaleInvK<<<1,1,0,strm>>>(c.sRes.data(), c.sNormF.data());
+        gsScaleInvLaunch(c.sRes.data(), c.sNormF.data(), strm);
         // minIter 0: the DISTRIBUTED path does not carry the fvSolution minIter yet (the single-GPU
         // solvers do). Passing 0 keeps it exactly as it was rather than half-wiring it.
-        pcgSetCondK<<<1,1,0,strm>>>(c.handle, c.sRes.data(), tol, c.sInit.data(), relTol, c.sIter.data(), maxIter-1, 0);
+        {
+            const cudaGraphConditionalHandle h = c.handle; const scalar* res = c.sRes.data(); const scalar tolD = tol;
+            const scalar* init = c.sInit.data(); const scalar relTolD = relTol; int* iter = c.sIter.data();
+            const int maxI = maxIter-1;
+            pcudaParallelFor(dim3(1), dim3(1), size_t(0), strm, [=] __device__ () {
+                pcgSetCondK(h, res, tolD, init, relTolD, iter, maxI, 0); });
+        }
         cudaGraph_t tmp;
         cudaCheck(cudaStreamEndCapture(strm, &tmp), "pgraph capture end");
         cudaCheck(cudaGraphInstantiate(&c.exec, c.graph, 0), "pgraph instantiate");
@@ -428,10 +455,11 @@ DeviceSolverPerf deviceAMGPCG(
             const LduF A0 = lduF(A, amg.fDiag[0], amg.fUpper[0], amg.fLower[0]);
             auto runF = [&]()                                                        // cast in -> FP32 V-cycle -> cast out
             {
-                cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, rA.data(), amg.vBF[0].data());
+                castLaunch<scalar,float>(nC, rA.data(), amg.vBF[0].data());
                 vcycleAtF(0, amg, A, A0, amg.vBF[0].data(), amg.vXF[0].data());
-                cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, amg.vXF[0].data(), wA.data());
+                castLaunch<float,scalar>(nC, amg.vXF[0].data(), wA.data());
             };
+#ifndef BRAE_ACPP
             if (!captureVcycle)
             {
                 runF();
@@ -457,8 +485,14 @@ DeviceSolverPerf deviceAMGPCG(
                 gcf.key = A.diag;
             }
             cudaCheck(cudaGraphLaunch(gcf.exec, cudaStreamPerThread), "amgF graph launch");
+#else
+            // No CUDA-graph capture under ACPP: always the direct launch, same as !captureVcycle above.
+            warnAcppNoGraphCapture(captureVcycle);
+            runF();
+#endif
             return;
         }
+#ifndef BRAE_ACPP
         if (!captureVcycle)
         {
             vcycleAt(0, amg, A, rA, wA);
@@ -483,6 +517,10 @@ DeviceSolverPerf deviceAMGPCG(
             gc.key = A.diag;
         }
         cudaCheck(cudaGraphLaunch(gc.exec, cudaStreamPerThread), "amg graph launch");
+#else
+        warnAcppNoGraphCapture(captureVcycle);
+        vcycleAt(0, amg, A, rA, wA);
+#endif
     };
 
     // Device-resident Krylov scalars: wArA / pAp / alpha / beta live on the device and feed the *Dev kernels by
@@ -509,7 +547,11 @@ DeviceSolverPerf deviceAMGPCG(
             else if (corrScaling)                             // flexible CG (Polak-Ribiere+): nonlinear precond
             {
                 deviceDotInto(wA, rOld, amg.sZrOld.data());
-                flexBetaK<<<1,1>>>(dWArA, amg.sZrOld.data(), dWArAold, dBeta);
+                {
+                    const scalar* zrNew = dWArA; const scalar* zrOld = amg.sZrOld.data();
+                    const scalar* rhoOld = dWArAold; scalar* out = dBeta;
+                    pcudaParallelFor(dim3(1), dim3(1), [=] __device__ () { flexBetaK(zrNew, zrOld, rhoOld, out); });
+                }
                 deviceFusedScaleAxpy(pA, dBeta, wA);
             }
             else

--- a/src/cuda/device_amg_smoothers.cu
+++ b/src/cuda/device_amg_smoothers.cu
@@ -11,6 +11,7 @@
 #include "amg_kernels.cuh"         // smoothT / zeroT / gsColorT (templated V-cycle kernels)
 #include "device_ldu.cuh"          // DeviceLduView / deviceAmul
 #include "device_blas.cuh"         // deviceDot / deviceScale / deviceCopy
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cmath>
 
@@ -18,7 +19,7 @@ namespace brae {
 
 namespace {
 // z = src/diag: applies the diagonal (Jacobi) preconditioner, used by the power iteration on D^-1 A.
-__global__
+__device__
 void invDiagMulK(
     int n,
     const scalar* __restrict__ src,
@@ -29,7 +30,7 @@ void invDiagMulK(
     if (i < n) z[i] = src[i]/diag[i];
 }
 // Chebyshev polynomial smoother step: d = c1*d + c2*(b - Ax)/diag ; x += d.
-__global__
+__device__
 void chebStepK(
     int n,
     const scalar* __restrict__ b,
@@ -47,7 +48,7 @@ void chebStepK(
 }
 // twoStageGaussSeidel kernels (BRAE_AMG_TSGS). upperMul = strictly-upper-triangle SpMV r = U z; the tsgs* kernels
 // below are the fused Jacobi/correction updates of the polynomial expansion.
-__global__
+__device__
 void upperMulK(
     int n,
     const label* __restrict__ ownerStart,
@@ -65,7 +66,7 @@ void upperMulK(
 }
 // lowerMul = strictly-lower-triangle SpMV r = L z, the transpose of upperMul for the symmetric matrix. Pre-smooth
 // with U and post-smooth with L so the V-cycle preconditioner stays symmetric, as the AMG-PCG outer solver requires.
-__global__
+__device__
 void lowerMulK(
     int n,
     const label* __restrict__ losortStart,
@@ -85,7 +86,7 @@ void lowerMulK(
     }
     r[c] = s;
 }
-__global__
+__device__
 void tsgsZUpdateK(
     int n,
     const scalar* __restrict__ b,
@@ -102,7 +103,7 @@ void tsgsZUpdateK(
         x[i]+=zi;
     }
 }
-__global__
+__device__
 void tsgsCorrSaveK(
     int n,
     const scalar* __restrict__ r,
@@ -119,7 +120,7 @@ void tsgsCorrSaveK(
         x[i]+=mult*zi;
     }
 }
-__global__
+__device__
 void tsgsCorrLastK(
     int n,
     const scalar* __restrict__ r,
@@ -139,7 +140,7 @@ void tsgsCorrLastK(
 // top modes ABOVE the interval, where the Chebyshev polynomial amplifies rather than damps them
 // -> the smoother diverges (observed as a stall at ~1.6e-3 on a 1M-cell Laplacian). A period-7
 // sawtooth injects broad spectral content, exactly as the SA path's hostSpectralRadius does.
-__global__
+__device__
 void fillSeedK(
     int n,
     scalar* __restrict__ x)
@@ -157,7 +158,7 @@ static scalar estimateLambdaMax(
     DeviceBuffer<scalar>& z)
 {
     const int n = A.nCells;
-    fillSeedK<<<nBlocks(n),TPB>>>(n, x.data());
+    { scalar* xd = x.data(); pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fillSeedK(n, xd); }); }
     scalar lam = 1.0;
     // 25 iterations, not 12: power iteration converges to lambda_max FROM BELOW, and every ms of
     // under-estimate risks divergence in the Chebyshev smoother, while an over-estimate only mildly
@@ -168,7 +169,10 @@ static scalar estimateLambdaMax(
         if (!(nrm > 0.0)) break;
         deviceScale(x, 1.0/nrm);                                  // x <- x/||x||
         deviceAmul(A, x, ax);                                     // ax = A x
-        invDiagMulK<<<nBlocks(n),TPB>>>(n, ax.data(), A.diag, z.data());  // z = D^-1 A x
+        {
+            const scalar* axd = ax.data(); const scalar* diag = A.diag; scalar* zd = z.data();
+            pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { invDiagMulK(n, axd, diag, zd); });  // z = D^-1 A x
+        }
         lam = std::sqrt(deviceDot(z, z));                         // ||D^-1 A x|| (||x||=1) -> Rayleigh-quotient bound
         deviceCopy(x, z);
     }
@@ -209,16 +213,24 @@ void chebyshevSmooth(
     // under-covering it diverges. 1.2 (not 1.1) buys margin for the residual under-estimate.
     const scalar upper = CHEB_UPPER_SAFETY*lambdaMax, lower = upper/CHEB_EIGRATIO;
     const scalar theta = 0.5*(upper+lower), delta = 0.5*(upper-lower), sigma = theta/delta;
-    zeroT<scalar><<<nBlocks(n),TPB>>>(n, d.data());                       // avoid 0*Inf=NaN on the c1=0 first step
+    zeroTLaunch<scalar>(n, d.data());                       // avoid 0*Inf=NaN on the c1=0 first step
     deviceAmul(A, x, ax);                                        // step 0: d = (1/theta)(b-Ax)/D ; x += d
-    chebStepK<<<nBlocks(n),TPB>>>(n, b.data(), ax.data(), A.diag, 0.0, 1.0/theta, d.data(), x.data());
+    {
+        const scalar* bd = b.data(); const scalar* axd = ax.data(); const scalar* diag = A.diag;
+        scalar* dd = d.data(); scalar* xd = x.data(); const scalar c2 = 1.0/theta;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { chebStepK(n, bd, axd, diag, 0.0, c2, dd, xd); });
+    }
     scalar rho = 1.0/sigma;
     for (int k = 1; k < deg; ++k)
     {
         const scalar rhoNew = 1.0/(2.0*sigma - rho);
         const scalar c1 = rho*rhoNew, c2 = 2.0*rhoNew/delta;
         deviceAmul(A, x, ax);
-        chebStepK<<<nBlocks(n),TPB>>>(n, b.data(), ax.data(), A.diag, c1, c2, d.data(), x.data());
+        {
+            const scalar* bd = b.data(); const scalar* axd = ax.data(); const scalar* diag = A.diag;
+            scalar* dd = d.data(); scalar* xd = x.data();
+            pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { chebStepK(n, bd, axd, diag, c1, c2, dd, xd); });
+        }
         rho = rhoNew;
     }
 }
@@ -249,17 +261,39 @@ void twoStageGSSmooth(
         deviceAmul(A, x, r);                                                                 // r = A x
         if (order == 0)   // == weighted Jacobi
         {
-            smoothT<scalar><<<nBlocks(n),TPB>>>(n, b.data(), r.data(), A.diag, x.data());
+            smoothTLaunch<scalar>(n, b.data(), r.data(), A.diag, x.data());
             continue;
         }
-        tsgsZUpdateK<<<nBlocks(n),TPB>>>(n, b.data(), r.data(), A.diag, z.data(), x.data());  // z=(b-Ax)/D; x+=z
+        {
+            const scalar* bd = b.data(); const scalar* rd = r.data(); const scalar* diag = A.diag;
+            scalar* zd = z.data(); scalar* xd = x.data();
+            pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { tsgsZUpdateK(n, bd, rd, diag, zd, xd); });  // z=(b-Ax)/D; x+=z
+        }
         scalar mult = -1.0;
         for (int k = 0; k < order; ++k)
         {
-            if (forward) upperMulK<<<nBlocks(n),TPB>>>(n, A.ownerStart, A.nei, A.upper, z.data(), r.data());              // r = U z (pre)
-            else         lowerMulK<<<nBlocks(n),TPB>>>(n, A.losortStart, A.losort, A.owner, A.lower, z.data(), r.data()); // r = L z (post -> symmetric)
-            if (k < order - 1) tsgsCorrSaveK<<<nBlocks(n),TPB>>>(n, r.data(), A.diag, mult, z.data(), x.data());
-            else               tsgsCorrLastK<<<nBlocks(n),TPB>>>(n, r.data(), A.diag, mult, x.data());
+            if (forward)
+            {
+                const label* ownerStart = A.ownerStart; const label* nei = A.nei; const scalar* upper = A.upper;
+                const scalar* zd = z.data(); scalar* rd = r.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { upperMulK(n, ownerStart, nei, upper, zd, rd); });              // r = U z (pre)
+            }
+            else
+            {
+                const label* losortStart = A.losortStart; const label* losort = A.losort; const label* owner = A.owner;
+                const scalar* lower = A.lower; const scalar* zd = z.data(); scalar* rd = r.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { lowerMulK(n, losortStart, losort, owner, lower, zd, rd); }); // r = L z (post -> symmetric)
+            }
+            if (k < order - 1)
+            {
+                const scalar* rd = r.data(); const scalar* diag = A.diag; scalar* zd = z.data(); scalar* xd = x.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { tsgsCorrSaveK(n, rd, diag, mult, zd, xd); });
+            }
+            else
+            {
+                const scalar* rd = r.data(); const scalar* diag = A.diag; scalar* xd = x.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { tsgsCorrLastK(n, rd, diag, mult, xd); });
+            }
             mult = -mult;
         }
     }
@@ -282,7 +316,7 @@ void gsSweep(
         const int lo = gc.startH[col], hi = gc.startH[col+1];
         const int nc = hi - lo;
         if (nc <= 0) continue;
-        gsColorT<scalar><<<nBlocks(nc),TPB>>>(lo, hi, gc.cells.data(), b.data(), A.diag,
+        gsColorTLaunch<scalar>(lo, hi, gc.cells.data(), b.data(), A.diag,
             A.ownerStart, A.nei, A.upper, A.losortStart, A.losort, A.owner, A.lower, x.data());
     }
 }

--- a/src/cuda/device_amg_vcycle.cu
+++ b/src/cuda/device_amg_vcycle.cu
@@ -11,6 +11,7 @@
 #include "amg_kernels.cuh"         // zeroT/smoothT/residualT/restrictT/prolongT<T>
 #include "device_ldu.cuh"          // DeviceLduView / deviceAmul
 #include "device_blas.cuh"         // deviceCopy / deviceDot / deviceReciprocalV
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cstdio>
 #include <cstdlib>
@@ -18,7 +19,7 @@
 namespace brae {
 
 namespace {
-__global__
+__device__
 void prolongToK(
     int nF,
     const label* __restrict__ map,
@@ -30,7 +31,7 @@ void prolongToK(
 }
 // Smoothed-aggregation sparse prolongator apply (BRAE_AMG_SA): restrict = P^T, prolong = P.
 // restrict: rc += P^T r  (each fine cell f scatters val*r[f] into its coarse columns, atomically).
-__global__
+__device__
 void restrictSparseK(
     int nF,
     const label* __restrict__ rowPtr,
@@ -46,7 +47,7 @@ void restrictSparseK(
         atomicAdd(&rc[col[k]], val[k]*rf);
 }
 // prolong (ADD): x[f] += sum_k P[f][k]*xc[col], the smoothed-P twin of prolongT.
-__global__
+__device__
 void prolongSparseK(
     int nF,
     const label* __restrict__ rowPtr,
@@ -63,7 +64,7 @@ void prolongSparseK(
     x[f] += s;
 }
 // prolong (SET): pc[f] = sum_k P[f][k]*xc[col], the corrScaling line-search path (writes pc, not added yet).
-__global__
+__device__
 void prolongToSparseK(
     int nF,
     const label* __restrict__ rowPtr,
@@ -81,7 +82,7 @@ void prolongToSparseK(
 }
 
 // Energy-minimising coarse-correction scale (OF GAMG): alpha = (r . c)/(c . Ac), guarded since c.Ac = ||c||_A^2 >= 0.
-__global__
+__device__
 void scaleFactorK(
     const scalar* __restrict__ num,
     const scalar* __restrict__ den,
@@ -106,7 +107,7 @@ void vcycleAt(
     DeviceBuffer<scalar>& xg)
 {
     const int n = Ag.nCells;
-    zeroT<scalar><<<nBlocks(n),TPB>>>(n, xg.data());
+    zeroTLaunch<scalar>(n, xg.data());
     if (g == amg.nLevels())                                    // coarsest: approximate solve
     {
         // BRAE_NCOARSE_CG overrides the coarsest PCG iteration count.
@@ -117,7 +118,7 @@ void vcycleAt(
         else for (int s = 0; s < NCOARSE; ++s)
         {
             deviceAmul(Ag, xg, amg.vAx[g]);
-            smoothT<scalar><<<nBlocks(n),TPB>>>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
+            smoothTLaunch<scalar>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
         }
         return;
     }
@@ -127,42 +128,62 @@ void vcycleAt(
     else for (int s = 0; s < NPRE; ++s)
     {
         deviceAmul(Ag, xg, amg.vAx[g]);
-        smoothT<scalar><<<nBlocks(n),TPB>>>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
+        smoothTLaunch<scalar>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
     }
     deviceAmul(Ag, xg, amg.vAx[g]);
-    residualT<scalar><<<nBlocks(n),TPB>>>(n, bg.data(), amg.vAx[g].data(), amg.vR[g].data());
+    residualTLaunch<scalar>(n, bg.data(), amg.vAx[g].data(), amg.vR[g].data());
     const int nc = amg.level[g].nCoarse;
     const AMGLevel& Lg = amg.level[g];
-    zeroT<scalar><<<nBlocks(nc),TPB>>>(nc, amg.vB[g+1].data());
+    zeroTLaunch<scalar>(nc, amg.vB[g+1].data());
     if (amg.saSmooth)                                            // restrict rc = P^T r (sparse smoothed prolongator)
-        restrictSparseK<<<nBlocks(n),TPB>>>(n, Lg.Prow.data(), Lg.Pcol.data(), Lg.Pval.data(), amg.vR[g].data(), amg.vB[g+1].data());
+    {
+        const label* rowPtr = Lg.Prow.data(); const label* col = Lg.Pcol.data(); const scalar* val = Lg.Pval.data();
+        const scalar* r = amg.vR[g].data(); scalar* rc = amg.vB[g+1].data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { restrictSparseK(n, rowPtr, col, val, r, rc); });
+    }
     else
-        restrictT<scalar><<<nBlocks(n),TPB>>>(n, Lg.map.data(), amg.vR[g].data(), amg.vB[g+1].data());
+        restrictTLaunch<scalar>(n, Lg.map.data(), amg.vR[g].data(), amg.vB[g+1].data());
     vcycleAt(g+1, amg, amg.level[g].coarseView(), amg.vB[g+1], amg.vX[g+1]);   // recurse to the next coarser grid
     if (amg.corrScaling)
     {
         // OF-GAMG-style scaled coarse correction: alpha = (r . A pc)/(A pc . A pc); xg += alpha*pc. The single
         // line-search per level fixes the magnitude of the prolongation. All scalars stay on the device
         // (deviceDotInto/scaleFactorK/AxpyDev) so it adds NO host sync and remains capturable into the V-cycle graph.
-        if (amg.saSmooth) prolongToSparseK<<<nBlocks(n),TPB>>>(n, Lg.Prow.data(), Lg.Pcol.data(), Lg.Pval.data(), amg.vX[g+1].data(), amg.vPc[g].data());
-        else              prolongToK<<<nBlocks(n),TPB>>>(n, Lg.map.data(), amg.vX[g+1].data(), amg.vPc[g].data());  // c = P*corr
+        if (amg.saSmooth)
+        {
+            const label* rowPtr = Lg.Prow.data(); const label* col = Lg.Pcol.data(); const scalar* val = Lg.Pval.data();
+            const scalar* xc = amg.vX[g+1].data(); scalar* pc = amg.vPc[g].data();
+            pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { prolongToSparseK(n, rowPtr, col, val, xc, pc); });
+        }
+        else
+        {
+            const label* map = Lg.map.data(); const scalar* xc = amg.vX[g+1].data(); scalar* pc = amg.vPc[g].data();
+            pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { prolongToK(n, map, xc, pc); });  // c = P*corr
+        }
         deviceAmul(Ag, amg.vPc[g], amg.vAx[g]);                                       // Ac
         deviceDotInto(amg.vR[g], amg.vPc[g], amg.sScNum.data());                      // r . c   (energy-min, OF GAMG)
         deviceDotInto(amg.vPc[g], amg.vAx[g], amg.sScDen.data());                     // c . Ac  (= ||c||_A^2 > 0)
-        scaleFactorK<<<1,1>>>(amg.sScNum.data(), amg.sScDen.data(), amg.sScAlpha.data());
+        {
+            const scalar* num = amg.sScNum.data(); const scalar* den = amg.sScDen.data(); scalar* out = amg.sScAlpha.data();
+            pcudaParallelFor(dim3(1), dim3(1), [=] __device__ () { scaleFactorK(num, den, out); });
+        }
         deviceAxpyDev(amg.sScAlpha.data(), amg.vPc[g], xg);                           // xg += alpha * c
     }
     else if (amg.saSmooth)
-        prolongSparseK<<<nBlocks(n),TPB>>>(n, Lg.Prow.data(), Lg.Pcol.data(), Lg.Pval.data(), amg.vX[g+1].data(), xg.data());
+    {
+        const label* rowPtr = Lg.Prow.data(); const label* col = Lg.Pcol.data(); const scalar* val = Lg.Pval.data();
+        const scalar* xc = amg.vX[g+1].data(); scalar* xgd = xg.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { prolongSparseK(n, rowPtr, col, val, xc, xgd); });
+    }
     else
-        prolongT<scalar><<<nBlocks(n),TPB>>>(n, Lg.map.data(), amg.vX[g+1].data(), xg.data());
+        prolongTLaunch<scalar>(n, Lg.map.data(), amg.vX[g+1].data(), xg.data());
     if (useChebyshev()) chebyshevSmooth(Ag, bg, xg, amg.vD[g], amg.vAx[g], amg.lambdaMax[g], chebDeg());  // post-smooth
     else if (useTSGS()) twoStageGSSmooth(Ag, bg, xg, amg.vD[g], amg.vAx[g], NPOST, tsgsOrder(), false);  // twoStageGaussSeidel (bwd -> symmetric)
     else if (amg.gsSmooth) for (int s = 0; s < NPOST; ++s) gsSweep(Ag, bg, xg, amg.coloring[g], false);  // backward GS (symmetric V-cycle)
     else for (int s = 0; s < NPOST; ++s)
     {
         deviceAmul(Ag, xg, amg.vAx[g]);
-        smoothT<scalar><<<nBlocks(n),TPB>>>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
+        smoothTLaunch<scalar>(n, bg.data(), amg.vAx[g].data(), Ag.diag, xg.data());
     }
 }
 
@@ -204,11 +225,11 @@ void amgCastFP32(
     for (int g=0; g<=G; ++g)
     {
         const DeviceLduView v = (g==0) ? A : amg.level[g-1].coarseView();
-        cast_<scalar,float><<<nBlocks(v.nCells),TPB>>>(v.nCells, v.diag, amg.fDiag[g].data());
+        castLaunch<scalar,float>(v.nCells, v.diag, amg.fDiag[g].data());
         if (v.nInternalFaces>0)
         {
-            cast_<scalar,float><<<nBlocks(v.nInternalFaces),TPB>>>(v.nInternalFaces, v.upper, amg.fUpper[g].data());
-            cast_<scalar,float><<<nBlocks(v.nInternalFaces),TPB>>>(v.nInternalFaces, v.lower, amg.fLower[g].data());
+            castLaunch<scalar,float>(v.nInternalFaces, v.upper, amg.fUpper[g].data());
+            castLaunch<scalar,float>(v.nInternalFaces, v.lower, amg.fLower[g].data());
         }
     }
 }
@@ -222,43 +243,43 @@ void vcycleAtF(
     float* xg)
 {
     const int n = Ag.nCells;
-    zeroT<float><<<nBlocks(n),TPB>>>(n, xg);
+    zeroTLaunch<float>(n, xg);
     if (g == amg.nLevels())                                    // coarsest: cast to FP64, exact FP64 solve, cast back
     {
-        cast_<float,scalar><<<nBlocks(n),TPB>>>(n, bg, amg.vB[g].data());
+        castLaunch<float,scalar>(n, bg, amg.vB[g].data());
         static const int ncoarseCG = [](){ const char* e=std::getenv("BRAE_NCOARSE_CG"); return (e&&std::atoi(e)>0)?std::atoi(e):NCOARSE_CG; }();
         if (n <= SB_CG_MAX) deviceCoarsePCG(topoG, amg.vB[g], amg.vX[g], ncoarseCG);
         else
         {
-            zeroT<scalar><<<nBlocks(n),TPB>>>(n, amg.vX[g].data());
+            zeroTLaunch<scalar>(n, amg.vX[g].data());
             for (int s=0;s<NCOARSE;++s)
             {
                 deviceAmul(topoG, amg.vX[g], amg.vAx[g]);
-                smoothT<scalar><<<nBlocks(n),TPB>>>(n, amg.vB[g].data(), amg.vAx[g].data(), topoG.diag, amg.vX[g].data());
+                smoothTLaunch<scalar>(n, amg.vB[g].data(), amg.vAx[g].data(), topoG.diag, amg.vX[g].data());
             }
         }
-        cast_<scalar,float><<<nBlocks(n),TPB>>>(n, amg.vX[g].data(), xg);
+        castLaunch<scalar,float>(n, amg.vX[g].data(), xg);
         return;
     }
     for (int s=0; s<NPRE; ++s)
     {
         amulF(Ag, xg, amg.vAxF[g].data());
-        smoothT<float><<<nBlocks(n),TPB>>>(n, bg, amg.vAxF[g].data(), Ag.diag, xg);
+        smoothTLaunch<float>(n, bg, amg.vAxF[g].data(), Ag.diag, xg);
     }
     amulF(Ag, xg, amg.vAxF[g].data());
-    residualT<float><<<nBlocks(n),TPB>>>(n, bg, amg.vAxF[g].data(), amg.vRF[g].data());
+    residualTLaunch<float>(n, bg, amg.vAxF[g].data(), amg.vRF[g].data());
     const AMGLevel& Lg = amg.level[g];
     const int nc = Lg.nCoarse;
-    zeroT<float><<<nBlocks(nc),TPB>>>(nc, amg.vBF[g+1].data());
-    restrictT<float><<<nBlocks(n),TPB>>>(n, Lg.map.data(), amg.vRF[g].data(), amg.vBF[g+1].data());
+    zeroTLaunch<float>(nc, amg.vBF[g+1].data());
+    restrictTLaunch<float>(n, Lg.map.data(), amg.vRF[g].data(), amg.vBF[g+1].data());
     const DeviceLduView topoC = Lg.coarseView();
     const LduF Ac = lduF(topoC, amg.fDiag[g+1], amg.fUpper[g+1], amg.fLower[g+1]);
     vcycleAtF(g+1, amg, topoC, Ac, amg.vBF[g+1].data(), amg.vXF[g+1].data());
-    prolongT<float><<<nBlocks(n),TPB>>>(n, Lg.map.data(), amg.vXF[g+1].data(), xg);
+    prolongTLaunch<float>(n, Lg.map.data(), amg.vXF[g+1].data(), xg);
     for (int s=0; s<NPOST; ++s)
     {
         amulF(Ag, xg, amg.vAxF[g].data());
-        smoothT<float><<<nBlocks(n),TPB>>>(n, bg, amg.vAxF[g].data(), Ag.diag, xg);
+        smoothTLaunch<float>(n, bg, amg.vAxF[g].data(), Ag.diag, xg);
     }
 }
 
@@ -277,6 +298,10 @@ void amgPrepareFP32(AMGData& amg, const DeviceLduView& A)
 // design: the outer distributed matvec (deviceParallelAmul) supplies the interface, the local V-cycle need only
 // approximate the local block. amg must be built (buildAMG) and current (amgGalerkin gives it this step's coarse
 // operators). Runs the FP32 V-cycle when amgPrepareFP32 cast the matrices this solve, else the FP64 one.
+//
+// Its captureVcycle branch uses CUDA-graph capture, which ACPP has no equivalent for; device_pcg.cu includes
+// this header for the type but never calls this function, so nothing in the built tree references it there.
+#ifndef BRAE_ACPP
 void amgVCycleApply(AMGData& amg, const DeviceLduView& A,
                     const DeviceBuffer<scalar>& r, DeviceBuffer<scalar>& z, bool captureVcycle)
 {
@@ -290,9 +315,9 @@ void amgVCycleApply(AMGData& amg, const DeviceLduView& A,
         if (fp32)
         {
             const LduF A0 = lduF(A, amg.fDiag[0], amg.fUpper[0], amg.fLower[0]);         // grid-0 FP32 matrix view
-            cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, r.data(), amg.vBF[0].data());   // r -> FP32
+            castLaunch<scalar,float>(nC, r.data(), amg.vBF[0].data());   // r -> FP32
             vcycleAtF(0, amg, A, A0, amg.vBF[0].data(), amg.vXF[0].data());              // FP32 V-cycle
-            cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, amg.vXF[0].data(), z.data());   // FP32 -> z (FP64)
+            castLaunch<float,scalar>(nC, amg.vXF[0].data(), z.data());   // FP32 -> z (FP64)
         }
         else vcycleAt(0, amg, A, r, z);    // FP64 V-cycle
         return;
@@ -313,9 +338,9 @@ void amgVCycleApply(AMGData& amg, const DeviceLduView& A,
             if (gcf.exec)  { cudaGraphExecDestroy(gcf.exec);  gcf.exec  = nullptr; }
             if (gcf.graph) { cudaGraphDestroy(gcf.graph);     gcf.graph = nullptr; }
             cudaCheck(cudaStreamBeginCapture(cudaStreamPerThread, cudaStreamCaptureModeThreadLocal), "amgF capture begin");
-            cast_<scalar,float><<<nBlocks(nC),TPB>>>(nC, amg.rA.data(), amg.vBF[0].data());
+            castLaunch<scalar,float>(nC, amg.rA.data(), amg.vBF[0].data());
             vcycleAtF(0, amg, A, A0, amg.vBF[0].data(), amg.vXF[0].data());
-            cast_<float,scalar><<<nBlocks(nC),TPB>>>(nC, amg.vXF[0].data(), amg.wA.data());
+            castLaunch<float,scalar>(nC, amg.vXF[0].data(), amg.wA.data());
             cudaCheck(cudaStreamEndCapture(cudaStreamPerThread, &gcf.graph), "amgF capture end");
             cudaCheck(cudaGraphInstantiate(&gcf.exec, gcf.graph, 0), "amgF graph instantiate");
             gcf.key = A.diag;
@@ -339,5 +364,6 @@ void amgVCycleApply(AMGData& amg, const DeviceLduView& A,
     }
     deviceCopy(z, amg.wA);
 }
+#endif // !BRAE_ACPP
 
 } // namespace brae

--- a/src/cuda/device_ami.cu
+++ b/src/cuda/device_ami.cu
@@ -1,5 +1,6 @@
 // cf GPU offload, cyclicAMI weighted-stencil coupling kernels. See device_ami.cuh.
 #include "device_ami.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -8,7 +9,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void amiInterpKernel(
     int n,
     const label* __restrict__ off,
@@ -27,7 +28,7 @@ void amiInterpKernel(
 }
 
 
-__global__
+__device__
 void amiInterpVecKernel(
     int n,
     const label* __restrict__ off,
@@ -65,7 +66,7 @@ void amiInterpVecKernel(
 }
 
 
-__global__
+__device__
 void amiAmulKernel(
     int n,
     const label* __restrict__ own,
@@ -90,8 +91,13 @@ void amiAmulKernel(
 void deviceAmiAmul(const DeviceAMI& ami, const DeviceBuffer<scalar>& psi, DeviceBuffer<scalar>& Apsi)
 {
     if (ami.n == 0) return;
-    amiAmulKernel<<<nBlocks(ami.n), TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(),
-                                           ami.weight.data(), ami.ifCoeff.data(), psi.data(), Apsi.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* ifc = ami.ifCoeff.data();
+        const scalar* psid = psi.data(); scalar* Apsid = Apsi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiAmulKernel(n, own, off, nbr, w, ifc, psid, Apsid); });
+    }
     cudaCheck(cudaGetLastError(), "amiAmul");
 }
 
@@ -102,14 +108,19 @@ void deviceAmiAmulCoeff(const DeviceAMI& ami, const DeviceBuffer<scalar>& coeff,
                         const DeviceBuffer<scalar>& psi, DeviceBuffer<scalar>& Apsi)
 {
     if (ami.n == 0) return;
-    amiAmulKernel<<<nBlocks(ami.n), TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(),
-                                           ami.weight.data(), coeff.data(), psi.data(), Apsi.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* coeffD = coeff.data();
+        const scalar* psid = psi.data(); scalar* Apsid = Apsi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiAmulKernel(n, own, off, nbr, w, coeffD, psid, Apsid); });
+    }
     cudaCheck(cudaGetLastError(), "amiAmulCoeff");
 }
 
 
 namespace {
-__global__
+__device__
 void amiMomKernel(
     int n,
     const label* __restrict__ own,
@@ -133,7 +144,7 @@ void amiMomKernel(
 }
 
 
-__global__
+__device__
 void amiLaplKernel(
     int n,
     const label* __restrict__ own,
@@ -156,7 +167,7 @@ void amiLaplKernel(
 }
 
 
-__global__
+__device__
 void amiOffSumKernel(
     int n,
     const label* __restrict__ own,
@@ -171,7 +182,7 @@ void amiOffSumKernel(
 }
 
 
-__global__
+__device__
 void amiAddHKernel(
     int n,
     const label* __restrict__ own,
@@ -188,7 +199,7 @@ void amiAddHKernel(
 }
 
 
-__global__
+__device__
 void amiFluxKernel(
     int n,
     const label* __restrict__ own,
@@ -213,7 +224,7 @@ void amiFluxKernel(
 }
 
 
-__global__
+__device__
 void amiDivAddKernel(
     int n,
     const label* __restrict__ own,
@@ -228,7 +239,7 @@ void amiDivAddKernel(
 }
 
 
-__global__
+__device__
 void amiGradAddKernel(
     int n,
     const label* __restrict__ own,
@@ -254,7 +265,7 @@ void amiGradAddKernel(
 }
 
 
-__global__
+__device__
 void amiFluxCorrKernel(
     int n,
     const label* __restrict__ own,
@@ -276,8 +287,14 @@ void deviceAmiAssembleMomentum(DeviceAMI& ami, const DeviceBuffer<scalar>& nuEff
     if (ami.n==0) return;
     DeviceBuffer<scalar> nuN;
     deviceAmiInterpolate(ami, nuEffCell, nuN);
-    amiMomKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), nuEffCell.data(), nuN.data(), ami.deltaCoeffs.data(),
-        ami.weights.data(), ami.magSf.data(), ami.phi.data(), ami.ifCoeff.data(), diag.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data();
+        const scalar* nu = nuEffCell.data(); const scalar* nuNd = nuN.data(); const scalar* dc = ami.deltaCoeffs.data();
+        const scalar* w = ami.weights.data(); const scalar* magSf = ami.magSf.data(); const scalar* phi = ami.phi.data();
+        scalar* ifc = ami.ifCoeff.data(); scalar* diagd = diag.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiMomKernel(n, own, nu, nuNd, dc, w, magSf, phi, ifc, diagd); });
+    }
     cudaCheck(cudaGetLastError(),"amiMom");
 }
 
@@ -287,8 +304,14 @@ void deviceAmiAssembleLaplacian(DeviceAMI& ami, const DeviceBuffer<scalar>& gamm
     if (ami.n==0) return;
     DeviceBuffer<scalar> gN;
     deviceAmiInterpolate(ami, gammaCell, gN);
-    amiLaplKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), gammaCell.data(), gN.data(), ami.deltaCoeffs.data(),
-        ami.weights.data(), ami.magSf.data(), ami.ifCoeff.data(), diag.data(), addToDiag?1:0);
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data();
+        const scalar* ga = gammaCell.data(); const scalar* gaN = gN.data(); const scalar* dc = ami.deltaCoeffs.data();
+        const scalar* w = ami.weights.data(); const scalar* magSf = ami.magSf.data();
+        scalar* ifc = ami.ifCoeff.data(); scalar* diagd = diag.data(); const int addD = addToDiag ? 1 : 0;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLaplKernel(n, own, ga, gaN, dc, w, magSf, ifc, diagd, addD); });
+    }
     cudaCheck(cudaGetLastError(),"amiLapl");
 }
 
@@ -296,7 +319,12 @@ void deviceAmiAssembleLaplacian(DeviceAMI& ami, const DeviceBuffer<scalar>& gamm
 void deviceAmiOffDiagSum(const DeviceAMI& ami, DeviceBuffer<scalar>& sumOff)
 {
     if (ami.n==0) return;
-    amiOffSumKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.ifCoeff.data(), ami.weightsSum.data(), sumOff.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* ifc = ami.ifCoeff.data();
+        const scalar* wsum = ami.weightsSum.data(); scalar* sumOffd = sumOff.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiOffSumKernel(n, own, ifc, wsum, sumOffd); });
+    }
     cudaCheck(cudaGetLastError(),"amiOffSum");
 }
 
@@ -304,7 +332,12 @@ void deviceAmiOffDiagSum(const DeviceAMI& ami, DeviceBuffer<scalar>& sumOff)
 void deviceAmiAddH(const DeviceAMI& ami, const DeviceBuffer<scalar>& UkNbr, const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& H)
 {
     if (ami.n==0) return;
-    amiAddHKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.ifCoeff.data(), UkNbr.data(), V.data(), H.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* ifc = ami.ifCoeff.data();
+        const scalar* UkNbrD = UkNbr.data(); const scalar* Vd = V.data(); scalar* Hd = H.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiAddHKernel(n, own, ifc, UkNbrD, Vd, Hd); });
+    }
     cudaCheck(cudaGetLastError(),"amiAddH");
 }
 
@@ -314,8 +347,15 @@ void deviceAmiFlux(DeviceAMI& ami, const DeviceBuffer<scalar>& Hx, const DeviceB
     if (ami.n==0) return;
     DeviceBuffer<scalar> Hnx,Hny,Hnz;
     deviceAmiInterpolateVec(ami, Hx,Hy,Hz, Hnx,Hny,Hnz);
-    amiFluxKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.weights.data(), Hx.data(),Hy.data(),Hz.data(),
-        Hnx.data(),Hny.data(),Hnz.data(), ami.Sfx.data(),ami.Sfy.data(),ami.Sfz.data(), ami.phi.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* w = ami.weights.data();
+        const scalar* Hxd = Hx.data(); const scalar* Hyd = Hy.data(); const scalar* Hzd = Hz.data();
+        const scalar* Hnxd = Hnx.data(); const scalar* Hnyd = Hny.data(); const scalar* Hnzd = Hnz.data();
+        const scalar* sfx = ami.Sfx.data(); const scalar* sfy = ami.Sfy.data(); const scalar* sfz = ami.Sfz.data();
+        scalar* phid = ami.phi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiFluxKernel(n, own, w, Hxd, Hyd, Hzd, Hnxd, Hnyd, Hnzd, sfx, sfy, sfz, phid); });
+    }
     cudaCheck(cudaGetLastError(),"amiFlux");
 }
 
@@ -323,13 +363,18 @@ void deviceAmiFlux(DeviceAMI& ami, const DeviceBuffer<scalar>& Hx, const DeviceB
 void deviceAmiAddDiv(const DeviceAMI& ami, const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& div)
 {
     if (ami.n==0) return;
-    amiDivAddKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.phi.data(), V.data(), div.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* phi = ami.phi.data();
+        const scalar* Vd = V.data(); scalar* divd = div.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiDivAddKernel(n, own, phi, Vd, divd); });
+    }
     cudaCheck(cudaGetLastError(),"amiDiv");
 }
 
 
 namespace {
-__global__
+__device__
 void amiZeroWallKernel(int n, const label* __restrict__ own, const label* __restrict__ isW, scalar* __restrict__ ifc)
 {
     const int i = blockIdx.x*blockDim.x+threadIdx.x;
@@ -343,7 +388,12 @@ void amiZeroWallKernel(int n, const label* __restrict__ own, const label* __rest
 void deviceAmiZeroWallIfCoeff(DeviceAMI& ami, const DeviceBuffer<label>& isWallCell)
 {
     if (ami.n==0) return;
-    amiZeroWallKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), isWallCell.data(), ami.ifCoeff.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* isW = isWallCell.data();
+        scalar* ifc = ami.ifCoeff.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiZeroWallKernel(n, own, isW, ifc); });
+    }
     cudaCheck(cudaGetLastError(),"amiZeroWall");
 }
 
@@ -351,7 +401,7 @@ void deviceAmiZeroWallIfCoeff(DeviceAMI& ami, const DeviceBuffer<label>& isWallC
 namespace {
 // face value of a CELL field on an interface face: fvc::interpolate on a coupled patch, i.e.
 //   w*patchInternalField + (1-w)*patchNeighbourField
-__global__
+__device__
 void amiFaceValueKernel(int n, const label* __restrict__ own, const scalar* __restrict__ w,
                         const scalar* __restrict__ cell, const scalar* __restrict__ nbrInterp,
                         scalar* __restrict__ out)
@@ -368,8 +418,12 @@ void deviceAmiFaceValue(const DeviceAMI& ami, const DeviceBuffer<scalar>& cell, 
     if (ami.n == 0) return;
     DeviceBuffer<scalar> nbr;
     deviceAmiInterpolate(ami, cell, nbr);
-    amiFaceValueKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.weights.data(),
-                                               cell.data(), nbr.data(), out.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* w = ami.weights.data();
+        const scalar* celld = cell.data(); const scalar* nbrd = nbr.data(); scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiFaceValueKernel(n, own, w, celld, nbrd, outd); });
+    }
     cudaCheck(cudaGetLastError(), "amiFaceValue");
 }
 
@@ -385,14 +439,20 @@ void deviceAmiAddGrad(
     if (ami.n==0) return;
     DeviceBuffer<scalar> pN;
     deviceAmiInterpolate(ami, psi, pN);
-    amiGradAddKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.weights.data(), psi.data(), pN.data(),
-        ami.Sfx.data(),ami.Sfy.data(),ami.Sfz.data(), V.data(), gx.data(),gy.data(),gz.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* w = ami.weights.data();
+        const scalar* psid = psi.data(); const scalar* pNd = pN.data();
+        const scalar* sfx = ami.Sfx.data(); const scalar* sfy = ami.Sfy.data(); const scalar* sfz = ami.Sfz.data();
+        const scalar* Vd = V.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiGradAddKernel(n, own, w, psid, pNd, sfx, sfy, sfz, Vd, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(),"amiGrad");
 }
 
 
 namespace {
-__global__
+__device__
 void amiTensorDivKernel(
     int n,
     const label* __restrict__ own,
@@ -468,7 +528,7 @@ void amiTensorDivKernel(
 }
 } // namespace
 namespace {
-__global__
+__device__
 void amiScaleImplicitKernel(
     int n,
     const scalar* __restrict__ ifc,
@@ -486,7 +546,7 @@ void amiScaleImplicitKernel(
 }
 
 
-__global__
+__device__
 void amiDeferredRotKernel(
     int n,
     const label* __restrict__ own,
@@ -509,7 +569,7 @@ void amiDeferredRotKernel(
 }
 
 
-__global__
+__device__
 void amiGradRotKernel(
     int n,
     const label* __restrict__ own,
@@ -539,8 +599,12 @@ void amiGradRotKernel(
 void deviceAmiScaleImplicit(DeviceAMI& ami)
 {
     if (ami.n==0) return;
-    amiScaleImplicitKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ifCoeff.data(), ami.fT.data(),
-        ami.ifCoeffC[0].data(), ami.ifCoeffC[1].data(), ami.ifCoeffC[2].data());
+    {
+        const int n = ami.n; const scalar* ifc = ami.ifCoeff.data(); const scalar* fT = ami.fT.data();
+        scalar* ic0 = ami.ifCoeffC[0].data(); scalar* ic1 = ami.ifCoeffC[1].data(); scalar* ic2 = ami.ifCoeffC[2].data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiScaleImplicitKernel(n, ifc, fT, ic0, ic1, ic2); });
+    }
     cudaCheck(cudaGetLastError(),"amiScaleImplicit");
 }
 
@@ -554,8 +618,14 @@ void deviceAmiAddDeferredRot(
     DeviceBuffer<scalar>& src)
 {
     if (ami.n==0) return;
-    amiDeferredRotKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.ifCoeff.data(), ami.fT.data(), comp,
-        uiX.data(), uiY.data(), uiZ.data(), src.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* ifc = ami.ifCoeff.data();
+        const scalar* fT = ami.fT.data(); const int compD = comp;
+        const scalar* uiXd = uiX.data(); const scalar* uiYd = uiY.data(); const scalar* uiZd = uiZ.data();
+        scalar* srcd = src.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiDeferredRotKernel(n, own, ifc, fT, compD, uiXd, uiYd, uiZd, srcd); });
+    }
     cudaCheck(cudaGetLastError(),"amiDeferredRot");
 }
 
@@ -570,8 +640,14 @@ void deviceAmiAddGradRot(
     DeviceBuffer<scalar>& gz)
 {
     if (ami.n==0) return;
-    amiGradRotKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.weights.data(), Uown.data(), UNbr.data(),
-        ami.Sfx.data(), ami.Sfy.data(), ami.Sfz.data(), V.data(), gx.data(), gy.data(), gz.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* w = ami.weights.data();
+        const scalar* Uownd = Uown.data(); const scalar* UNbrd = UNbr.data();
+        const scalar* sfx = ami.Sfx.data(); const scalar* sfy = ami.Sfy.data(); const scalar* sfz = ami.Sfz.data();
+        const scalar* Vd = V.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiGradRotKernel(n, own, w, Uownd, UNbrd, sfx, sfy, sfz, Vd, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(),"amiGradRot");
 }
 
@@ -585,9 +661,16 @@ void deviceAmiAddTensorDiv(
     DeviceBuffer<scalar>& srcZ)
 {
     if (ami.n==0) return;
-    amiTensorDivKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(),
-        ami.weight.data(), ami.weights.data(), ami.Sfx.data(), ami.Sfy.data(), ami.Sfz.data(),
-        sigmaC.data(), nC, ami.rotational?ami.fT.data():nullptr, ami.rotational?1:0, srcX.data(), srcY.data(), srcZ.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* wf = ami.weights.data();
+        const scalar* sfx = ami.Sfx.data(); const scalar* sfy = ami.Sfy.data(); const scalar* sfz = ami.Sfz.data();
+        const scalar* sigmaCd = sigmaC.data(); const int nCd = nC;
+        const scalar* fT = ami.rotational ? ami.fT.data() : nullptr; const int rot = ami.rotational ? 1 : 0;
+        scalar* dXd = srcX.data(); scalar* dYd = srcY.data(); scalar* dZd = srcZ.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiTensorDivKernel(n, own, off, nbr, w, wf, sfx, sfy, sfz, sigmaCd, nCd, fT, rot, dXd, dYd, dZd); });
+    }
     cudaCheck(cudaGetLastError(),"amiTensorDiv");
 }
 
@@ -597,7 +680,12 @@ void deviceAmiCorrectFlux(DeviceAMI& ami, const DeviceBuffer<scalar>& p)
     if (ami.n==0) return;
     DeviceBuffer<scalar> pN;
     deviceAmiInterpolate(ami, p, pN);
-    amiFluxCorrKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.ifCoeff.data(), pN.data(), p.data(), ami.phi.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* ifc = ami.ifCoeff.data();
+        const scalar* pNd = pN.data(); const scalar* pd = p.data(); scalar* phid = ami.phi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiFluxCorrKernel(n, own, ifc, pNd, pd, phid); });
+    }
     cudaCheck(cudaGetLastError(),"amiFluxCorr");
 }
 
@@ -606,8 +694,12 @@ void deviceAmiInterpolate(const DeviceAMI& ami, const DeviceBuffer<scalar>& psi,
 {
     if (ami.n == 0) return;
     out.resize(ami.n);
-    amiInterpKernel<<<nBlocks(ami.n), TPB>>>(ami.n, ami.off.data(), ami.nbrCell.data(), ami.weight.data(),
-                                             psi.data(), out.data());
+    {
+        const int n = ami.n; const label* off = ami.off.data(); const label* nbr = ami.nbrCell.data();
+        const scalar* w = ami.weight.data(); const scalar* psid = psi.data(); scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiInterpKernel(n, off, nbr, w, psid, outd); });
+    }
     cudaCheck(cudaGetLastError(), "amiInterp");
 }
 
@@ -623,15 +715,21 @@ void deviceAmiInterpolateVec(
 {
     if (ami.n == 0) return;
     oX.resize(ami.n); oY.resize(ami.n); oZ.resize(ami.n);
-    amiInterpVecKernel<<<nBlocks(ami.n), TPB>>>(ami.n, ami.off.data(), ami.nbrCell.data(), ami.weight.data(),
-        Ux.data(), Uy.data(), Uz.data(), ami.rotational ? ami.fT.data() : nullptr, ami.rotational ? 1 : 0,
-        oX.data(), oY.data(), oZ.data());
+    {
+        const int n = ami.n; const label* off = ami.off.data(); const label* nbr = ami.nbrCell.data();
+        const scalar* w = ami.weight.data();
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        const scalar* fT = ami.rotational ? ami.fT.data() : nullptr; const int rot = ami.rotational ? 1 : 0;
+        scalar* oXd = oX.data(); scalar* oYd = oY.data(); scalar* oZd = oZ.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiInterpVecKernel(n, off, nbr, w, Uxd, Uyd, Uzd, fT, rot, oXd, oYd, oZd); });
+    }
     cudaCheck(cudaGetLastError(), "amiInterpVec");
 }
 
 
 namespace {
-__global__
+__device__
 void amiLinUpwindKernel(
     int n,
     const label* __restrict__ own,
@@ -690,7 +788,7 @@ void amiLinUpwindKernel(
 }
 
 
-__global__
+__device__
 void amiLapCorrKernel(
     int n,
     const label* __restrict__ own,
@@ -760,7 +858,7 @@ void amiLapCorrKernel(
 }
 
 
-__global__
+__device__
 void amiLapCorrPKernel(
     int n,
     const label* __restrict__ own,
@@ -803,10 +901,20 @@ void deviceAmiAddLinUpwindCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (ami.n==0) return;
-    amiLinUpwindKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(),
-        ami.weight.data(), ami.phi.data(), gUx[0].data(),gUy[0].data(),gUz[0].data(), gUx[1].data(),gUy[1].data(),gUz[1].data(),
-        gUx[2].data(),gUy[2].data(),gUz[2].data(), ami.dOwnX.data(),ami.dOwnY.data(),ami.dOwnZ.data(),
-        ami.dNbrX.data(),ami.dNbrY.data(),ami.dNbrZ.data(), ami.rotational?ami.fT.data():nullptr, ami.rotational?1:0, comp, corr.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* phi = ami.phi.data();
+        const scalar* gx0 = gUx[0].data(); const scalar* gy0 = gUy[0].data(); const scalar* gz0 = gUz[0].data();
+        const scalar* gx1 = gUx[1].data(); const scalar* gy1 = gUy[1].data(); const scalar* gz1 = gUz[1].data();
+        const scalar* gx2 = gUx[2].data(); const scalar* gy2 = gUy[2].data(); const scalar* gz2 = gUz[2].data();
+        const scalar* dox = ami.dOwnX.data(); const scalar* doy = ami.dOwnY.data(); const scalar* doz = ami.dOwnZ.data();
+        const scalar* dnx = ami.dNbrX.data(); const scalar* dny = ami.dNbrY.data(); const scalar* dnz = ami.dNbrZ.data();
+        const scalar* fT = ami.rotational ? ami.fT.data() : nullptr; const int rot = ami.rotational ? 1 : 0;
+        const int compD = comp; scalar* corrd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLinUpwindKernel(n, own, off, nbr, w, phi, gx0, gy0, gz0, gx1, gy1, gz1, gx2, gy2, gz2,
+                                dox, doy, doz, dnx, dny, dnz, fT, rot, compD, corrd); });
+    }
     cudaCheck(cudaGetLastError(),"amiLinUpwind");
 }
 
@@ -822,10 +930,17 @@ void deviceAmiAddLinUpwindCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (ami.n==0) return;
-    amiLinUpwindKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(),
-        ami.weight.data(), ami.phi.data(), gx.data(),gy.data(),gz.data(), gx.data(),gy.data(),gz.data(),
-        gx.data(),gy.data(),gz.data(), ami.dOwnX.data(),ami.dOwnY.data(),ami.dOwnZ.data(),
-        ami.dNbrX.data(),ami.dNbrY.data(),ami.dNbrZ.data(), nullptr, 0, 0, corr.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* phi = ami.phi.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        const scalar* dox = ami.dOwnX.data(); const scalar* doy = ami.dOwnY.data(); const scalar* doz = ami.dOwnZ.data();
+        const scalar* dnx = ami.dNbrX.data(); const scalar* dny = ami.dNbrY.data(); const scalar* dnz = ami.dNbrZ.data();
+        scalar* corrd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLinUpwindKernel(n, own, off, nbr, w, phi, gxd, gyd, gzd, gxd, gyd, gzd, gxd, gyd, gzd,
+                                dox, doy, doz, dnx, dny, dnz, nullptr, 0, 0, corrd); });
+    }
     cudaCheck(cudaGetLastError(),"amiLinUpwindScalar");
 }
 
@@ -842,10 +957,20 @@ void deviceAmiAddLapCorr(
     if (ami.n==0) return;
     DeviceBuffer<scalar> nuN;
     deviceAmiInterpolate(ami, gammaCell, nuN);
-    amiLapCorrKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(), ami.weight.data(),
-        ami.weights.data(), gammaCell.data(), nuN.data(), ami.magSf.data(), ami.corrVecX.data(),ami.corrVecY.data(),ami.corrVecZ.data(),
-        gUx[0].data(),gUy[0].data(),gUz[0].data(), gUx[1].data(),gUy[1].data(),gUz[1].data(), gUx[2].data(),gUy[2].data(),gUz[2].data(),
-        ami.rotational?ami.fT.data():nullptr, ami.rotational?1:0, comp, corr.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* wf = ami.weights.data();
+        const scalar* ga = gammaCell.data(); const scalar* gaN = nuN.data(); const scalar* magSf = ami.magSf.data();
+        const scalar* cvx = ami.corrVecX.data(); const scalar* cvy = ami.corrVecY.data(); const scalar* cvz = ami.corrVecZ.data();
+        const scalar* gx0 = gUx[0].data(); const scalar* gy0 = gUy[0].data(); const scalar* gz0 = gUz[0].data();
+        const scalar* gx1 = gUx[1].data(); const scalar* gy1 = gUy[1].data(); const scalar* gz1 = gUz[1].data();
+        const scalar* gx2 = gUx[2].data(); const scalar* gy2 = gUy[2].data(); const scalar* gz2 = gUz[2].data();
+        const scalar* fT = ami.rotational ? ami.fT.data() : nullptr; const int rot = ami.rotational ? 1 : 0;
+        const int compD = comp; scalar* srcd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLapCorrKernel(n, own, off, nbr, w, wf, ga, gaN, magSf, cvx, cvy, cvz,
+                              gx0, gy0, gz0, gx1, gy1, gz1, gx2, gy2, gz2, fT, rot, compD, srcd); });
+    }
     cudaCheck(cudaGetLastError(),"amiLapCorr");
 }
 
@@ -861,10 +986,17 @@ void deviceAmiAddLapCorr(
     if (ami.n==0) return;
     DeviceBuffer<scalar> nuN;
     deviceAmiInterpolate(ami, gammaCell, nuN);
-    amiLapCorrKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.off.data(), ami.nbrCell.data(), ami.weight.data(),
-        ami.weights.data(), gammaCell.data(), nuN.data(), ami.magSf.data(), ami.corrVecX.data(),ami.corrVecY.data(),ami.corrVecZ.data(),
-        gx.data(),gy.data(),gz.data(), gx.data(),gy.data(),gz.data(), gx.data(),gy.data(),gz.data(),
-        nullptr, 0, 0, corr.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const label* off = ami.off.data();
+        const label* nbr = ami.nbrCell.data(); const scalar* w = ami.weight.data(); const scalar* wf = ami.weights.data();
+        const scalar* ga = gammaCell.data(); const scalar* gaN = nuN.data(); const scalar* magSf = ami.magSf.data();
+        const scalar* cvx = ami.corrVecX.data(); const scalar* cvy = ami.corrVecY.data(); const scalar* cvz = ami.corrVecZ.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* srcd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLapCorrKernel(n, own, off, nbr, w, wf, ga, gaN, magSf, cvx, cvy, cvz,
+                              gxd, gyd, gzd, gxd, gyd, gzd, gxd, gyd, gzd, nullptr, 0, 0, srcd); });
+    }
     cudaCheck(cudaGetLastError(),"amiLapCorrScalar");
 }
 
@@ -883,9 +1015,16 @@ void deviceAmiLapCorrP(
     DeviceBuffer<scalar> gaN, gxN, gyN, gzN;
     deviceAmiInterpolate(ami, gammaCell, gaN); deviceAmiInterpolate(ami, gx, gxN);
     deviceAmiInterpolate(ami, gy, gyN); deviceAmiInterpolate(ami, gz, gzN);
-    amiLapCorrPKernel<<<nBlocks(ami.n),TPB>>>(ami.n, ami.ownCell.data(), ami.weights.data(), gammaCell.data(), gaN.data(),
-        ami.magSf.data(), ami.corrVecX.data(),ami.corrVecY.data(),ami.corrVecZ.data(), gx.data(),gy.data(),gz.data(),
-        gxN.data(),gyN.data(),gzN.data(), bp.data(), ffcOut.data());
+    {
+        const int n = ami.n; const label* own = ami.ownCell.data(); const scalar* wf = ami.weights.data();
+        const scalar* ga = gammaCell.data(); const scalar* gaNd = gaN.data(); const scalar* magSf = ami.magSf.data();
+        const scalar* cvx = ami.corrVecX.data(); const scalar* cvy = ami.corrVecY.data(); const scalar* cvz = ami.corrVecZ.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        const scalar* gxNd = gxN.data(); const scalar* gyNd = gyN.data(); const scalar* gzNd = gzN.data();
+        scalar* bpd = bp.data(); scalar* ffcOutd = ffcOut.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            amiLapCorrPKernel(n, own, wf, ga, gaNd, magSf, cvx, cvy, cvz, gxd, gyd, gzd, gxNd, gyNd, gzNd, bpd, ffcOutd); });
+    }
     cudaCheck(cudaGetLastError(),"amiLapCorrP");
 }
 

--- a/src/cuda/device_boundary_assembly.cu
+++ b/src/cuda/device_boundary_assembly.cu
@@ -3,6 +3,7 @@
 // per boundary face; the BC category (bcType) selects the formula. Split from device_boundary.cu (the per-iteration
 // flow-BC value updates are in device_boundary_flow.cu). Shared internal decls: device_boundary.cuh.
 #include "device_boundary.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -12,7 +13,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void bcValueKernel(
     int n,
     const label* __restrict__ type,
@@ -47,7 +48,7 @@ void bcValueKernel(
 
 // mixed-aware laplacian gradient weight: w = vf (fixedValue vf=1 -> gradIC=-dc; zeroGradient vf=0 -> 0). vf[i] is
 // read ONLY for type==5 (the ternary short-circuits), so a non-mixed boundary with no valueFraction is safe.
-__global__
+__device__
 void bcLaplacianKernel(
     int n,
     const label* __restrict__ type,
@@ -79,7 +80,7 @@ void bcLaplacianKernel(
 
 
 // same as bcLaplacianKernel but gamma is given per BOUNDARY FACE (e.g. nuEff = nu + nutkWallFunction at walls).
-__global__
+__device__
 void bcLaplacianFaceKernel(
     int n,
     const label* __restrict__ type,
@@ -106,7 +107,7 @@ void bcLaplacianFaceKernel(
 }
 
 
-__global__
+__device__
 void bcDivKernel(
     int n,
     const label* __restrict__ type,
@@ -146,7 +147,7 @@ void bcDivKernel(
 }
 
 
-__global__
+__device__
 void bcMatrixFluxKernel(
     int n,
     const label* __restrict__ fc,
@@ -164,10 +165,17 @@ void bcMatrixFluxKernel(
 void deviceBCValue(const DeviceBoundary& db, const DeviceBuffer<scalar>& internal, DeviceBuffer<scalar>& value)
 {
     value.resize(db.n);
-    bcValueKernel<<<nBlocks(db.n), TPB>>>(db.n, db.bcType.data(), db.refValue.data(), db.valueFraction.data(),
-                                          db.faceCell.data(), internal.data(),
-                                          db.refGrad.size() ? db.refGrad.data() : nullptr,
-                                          db.deltaCoeffs.data(), value.data());
+    {
+        const int n = db.n;
+        const label *type = db.bcType.data(), *fc = db.faceCell.data();
+        const scalar *ref = db.refValue.data(), *vf = db.valueFraction.data(), *internald = internal.data();
+        const scalar *rgr = db.refGrad.size() ? db.refGrad.data() : nullptr;
+        const scalar *dcv = db.deltaCoeffs.data();
+        scalar* valued = value.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            bcValueKernel(n, type, ref, vf, fc, internald, rgr, dcv, valued);
+        });
+    }
     cudaCheck(cudaGetLastError(), "bcValue");
 }
 
@@ -180,9 +188,17 @@ void deviceBCLaplacianCoeffsFace(
 {
     iC.resize(db.n);
     bC.resize(db.n);
-    bcLaplacianFaceKernel<<<nBlocks(db.n), TPB>>>(db.n, db.bcType.data(), db.refValue.data(), db.valueFraction.data(),
-                                                  db.deltaCoeffs.data(), db.magSf.data(), gammaFace.data(),
-                                                  db.refGrad.size() ? db.refGrad.data() : nullptr, iC.data(), bC.data());
+    {
+        const int n = db.n;
+        const label* type = db.bcType.data();
+        const scalar *ref = db.refValue.data(), *vf = db.valueFraction.data(), *dc = db.deltaCoeffs.data();
+        const scalar *magSf = db.magSf.data(), *gammaFaced = gammaFace.data();
+        const scalar *rgr = db.refGrad.size() ? db.refGrad.data() : nullptr;
+        scalar *iCd = iC.data(), *bCd = bC.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            bcLaplacianFaceKernel(n, type, ref, vf, dc, magSf, gammaFaced, rgr, iCd, bCd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "bcLaplacianFace");
 }
 
@@ -195,10 +211,17 @@ void deviceBCLaplacianCoeffs(
 {
     iC.resize(db.n);
     bC.resize(db.n);
-    bcLaplacianKernel<<<nBlocks(db.n), TPB>>>(db.n, db.bcType.data(), db.refValue.data(), db.valueFraction.data(),
-                                              db.deltaCoeffs.data(), db.magSf.data(), gammaCell.data(), db.faceCell.data(),
-                                              db.refGrad.size() ? db.refGrad.data() : nullptr,
-                                              iC.data(), bC.data());
+    {
+        const int n = db.n;
+        const label *type = db.bcType.data(), *fc = db.faceCell.data();
+        const scalar *ref = db.refValue.data(), *vf = db.valueFraction.data(), *dc = db.deltaCoeffs.data();
+        const scalar *magSf = db.magSf.data(), *gammaCelld = gammaCell.data();
+        const scalar *rgr = db.refGrad.size() ? db.refGrad.data() : nullptr;
+        scalar *iCd = iC.data(), *bCd = bC.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            bcLaplacianKernel(n, type, ref, vf, dc, magSf, gammaCelld, fc, rgr, iCd, bCd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "bcLaplacian");
 }
 
@@ -211,9 +234,17 @@ void deviceBCDivCoeffs(
 {
     iC.resize(db.n);
     bC.resize(db.n);
-    bcDivKernel<<<nBlocks(db.n), TPB>>>(db.n, db.bcType.data(), db.refValue.data(), db.valueFraction.data(),
-                                        db.refGrad.size() ? db.refGrad.data() : nullptr, db.deltaCoeffs.data(),
-                                        phiB.data(), iC.data(), bC.data());
+    {
+        const int n = db.n;
+        const label* type = db.bcType.data();
+        const scalar *ref = db.refValue.data(), *vf = db.valueFraction.data();
+        const scalar *rgr = db.refGrad.size() ? db.refGrad.data() : nullptr;
+        const scalar *dcv = db.deltaCoeffs.data(), *phiBd = phiB.data();
+        scalar *iCd = iC.data(), *bCd = bC.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            bcDivKernel(n, type, ref, vf, rgr, dcv, phiBd, iCd, bCd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "bcDiv");
 }
 
@@ -226,7 +257,13 @@ void deviceMatrixFluxBoundary(
     DeviceBuffer<scalar>& fluxB)
 {
     fluxB.resize(db.n);
-    bcMatrixFluxKernel<<<nBlocks(db.n), TPB>>>(db.n, db.faceCell.data(), iC.data(), bC.data(), p.data(), fluxB.data());
+    {
+        const int n = db.n;
+        const label* fc = db.faceCell.data();
+        const scalar *iCd = iC.data(), *bCd = bC.data(), *pd = p.data();
+        scalar* fluxBd = fluxB.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { bcMatrixFluxKernel(n, fc, iCd, bCd, pd, fluxBd); });
+    }
     cudaCheck(cudaGetLastError(), "bcMatrixFlux");
 }
 

--- a/src/cuda/device_boundary_flow.cu
+++ b/src/cuda/device_boundary_flow.cu
@@ -3,6 +3,7 @@
 // slip/symmetry, totalPressure, and the HbyA constraints at slip/mixed faces. Split from device_boundary.cu
 // (the BC matrix/flux contributions are in device_boundary_assembly.cu). Shared decls: device_boundary.cuh.
 #include "device_boundary.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -14,7 +15,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 // inletOutlet/outletInlet updateCoeffs: valueFraction is BINARY from the flux sign. inletOutlet -> inflow
 // (phi<0) = fixedValue; outletInlet (freestreamPressure) -> the OPPOSITE: outflow (phi>=0) = fixedValue.
-__global__
+__device__
 void ioUpdateKernel(
     int n,
     const label* __restrict__ ioMask,
@@ -34,7 +35,7 @@ void ioUpdateKernel(
 // LOCAL adjacent-cell speed (OF uses the patch |U|; the cell value ~= it and avoids the vf circularity). Using the
 // freestream |Uinf| instead is fine at a true far field but mis-scales an outlet whose speed != |Uinf|. Continuous
 // in the flow angle (not a binary switch); at grazing faces (phi~0) vf->0.5 (the Robin midpoint OF uses).
-__global__
+__device__
 void mixedUpdateKernel(
     int n,
     const label* __restrict__ maskU,
@@ -89,7 +90,7 @@ void mixedUpdateKernel(
 
 // pressureInletOutletVelocity updateCoeffs (directionMixed): per piov face, outflow -> zeroGradient (bcType 0),
 // inflow -> fixedValue (bcType 1) with refValue = n*(n.U_cell) (the normal projection; tangential refValue 0).
-__global__
+__device__
 void piovUpdateKernel(
     int n,
     const label* __restrict__ piov,
@@ -130,7 +131,7 @@ void piovUpdateKernel(
 // slip/symmetry updateCoeffs (OF basicSymmetry, general normal): per symMask face, per component k set the mixed
 // valueFraction vf_k = |n_k| and ref_k = U_c[k] - sign(n_k)*(n.U_c). The cat-5 kernels then give valueIC_k = 1-|n_k|,
 // gradIC_k = -dc*|n_k|, value = U_c - n(n.U_c), OF's symmetry coeffs. sign(0)=0 -> tangential (n_k=0) is zeroGradient.
-__global__
+__device__
 void symUpdateKernel(
     int n,
     const label* __restrict__ sym,
@@ -167,7 +168,7 @@ void symUpdateKernel(
 // (tangential projection) -> phiHbyA_b = HbyA_b.Sf = |Sf|(HbyA_b.n) = 0. The cat-5 deviceBCValue blends `ref` (built
 // from U, not HbyA), which is NOT the HbyA projection on an angled wall, so override it here. (Axis-aligned already
 // gets 0 from ref_normal=0, so this is a no-op there.)
-__global__
+__device__
 void symHbyAKernel(
     int n,
     const label* __restrict__ sym,
@@ -194,7 +195,7 @@ void symHbyAKernel(
 
 
 // at mixed faces, overwrite the HbyA boundary value with the U boundary value (constrainHbyA at fixesValue patches).
-__global__
+__device__
 void selectMixedKernel(
     int n,
     const label* __restrict__ mask,
@@ -211,7 +212,7 @@ void selectMixedKernel(
 
 
 // at inletOutlet faces, put back the zero-gradient (extrapolated) HbyA -- see deviceExtrapolateIOHbyA.
-__global__
+__device__
 void selectIOKernel(
     int n,
     const label* __restrict__ ioMask,
@@ -236,7 +237,7 @@ void selectIOKernel(
 // m2/s2 and one in Pa. Passing rhoBnd = null gives the incompressible form, bit-identical to before.
 // (OF's third branch, the high-speed isentropic form with a named psi and gamma, is NOT implemented --
 // readThermoCoeffs-style refusal happens at load rather than silently running the low-speed form.)
-__global__
+__device__
 void tpUpdateKernel(
     int n,
     const label* __restrict__ tpMask,
@@ -264,7 +265,7 @@ void tpUpdateKernel(
 // avgU is a single patch-wide scalar, computed by the caller as -mdot/dot(rhoBnd, maskedMagSf) -- the
 // mask makes that dot product exactly OF's gSum over this patch. Faces outside the patch have mask 0
 // and are left untouched.
-__global__
+__device__
 void frUpdateKernel(
     int n,
     const scalar* __restrict__ mask,
@@ -293,17 +294,21 @@ void deviceUpdateFlowRateInlet(
 {
     const int n = dbU.comp[0].n;
     if (n == 0) return;
-    frUpdateKernel<<<nBlocks(n), TPB>>>(n, maskMagSf.data(), avgU, nx.data(), ny.data(), nz.data(),
-                                        dbU.comp[0].refValue.data(),
-                                        dbU.comp[1].refValue.data(),
-                                        dbU.comp[2].refValue.data());
+    const scalar* maskD = maskMagSf.data(); const scalar* nxd = nx.data(); const scalar* nyd = ny.data(); const scalar* nzd = nz.data();
+    scalar* r0 = dbU.comp[0].refValue.data(); scalar* r1 = dbU.comp[1].refValue.data(); scalar* r2 = dbU.comp[2].refValue.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        frUpdateKernel(n, maskD, avgU, nxd, nyd, nzd, r0, r1, r2); });
     cudaCheck(cudaGetLastError(), "frUpdate");
 }
 
 void deviceUpdateInletOutlet(DeviceBoundary& db, const DeviceBuffer<scalar>& phiBnd)
 {
     if (db.n == 0) return;
-    ioUpdateKernel<<<nBlocks(db.n), TPB>>>(db.n, db.ioMask.data(), db.oioMask.data(), phiBnd.data(), db.bcType.data());
+    const int n = db.n;
+    const label* ioMask = db.ioMask.data(); const label* oioMask = db.oioMask.data();
+    const scalar* phiBd = phiBnd.data(); label* bcType = db.bcType.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        ioUpdateKernel(n, ioMask, oioMask, phiBd, bcType); });
     cudaCheck(cudaGetLastError(), "ioUpdate");
 }
 
@@ -325,14 +330,19 @@ void deviceUpdateMixedFreestream(
     deviceBCValue(dbU.comp[0], Ux, ub0);
     deviceBCValue(dbU.comp[1], Uy, ub1);
     deviceBCValue(dbU.comp[2], Uz, ub2);
-    mixedUpdateKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].mixedMask.data(), dbP.mixedMask.data(), dbP.faceCell.data(),
-                                           phiBnd.data(), dbP.magSf.data(),
-                                           (rhoBnd && rhoBnd->size() == static_cast<std::size_t>(n)) ? rhoBnd->data() : nullptr,
-                                           Ux.data(), Uy.data(), Uz.data(),
-                                           ub0.data(), ub1.data(), ub2.data(),
-                                           dbU.nx.data(), dbU.ny.data(), dbU.nz.data(),
-                                           dbU.comp[0].valueFraction.data(), dbU.comp[1].valueFraction.data(),
-                                           dbU.comp[2].valueFraction.data(), dbP.valueFraction.data());
+    {
+        const label* maskU = dbU.comp[0].mixedMask.data(); const label* maskP = dbP.mixedMask.data();
+        const label* fc = dbP.faceCell.data(); const scalar* phiBd = phiBnd.data(); const scalar* magSf = dbP.magSf.data();
+        const scalar* rhoBndD = (rhoBnd && rhoBnd->size() == static_cast<std::size_t>(n)) ? rhoBnd->data() : nullptr;
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        const scalar* ub0d = ub0.data(); const scalar* ub1d = ub1.data(); const scalar* ub2d = ub2.data();
+        const scalar* nxd = dbU.nx.data(); const scalar* nyd = dbU.ny.data(); const scalar* nzd = dbU.nz.data();
+        scalar* vfU0 = dbU.comp[0].valueFraction.data(); scalar* vfU1 = dbU.comp[1].valueFraction.data();
+        scalar* vfU2 = dbU.comp[2].valueFraction.data(); scalar* vfP = dbP.valueFraction.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            mixedUpdateKernel(n, maskU, maskP, fc, phiBd, magSf, rhoBndD, Uxd, Uyd, Uzd,
+                               ub0d, ub1d, ub2d, nxd, nyd, nzd, vfU0, vfU1, vfU2, vfP); });
+    }
     cudaCheck(cudaGetLastError(), "mixedUpdate");
 }
 
@@ -346,10 +356,16 @@ void deviceUpdatePressureInletOutletVelocity(
 {
     const int n = dbU.n;
     if (n == 0) return;
-    piovUpdateKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].piovMask.data(), dbU.comp[0].faceCell.data(), phiBnd.data(),
-                                          dbU.nx.data(), dbU.ny.data(), dbU.nz.data(), Ux.data(), Uy.data(), Uz.data(),
-                                          dbU.comp[0].bcType.data(), dbU.comp[1].bcType.data(), dbU.comp[2].bcType.data(),
-                                          dbU.comp[0].refValue.data(), dbU.comp[1].refValue.data(), dbU.comp[2].refValue.data());
+    {
+        const label* piov = dbU.comp[0].piovMask.data(); const label* fc = dbU.comp[0].faceCell.data();
+        const scalar* phiBd = phiBnd.data();
+        const scalar* nxd = dbU.nx.data(); const scalar* nyd = dbU.ny.data(); const scalar* nzd = dbU.nz.data();
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        label* ty0 = dbU.comp[0].bcType.data(); label* ty1 = dbU.comp[1].bcType.data(); label* ty2 = dbU.comp[2].bcType.data();
+        scalar* r0 = dbU.comp[0].refValue.data(); scalar* r1 = dbU.comp[1].refValue.data(); scalar* r2 = dbU.comp[2].refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            piovUpdateKernel(n, piov, fc, phiBd, nxd, nyd, nzd, Uxd, Uyd, Uzd, ty0, ty1, ty2, r0, r1, r2); });
+    }
     cudaCheck(cudaGetLastError(), "piovUpdate");
 }
 
@@ -362,7 +378,7 @@ void deviceUpdatePressureInletOutletVelocity(
 // d_k is exactly zero on the AXIS component -- the rotation leaves it alone -- and there the blend is
 // already pure zeroGradient, which equals target_k, so ref_k is multiplied by zero and left at zero
 // rather than divided by it.
-__global__
+__device__
 void wedgeUpdateKernel(
     int n,
     const label* __restrict__ wdg,
@@ -397,13 +413,16 @@ void deviceUpdateWedge(DeviceVectorBoundary& dbU, const DeviceBuffer<scalar>& Ux
 {
     const int n = dbU.n;
     if (n == 0 || dbU.comp[0].wedgeMask.size() == 0) return;
-    wedgeUpdateKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].wedgeMask.data(), dbU.comp[0].faceCell.data(),
-                                           dbU.comp[0].wedgeT.data(),
-                                           dbU.comp[0].valueFraction.data(), dbU.comp[1].valueFraction.data(),
-                                           dbU.comp[2].valueFraction.data(),
-                                           Ux.data(), Uy.data(), Uz.data(),
-                                           dbU.comp[0].refValue.data(), dbU.comp[1].refValue.data(),
-                                           dbU.comp[2].refValue.data());
+    {
+        const label* wdg = dbU.comp[0].wedgeMask.data(); const label* fc = dbU.comp[0].faceCell.data();
+        const scalar* T = dbU.comp[0].wedgeT.data();
+        const scalar* vf0 = dbU.comp[0].valueFraction.data(); const scalar* vf1 = dbU.comp[1].valueFraction.data();
+        const scalar* vf2 = dbU.comp[2].valueFraction.data();
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        scalar* r0 = dbU.comp[0].refValue.data(); scalar* r1 = dbU.comp[1].refValue.data(); scalar* r2 = dbU.comp[2].refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            wedgeUpdateKernel(n, wdg, fc, T, vf0, vf1, vf2, Uxd, Uyd, Uzd, r0, r1, r2); });
+    }
     cudaCheck(cudaGetLastError(), "updateWedge");
 }
 
@@ -416,7 +435,7 @@ namespace {
 // through the wedge plane is then identically zero. Evaluating HbyA through U's refValue instead leaves a
 // residual (faceT & U_c) - (faceT & HbyA_c) on every wedge face, which on movingCone's 3800 of them was a
 // net leak the pressure equation answered with a fictitious inflow at the open end.
-__global__
+__device__
 void wedgeFaceValueKernel(
     int n,
     const label* __restrict__ wdg,
@@ -447,9 +466,14 @@ void deviceWedgeFaceValue(
 {
     const int n = dbU.n;
     if (n == 0 || dbU.comp[0].wedgeMask.size() == 0) return;
-    wedgeFaceValueKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].wedgeMask.data(), dbU.comp[0].faceCell.data(),
-                                              dbU.comp[0].wedgeT.data(), fx.data(), fy.data(), fz.data(),
-                                              bx.data(), by.data(), bz.data());
+    {
+        const label* wdg = dbU.comp[0].wedgeMask.data(); const label* fc = dbU.comp[0].faceCell.data();
+        const scalar* T = dbU.comp[0].wedgeT.data();
+        const scalar* fxd = fx.data(); const scalar* fyd = fy.data(); const scalar* fzd = fz.data();
+        scalar* bxd = bx.data(); scalar* byd = by.data(); scalar* bzd = bz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            wedgeFaceValueKernel(n, wdg, fc, T, fxd, fyd, fzd, bxd, byd, bzd); });
+    }
     cudaCheck(cudaGetLastError(), "wedgeFaceValue");
 }
 
@@ -459,7 +483,7 @@ namespace {
 // adjustPhi mask, which is already !fixesValue() over the same face order -- so the faces to overwrite
 // are exactly the zeros. Kept as its own kernel rather than folded into the flux computation: the
 // unmasked faces must keep the flux the Sf&Uf remap just gave them.
-__global__
+__device__
 void selectFixedFluxKernel(int n, const label* __restrict__ adjustable,
                            const scalar* __restrict__ phiFixed, scalar* __restrict__ phiB)
 {
@@ -475,7 +499,11 @@ void deviceSelectFixedFlux(const DeviceBuffer<label>& adjustable,
 {
     const int n = static_cast<int>(phiB.size());
     if (n == 0 || static_cast<int>(adjustable.size()) != n || static_cast<int>(phiFixed.size()) != n) return;
-    selectFixedFluxKernel<<<nBlocks(n), TPB>>>(n, adjustable.data(), phiFixed.data(), phiB.data());
+    {
+        const label* adjustableD = adjustable.data(); const scalar* phiFixedD = phiFixed.data(); scalar* phiBd = phiB.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            selectFixedFluxKernel(n, adjustableD, phiFixedD, phiBd); });
+    }
     cudaCheck(cudaGetLastError(), "selectFixedFlux");
 }
 
@@ -488,10 +516,15 @@ void deviceUpdateSymmetry(
 {
     const int n = dbU.n;
     if (n == 0) return;
-    symUpdateKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].symMask.data(), dbU.comp[0].faceCell.data(),
-                                         dbU.nx.data(), dbU.ny.data(), dbU.nz.data(), Ux.data(), Uy.data(), Uz.data(),
-                                         dbU.comp[0].valueFraction.data(), dbU.comp[1].valueFraction.data(), dbU.comp[2].valueFraction.data(),
-                                         dbU.comp[0].refValue.data(), dbU.comp[1].refValue.data(), dbU.comp[2].refValue.data());
+    {
+        const label* sym = dbU.comp[0].symMask.data(); const label* fc = dbU.comp[0].faceCell.data();
+        const scalar* nxd = dbU.nx.data(); const scalar* nyd = dbU.ny.data(); const scalar* nzd = dbU.nz.data();
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        scalar* vf0 = dbU.comp[0].valueFraction.data(); scalar* vf1 = dbU.comp[1].valueFraction.data(); scalar* vf2 = dbU.comp[2].valueFraction.data();
+        scalar* r0 = dbU.comp[0].refValue.data(); scalar* r1 = dbU.comp[1].refValue.data(); scalar* r2 = dbU.comp[2].refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            symUpdateKernel(n, sym, fc, nxd, nyd, nzd, Uxd, Uyd, Uzd, vf0, vf1, vf2, r0, r1, r2); });
+    }
     cudaCheck(cudaGetLastError(), "symUpdate");
 }
 
@@ -507,9 +540,14 @@ void deviceConstrainSymmetryHbyA(
 {
     const int n = dbU.n;
     if (n == 0) return;
-    symHbyAKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].symMask.data(), dbU.comp[0].faceCell.data(),
-                                       dbU.nx.data(), dbU.ny.data(), dbU.nz.data(), Hx.data(), Hy.data(), Hz.data(),
-                                       hbx.data(), hby.data(), hbz.data());
+    {
+        const label* sym = dbU.comp[0].symMask.data(); const label* fc = dbU.comp[0].faceCell.data();
+        const scalar* nxd = dbU.nx.data(); const scalar* nyd = dbU.ny.data(); const scalar* nzd = dbU.nz.data();
+        const scalar* Hxd = Hx.data(); const scalar* Hyd = Hy.data(); const scalar* Hzd = Hz.data();
+        scalar* hbxd = hbx.data(); scalar* hbyd = hby.data(); scalar* hbzd = hbz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            symHbyAKernel(n, sym, fc, nxd, nyd, nzd, Hxd, Hyd, Hzd, hbxd, hbyd, hbzd); });
+    }
     cudaCheck(cudaGetLastError(), "constrainSymmetryHbyA");
 }
 
@@ -525,8 +563,13 @@ void deviceExtrapolateIOHbyA(
 {
     const int n = dbU.n;
     if (n == 0) return;
-    selectIOKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].ioMask.data(), extx.data(), exty.data(), extz.data(),
-                                        hbx.data(), hby.data(), hbz.data());
+    {
+        const label* ioMask = dbU.comp[0].ioMask.data();
+        const scalar* extxd = extx.data(); const scalar* extyd = exty.data(); const scalar* extzd = extz.data();
+        scalar* hbxd = hbx.data(); scalar* hbyd = hby.data(); scalar* hbzd = hbz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            selectIOKernel(n, ioMask, extxd, extyd, extzd, hbxd, hbyd, hbzd); });
+    }
     cudaCheck(cudaGetLastError(), "extrapolateIOHbyA");
 }
 
@@ -546,8 +589,13 @@ void deviceConstrainMixedHbyA(
     deviceBCValue(dbU.comp[0], Ux, ubx);
     deviceBCValue(dbU.comp[1], Uy, uby);
     deviceBCValue(dbU.comp[2], Uz, ubz);
-    selectMixedKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].mixedMask.data(), ubx.data(), uby.data(), ubz.data(),
-                                           hbx.data(), hby.data(), hbz.data());
+    {
+        const label* mask = dbU.comp[0].mixedMask.data();
+        const scalar* ubxd = ubx.data(); const scalar* ubyd = uby.data(); const scalar* ubzd = ubz.data();
+        scalar* hbxd = hbx.data(); scalar* hbyd = hby.data(); scalar* hbzd = hbz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            selectMixedKernel(n, mask, ubxd, ubyd, ubzd, hbxd, hbyd, hbzd); });
+    }
     cudaCheck(cudaGetLastError(), "constrainMixedHbyA");
 }
 
@@ -556,7 +604,7 @@ namespace {
 // patchInternalField for EVERY boundary face: out[i] = cellField[faceCell[i]]. OF's
 // fvPatchField::patchInternalField(). Small (nBndFaces), so a caller can pull it to the host and do a
 // patch-wide reduction there without moving the whole cell field.
-__global__
+__device__
 void gatherPatchInternalKernel(int n, const label* __restrict__ faceCell,
                                const scalar* __restrict__ cellField, scalar* __restrict__ out)
 {
@@ -570,7 +618,12 @@ void deviceGatherPatchInternal(const DeviceBoundary& db, const DeviceBuffer<scal
 {
     out.resize(db.n);
     if (db.n == 0) return;
-    gatherPatchInternalKernel<<<nBlocks(db.n), TPB>>>(db.n, db.faceCell.data(), cellField.data(), out.data());
+    {
+        const int n = db.n;
+        const label* fc = db.faceCell.data(); const scalar* cellFieldD = cellField.data(); scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            gatherPatchInternalKernel(n, fc, cellFieldD, outd); });
+    }
     cudaCheck(cudaGetLastError(), "gatherPatchInternal");
 }
 
@@ -584,10 +637,15 @@ void deviceUpdateTotalPressure(
     const DeviceBuffer<scalar>* rhoBnd)
 {
     if (db.n == 0) return;
-    tpUpdateKernel<<<nBlocks(db.n), TPB>>>(db.n, db.tpMask.data(), db.p0.data(), phiB.data(), Uxb.data(),
-                                           Uyb.data(), Uzb.data(),
-                                           (rhoBnd && rhoBnd->size() == static_cast<std::size_t>(db.n)) ? rhoBnd->data() : nullptr,
-                                           db.refValue.data());
+    {
+        const int n = db.n;
+        const label* tpMask = db.tpMask.data(); const scalar* p0 = db.p0.data(); const scalar* phiBd = phiB.data();
+        const scalar* Uxbd = Uxb.data(); const scalar* Uybd = Uyb.data(); const scalar* Uzbd = Uzb.data();
+        const scalar* rhoBndD = (rhoBnd && rhoBnd->size() == static_cast<std::size_t>(n)) ? rhoBnd->data() : nullptr;
+        scalar* refValueD = db.refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            tpUpdateKernel(n, tpMask, p0, phiBd, Uxbd, Uybd, Uzbd, rhoBndD, refValueD); });
+    }
     cudaCheck(cudaGetLastError(), "tpUpdate");
 }
 
@@ -597,7 +655,7 @@ namespace brae {
 namespace {
 
 // turbulentIntensityKineticEnergyInlet: refValue = 1.5*I^2*|Up|^2, from the CURRENT boundary U.
-__global__
+__device__
 void tkeInletKernel(
     int n,
     const label* __restrict__ mask,
@@ -615,7 +673,7 @@ void tkeInletKernel(
 
 // turbulentMixingLength{DissipationRate,Frequency}Inlet, from the CURRENT boundary k.
 //   epsilon: (Cmu^0.75/L)*k^1.5      omega: sqrt(k)/(Cmu^0.25*L)
-__global__
+__device__
 void mixingLengthInletKernel(
     int n,
     const label* __restrict__ mask,      // 1 = epsilon, 2 = omega
@@ -647,9 +705,13 @@ void deviceUpdateTurbulentInletK(
 {
     const int n = dbK.n;
     if (!n || !mask.size()) return;
-    tkeInletKernel<<<nBlocks(n), TPB>>>(n, mask.data(), intensity.data(),
-                                        dbU.comp[0].refValue.data(), dbU.comp[1].refValue.data(),
-                                        dbU.comp[2].refValue.data(), dbK.refValue.data());
+    {
+        const label* maskD = mask.data(); const scalar* intensityD = intensity.data();
+        const scalar* r0 = dbU.comp[0].refValue.data(); const scalar* r1 = dbU.comp[1].refValue.data();
+        const scalar* r2 = dbU.comp[2].refValue.data(); scalar* kRefD = dbK.refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            tkeInletKernel(n, maskD, intensityD, r0, r1, r2, kRefD); });
+    }
     cudaCheck(cudaGetLastError(), "tkeInlet");
 }
 
@@ -662,9 +724,13 @@ void deviceUpdateTurbulentInletSecond(
 {
     const int n = dbSecond.n;
     if (!n || !mask.size()) return;
-    mixingLengthInletKernel<<<nBlocks(n), TPB>>>(n, mask.data(), len.data(), dbK.refValue.data(),
-                                                 pow(Cmu, scalar(0.75)), pow(Cmu, scalar(0.25)),
-                                                 dbSecond.refValue.data());
+    {
+        const label* maskD = mask.data(); const scalar* lenD = len.data(); const scalar* kRefD = dbK.refValue.data();
+        const scalar cmu75 = pow(Cmu, scalar(0.75)); const scalar cmu25 = pow(Cmu, scalar(0.25));
+        scalar* sRefD = dbSecond.refValue.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            mixingLengthInletKernel(n, maskD, lenD, kRefD, cmu75, cmu25, sRefD); });
+    }
     cudaCheck(cudaGetLastError(), "mixingLengthInlet");
 }
 

--- a/src/cuda/device_coded_bc_acpp_stub.cpp
+++ b/src/cuda/device_coded_bc_acpp_stub.cpp
@@ -1,0 +1,61 @@
+// ACPP-only stand-in for device_coded_bc.cu: coded BCs JIT-compile user C++ via NVRTC, no PCUDA equivalent.
+// These stubs let brae_core link; a case using a coded BC fails loudly at runtime instead.
+#include "device_coded_bc.cuh"
+#include <stdexcept>
+
+namespace brae {
+
+namespace {
+[[noreturn]] void notSupported(const char* what)
+{
+    throw std::runtime_error(std::string("brae: coded boundary conditions (") + what +
+                              ") are not supported in the ACPP build -- no NVRTC/driver-API JIT path under "
+                              "AdaptiveCpp/PCUDA. Use the CUDA build (BRAE_BACKEND=CUDA) for coded BCs.");
+}
+} // namespace
+
+CodedBcKernel compileCodedVectorBc(const std::string&, const std::string&) { notSupported("compileCodedVectorBc"); }
+CodedBcKernel compileCodedScalarBc(const std::string&, const std::string&) { notSupported("compileCodedScalarBc"); }
+CodedBcKernel compileCodedMixedVectorBc(const std::string&, const std::string&) { notSupported("compileCodedMixedVectorBc"); }
+CodedBcKernel compileCodedMixedScalarBc(const std::string&, const std::string&) { notSupported("compileCodedMixedScalarBc"); }
+
+void launchCodedVectorBc(
+    const CodedBcKernel&, int, int, scalar,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<label>&,
+    DeviceBuffer<scalar>&, DeviceBuffer<scalar>&, DeviceBuffer<scalar>&)
+{
+    notSupported("launchCodedVectorBc");
+}
+
+void launchCodedScalarBc(
+    const CodedBcKernel&, int, int, scalar,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<label>&,
+    DeviceBuffer<scalar>&)
+{
+    notSupported("launchCodedScalarBc");
+}
+
+void launchCodedMixedVectorBc(
+    const CodedBcKernel&, int, int, scalar,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<label>&,
+    DeviceBuffer<scalar>&, DeviceBuffer<scalar>&, DeviceBuffer<scalar>&,
+    DeviceBuffer<scalar>&, DeviceBuffer<scalar>&, DeviceBuffer<scalar>&)
+{
+    notSupported("launchCodedMixedVectorBc");
+}
+
+void launchCodedMixedScalarBc(
+    const CodedBcKernel&, int, int, scalar,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&, const DeviceBuffer<scalar>&,
+    const DeviceBuffer<scalar>&, const DeviceBuffer<label>&,
+    DeviceBuffer<scalar>&, DeviceBuffer<scalar>&)
+{
+    notSupported("launchCodedMixedScalarBc");
+}
+
+} // namespace brae

--- a/src/cuda/device_cyclic.cu
+++ b/src/cuda/device_cyclic.cu
@@ -4,6 +4,7 @@
 // Sign convention matches device_fvm.cu: off-diagonal ifCoeff is added in Amul as Apsi[own]+=ifCoeff*psi[nbr];
 // diag[own] -= ifCoeff (Laplacian) / += max(phi,0) (upwind convection).
 #include "device_cyclic.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -12,7 +13,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void laplKernel(
     int n,
     const label* __restrict__ own,
@@ -35,7 +36,7 @@ void laplKernel(
 }
 
 
-__global__
+__device__
 void convKernel(
     int n,
     const label* __restrict__ own,
@@ -52,7 +53,7 @@ void convKernel(
 }
 
 
-__global__
+__device__
 void momKernel(
     int n,
     const label* __restrict__ own,
@@ -76,7 +77,7 @@ void momKernel(
 }
 
 
-__global__
+__device__
 void addHKernel(
     int n,
     const label* __restrict__ own,
@@ -93,7 +94,7 @@ void addHKernel(
 }
 
 
-__global__
+__device__
 void offSumKernel(
     int n,
     const label* __restrict__ own,
@@ -107,7 +108,7 @@ void offSumKernel(
 }
 
 
-__global__
+__device__
 void fluxKernel(
     int n,
     const label* __restrict__ own,
@@ -131,7 +132,7 @@ void fluxKernel(
 }
 
 
-__global__
+__device__
 void divAddKernel(
     int n,
     const label* __restrict__ own,
@@ -146,7 +147,7 @@ void divAddKernel(
 }
 
 
-__global__
+__device__
 void fluxCorrKernel(
     int n,
     const label* __restrict__ own,
@@ -162,7 +163,7 @@ void fluxCorrKernel(
 }
 
 
-__global__
+__device__
 void cycTensorDivKernel(
     int n,
     const label* __restrict__ own,
@@ -230,7 +231,7 @@ void cycTensorDivKernel(
 }
 
 
-__global__
+__device__
 void gradAddKernel(
     int n,
     const label* __restrict__ own,
@@ -267,7 +268,7 @@ void rotNbr(const scalar* fT, int n, int j, scalar vx, scalar vy, scalar vz,
 }
 
 
-__global__
+__device__
 void scaleImplicitKernel(
     int n,
     const scalar* __restrict__ ifc,
@@ -285,7 +286,7 @@ void scaleImplicitKernel(
 }
 
 
-__global__
+__device__
 void fluxRotKernel(
     int n,
     const label* __restrict__ own,
@@ -312,7 +313,7 @@ void fluxRotKernel(
 }
 
 
-__global__
+__device__
 void addHRotKernel(
     int n,
     const label* __restrict__ own,
@@ -340,7 +341,7 @@ void addHRotKernel(
 }
 
 
-__global__
+__device__
 void gradRotKernel(
     int n,
     const label* __restrict__ own,
@@ -374,7 +375,7 @@ void gradRotKernel(
 }
 
 
-__global__
+__device__
 void deferredRotKernel(
     int n,
     const label* __restrict__ own,
@@ -400,7 +401,7 @@ void deferredRotKernel(
 }
 
 
-__global__
+__device__
 void addHDiagKernel(
     int n,
     const label* __restrict__ own,
@@ -425,8 +426,14 @@ void deviceCyclicAssembleLaplacian(
     bool addToDiag)
 {
     if (cyc.n == 0) return;
-    laplKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), gammaCell.data(),
-        cyc.deltaCoeffs.data(), cyc.weights.data(), cyc.magSf.data(), cyc.ifCoeff.data(), diag.data(), addToDiag ? 1 : 0);
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* gamma = gammaCell.data(); const scalar* dc = cyc.deltaCoeffs.data();
+        const scalar* w = cyc.weights.data(); const scalar* magSf = cyc.magSf.data();
+        scalar* ifc = cyc.ifCoeff.data(); scalar* diagd = diag.data(); const int addD = addToDiag ? 1 : 0;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            laplKernel(n, own, nbr, gamma, dc, w, magSf, ifc, diagd, addD); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLapl");
 }
 
@@ -434,7 +441,11 @@ void deviceCyclicAssembleLaplacian(
 void deviceCyclicAddConvection(DeviceCyclic& cyc, DeviceBuffer<scalar>& diag)
 {
     if (cyc.n == 0) return;
-    convKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.phi.data(), cyc.ifCoeff.data(), diag.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const scalar* phi = cyc.phi.data();
+        scalar* ifc = cyc.ifCoeff.data(); scalar* diagd = diag.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { convKernel(n, own, phi, ifc, diagd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicConv");
 }
 
@@ -442,8 +453,14 @@ void deviceCyclicAddConvection(DeviceCyclic& cyc, DeviceBuffer<scalar>& diag)
 void deviceCyclicAssembleMomentum(DeviceCyclic& cyc, const DeviceBuffer<scalar>& nuEffCell, DeviceBuffer<scalar>& diag)
 {
     if (cyc.n == 0) return;
-    momKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), nuEffCell.data(),
-        cyc.deltaCoeffs.data(), cyc.weights.data(), cyc.magSf.data(), cyc.phi.data(), cyc.ifCoeff.data(), diag.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* nu = nuEffCell.data(); const scalar* dc = cyc.deltaCoeffs.data();
+        const scalar* w = cyc.weights.data(); const scalar* magSf = cyc.magSf.data(); const scalar* phi = cyc.phi.data();
+        scalar* ifc = cyc.ifCoeff.data(); scalar* diagd = diag.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            momKernel(n, own, nbr, nu, dc, w, magSf, phi, ifc, diagd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicMom");
 }
 
@@ -455,8 +472,12 @@ void deviceCyclicAddH(
     DeviceBuffer<scalar>& H)
 {
     if (cyc.n == 0) return;
-    addHKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.ifCoeff.data(),
-        psi.data(), V.data(), H.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* ifc = cyc.ifCoeff.data(); const scalar* psid = psi.data(); const scalar* Vd = V.data();
+        scalar* Hd = H.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { addHKernel(n, own, nbr, ifc, psid, Vd, Hd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicAddH");
 }
 
@@ -464,7 +485,11 @@ void deviceCyclicAddH(
 void deviceCyclicOffDiagSum(const DeviceCyclic& cyc, DeviceBuffer<scalar>& sumOff)
 {
     if (cyc.n == 0) return;
-    offSumKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.ifCoeff.data(), sumOff.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const scalar* ifc = cyc.ifCoeff.data();
+        scalar* sumOffd = sumOff.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { offSumKernel(n, own, ifc, sumOffd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicOffSum");
 }
 
@@ -476,8 +501,15 @@ void deviceCyclicFlux(
     const DeviceBuffer<scalar>& Hz)
 {
     if (cyc.n == 0) return;
-    fluxKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.weights.data(),
-        Hx.data(), Hy.data(), Hz.data(), cyc.Sfx.data(), cyc.Sfy.data(), cyc.Sfz.data(), cyc.phi.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data();
+        const scalar* Hxd = Hx.data(); const scalar* Hyd = Hy.data(); const scalar* Hzd = Hz.data();
+        const scalar* sfx = cyc.Sfx.data(); const scalar* sfy = cyc.Sfy.data(); const scalar* sfz = cyc.Sfz.data();
+        scalar* phid = cyc.phi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            fluxKernel(n, own, nbr, w, Hxd, Hyd, Hzd, sfx, sfy, sfz, phid); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicFlux");
 }
 
@@ -485,13 +517,17 @@ void deviceCyclicFlux(
 void deviceCyclicAddDiv(const DeviceCyclic& cyc, const DeviceBuffer<scalar>& V, DeviceBuffer<scalar>& div)
 {
     if (cyc.n == 0) return;
-    divAddKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.phi.data(), V.data(), div.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const scalar* phi = cyc.phi.data();
+        const scalar* Vd = V.data(); scalar* divd = div.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { divAddKernel(n, own, phi, Vd, divd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicDiv");
 }
 
 
 namespace {
-__global__
+__device__
 void cycZeroWallKernel(int n, const label* __restrict__ own, const label* __restrict__ isW, scalar* __restrict__ ifc)
 {
     const int j = blockIdx.x*blockDim.x+threadIdx.x;
@@ -504,7 +540,11 @@ void cycZeroWallKernel(int n, const label* __restrict__ own, const label* __rest
 void deviceCyclicZeroWallIfCoeff(DeviceCyclic& cyc, const DeviceBuffer<label>& isWallCell)
 {
     if (cyc.n == 0) return;
-    cycZeroWallKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), isWallCell.data(), cyc.ifCoeff.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* isW = isWallCell.data();
+        scalar* ifc = cyc.ifCoeff.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { cycZeroWallKernel(n, own, isW, ifc); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicZeroWall");
 }
 
@@ -512,8 +552,11 @@ void deviceCyclicZeroWallIfCoeff(DeviceCyclic& cyc, const DeviceBuffer<label>& i
 void deviceCyclicCorrectFlux(DeviceCyclic& cyc, const DeviceBuffer<scalar>& p)
 {
     if (cyc.n == 0) return;
-    fluxCorrKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.ifCoeff.data(),
-        p.data(), cyc.phi.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* ifc = cyc.ifCoeff.data(); const scalar* pd = p.data(); scalar* phid = cyc.phi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { fluxCorrKernel(n, own, nbr, ifc, pd, phid); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicFluxCorr");
 }
 
@@ -521,7 +564,7 @@ void deviceCyclicCorrectFlux(DeviceCyclic& cyc, const DeviceBuffer<scalar>& p)
 namespace {
 // face value of a CELL field on a cyclic face: w*psi[own] + (1-w)*psi[nbr] -- fvc::interpolate on a
 // coupled patch, the 1:1 counterpart of deviceAmiFaceValue.
-__global__
+__device__
 void cyclicFaceValueKernel(int n, const label* __restrict__ own, const label* __restrict__ nbr,
                            const scalar* __restrict__ w, const scalar* __restrict__ cell,
                            scalar* __restrict__ out)
@@ -536,7 +579,7 @@ namespace {
 // The RAW periodic-neighbour value per cyclic face -- OF's patchNeighbourField(), not a face
 // interpolation. cellLimitedGrad needs it to fold the coupled neighbour into a cell's min/max range.
 // Rotational: the neighbour vector is rotated by forwardT first, so component `comp` mixes all three.
-__global__
+__device__
 void cyclicNbrValueKernel(int n, const label* __restrict__ nbr, const scalar* __restrict__ cell,
                           const scalar* __restrict__ c0, const scalar* __restrict__ c1,
                           const scalar* __restrict__ c2, const scalar* __restrict__ fT,
@@ -557,9 +600,15 @@ void deviceCyclicNbrValue(const DeviceCyclic& cyc, const DeviceBuffer<scalar>& c
     out.resize(cyc.n);
     if (cyc.n == 0) return;
     const bool rot = cyc.rotational && c0.size() && c1.size() && c2.size();
-    cyclicNbrValueKernel<<<nBlocks(cyc.n),TPB>>>(cyc.n, cyc.nbrCell.data(), cell.data(),
-        rot ? c0.data() : nullptr, rot ? c1.data() : nullptr, rot ? c2.data() : nullptr,
-        cyc.rotational ? cyc.fT.data() : nullptr, cyc.rotational ? 1 : 0, comp, out.data());
+    {
+        const int n = cyc.n; const label* nbr = cyc.nbrCell.data(); const scalar* celld = cell.data();
+        const scalar* c0d = rot ? c0.data() : nullptr; const scalar* c1d = rot ? c1.data() : nullptr;
+        const scalar* c2d = rot ? c2.data() : nullptr;
+        const scalar* fT = cyc.rotational ? cyc.fT.data() : nullptr; const int rotD = cyc.rotational ? 1 : 0;
+        const int compD = comp; scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cyclicNbrValueKernel(n, nbr, celld, c0d, c1d, c2d, fT, rotD, compD, outd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicNbrValue");
 }
 
@@ -568,8 +617,12 @@ void deviceCyclicFaceValue(const DeviceCyclic& cyc, const DeviceBuffer<scalar>& 
 {
     out.resize(cyc.n);
     if (cyc.n == 0) return;
-    cyclicFaceValueKernel<<<nBlocks(cyc.n),TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(),
-                                                  cyc.weights.data(), cell.data(), out.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data(); const scalar* celld = cell.data(); scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cyclicFaceValueKernel(n, own, nbr, w, celld, outd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicFaceValue");
 }
 
@@ -583,8 +636,14 @@ void deviceCyclicAddGrad(
     DeviceBuffer<scalar>& gz)
 {
     if (cyc.n == 0) return;
-    gradAddKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.weights.data(),
-        psi.data(), cyc.Sfx.data(), cyc.Sfy.data(), cyc.Sfz.data(), V.data(), gx.data(), gy.data(), gz.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data(); const scalar* psid = psi.data();
+        const scalar* sfx = cyc.Sfx.data(); const scalar* sfy = cyc.Sfy.data(); const scalar* sfz = cyc.Sfz.data();
+        const scalar* Vd = V.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            gradAddKernel(n, own, nbr, w, psid, sfx, sfy, sfz, Vd, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicGrad");
 }
 
@@ -592,8 +651,12 @@ void deviceCyclicAddGrad(
 void deviceCyclicScaleImplicit(DeviceCyclic& cyc)
 {
     if (cyc.n == 0) return;
-    scaleImplicitKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ifCoeff.data(), cyc.fT.data(),
-        cyc.ifCoeffC[0].data(), cyc.ifCoeffC[1].data(), cyc.ifCoeffC[2].data());
+    {
+        const int n = cyc.n; const scalar* ifc = cyc.ifCoeff.data(); const scalar* fT = cyc.fT.data();
+        scalar* ic0 = cyc.ifCoeffC[0].data(); scalar* ic1 = cyc.ifCoeffC[1].data(); scalar* ic2 = cyc.ifCoeffC[2].data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            scaleImplicitKernel(n, ifc, fT, ic0, ic1, ic2); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicScaleImplicit");
 }
 
@@ -605,8 +668,16 @@ void deviceCyclicFluxRot(
     const DeviceBuffer<scalar>& Hz)
 {
     if (cyc.n == 0) return;
-    fluxRotKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.weights.data(),
-        Hx.data(), Hy.data(), Hz.data(), cyc.fT.data(), cyc.Sfx.data(), cyc.Sfy.data(), cyc.Sfz.data(), cyc.phi.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data();
+        const scalar* Hxd = Hx.data(); const scalar* Hyd = Hy.data(); const scalar* Hzd = Hz.data();
+        const scalar* fT = cyc.fT.data();
+        const scalar* sfx = cyc.Sfx.data(); const scalar* sfy = cyc.Sfy.data(); const scalar* sfz = cyc.Sfz.data();
+        scalar* phid = cyc.phi.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            fluxRotKernel(n, own, nbr, w, Hxd, Hyd, Hzd, fT, sfx, sfy, sfz, phid); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicFluxRot");
 }
 
@@ -622,8 +693,14 @@ void deviceCyclicAddHRot(
     DeviceBuffer<scalar>& Hz)
 {
     if (cyc.n == 0) return;
-    addHRotKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.ifCoeff.data(),
-        cyc.fT.data(), Ux.data(), Uy.data(), Uz.data(), V.data(), Hx.data(), Hy.data(), Hz.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* ifc = cyc.ifCoeff.data(); const scalar* fT = cyc.fT.data();
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        const scalar* Vd = V.data(); scalar* Hxd = Hx.data(); scalar* Hyd = Hy.data(); scalar* Hzd = Hz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            addHRotKernel(n, own, nbr, ifc, fT, Uxd, Uyd, Uzd, Vd, Hxd, Hyd, Hzd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicAddHRot");
 }
 
@@ -640,9 +717,15 @@ void deviceCyclicAddGradRot(
     DeviceBuffer<scalar>& gz)
 {
     if (cyc.n == 0) return;
-    gradRotKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.weights.data(),
-        cyc.fT.data(), comp, Ux.data(), Uy.data(), Uz.data(), cyc.Sfx.data(), cyc.Sfy.data(), cyc.Sfz.data(),
-        V.data(), gx.data(), gy.data(), gz.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data(); const scalar* fT = cyc.fT.data(); const int compD = comp;
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        const scalar* sfx = cyc.Sfx.data(); const scalar* sfy = cyc.Sfy.data(); const scalar* sfz = cyc.Sfz.data();
+        const scalar* Vd = V.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            gradRotKernel(n, own, nbr, w, fT, compD, Uxd, Uyd, Uzd, sfx, sfy, sfz, Vd, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicGradRot");
 }
 
@@ -656,8 +739,14 @@ void deviceCyclicAddDeferredRot(
     DeviceBuffer<scalar>& src)
 {
     if (cyc.n == 0) return;
-    deferredRotKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.ifCoeff.data(),
-        cyc.fT.data(), comp, Ux.data(), Uy.data(), Uz.data(), src.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* ifc = cyc.ifCoeff.data(); const scalar* fT = cyc.fT.data(); const int compD = comp;
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        scalar* srcd = src.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            deferredRotKernel(n, own, nbr, ifc, fT, compD, Uxd, Uyd, Uzd, srcd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicDeferredRot");
 }
 
@@ -670,13 +759,18 @@ void deviceCyclicAddHDiag(
     DeviceBuffer<scalar>& H)
 {
     if (cyc.n == 0) return;
-    addHDiagKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.ifCoeffC[comp].data(),
-        psi.data(), V.data(), H.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* ifcC = cyc.ifCoeffC[comp].data();
+        const scalar* psid = psi.data(); const scalar* Vd = V.data(); scalar* Hd = H.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            addHDiagKernel(n, own, nbr, ifcC, psid, Vd, Hd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicAddHDiag");
 }
 
 
-__global__
+__device__
 void cycLinUpwindKernel(
     int n,
     const label* __restrict__ own,
@@ -736,11 +830,20 @@ void deviceCyclicAddLinUpwindCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (cyc.n == 0) return;
-    cycLinUpwindKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.phi.data(),
-        gUx[0].data(), gUy[0].data(), gUz[0].data(), gUx[1].data(), gUy[1].data(), gUz[1].data(),
-        gUx[2].data(), gUy[2].data(), gUz[2].data(),
-        cyc.dOwnX.data(), cyc.dOwnY.data(), cyc.dOwnZ.data(), cyc.dNbrX.data(), cyc.dNbrY.data(), cyc.dNbrZ.data(),
-        cyc.rotational ? cyc.fT.data() : nullptr, cyc.rotational ? 1 : 0, comp, corr.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* phi = cyc.phi.data();
+        const scalar* gx0 = gUx[0].data(); const scalar* gy0 = gUy[0].data(); const scalar* gz0 = gUz[0].data();
+        const scalar* gx1 = gUx[1].data(); const scalar* gy1 = gUy[1].data(); const scalar* gz1 = gUz[1].data();
+        const scalar* gx2 = gUx[2].data(); const scalar* gy2 = gUy[2].data(); const scalar* gz2 = gUz[2].data();
+        const scalar* dox = cyc.dOwnX.data(); const scalar* doy = cyc.dOwnY.data(); const scalar* doz = cyc.dOwnZ.data();
+        const scalar* dnx = cyc.dNbrX.data(); const scalar* dny = cyc.dNbrY.data(); const scalar* dnz = cyc.dNbrZ.data();
+        const scalar* fT = cyc.rotational ? cyc.fT.data() : nullptr; const int rot = cyc.rotational ? 1 : 0;
+        const int compD = comp; scalar* corrd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycLinUpwindKernel(n, own, nbr, phi, gx0, gy0, gz0, gx1, gy1, gz1, gx2, gy2, gz2,
+                                dox, doy, doz, dnx, dny, dnz, fT, rot, compD, corrd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLinUpwind");
 }
 
@@ -753,15 +856,22 @@ void deviceCyclicAddLinUpwindCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (cyc.n == 0) return;
-    cycLinUpwindKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.phi.data(),
-        gx.data(), gy.data(), gz.data(), gx.data(), gy.data(), gz.data(), gx.data(), gy.data(), gz.data(),
-        cyc.dOwnX.data(), cyc.dOwnY.data(), cyc.dOwnZ.data(), cyc.dNbrX.data(), cyc.dNbrY.data(), cyc.dNbrZ.data(),
-        nullptr, 0, 0, corr.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* phi = cyc.phi.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        const scalar* dox = cyc.dOwnX.data(); const scalar* doy = cyc.dOwnY.data(); const scalar* doz = cyc.dOwnZ.data();
+        const scalar* dnx = cyc.dNbrX.data(); const scalar* dny = cyc.dNbrY.data(); const scalar* dnz = cyc.dNbrZ.data();
+        scalar* corrd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycLinUpwindKernel(n, own, nbr, phi, gxd, gyd, gzd, gxd, gyd, gzd, gxd, gyd, gzd,
+                                dox, doy, doz, dnx, dny, dnz, nullptr, 0, 0, corrd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLinUpwindScalar");
 }
 
 
-__global__
+__device__
 void cycLapCorrKernel(
     int n,
     const label* __restrict__ own,
@@ -830,11 +940,19 @@ void deviceCyclicAddLapCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (cyc.n == 0) return;
-    cycLapCorrKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), gammaCell.data(),
-        cyc.weights.data(), cyc.magSf.data(), cyc.corrVecX.data(), cyc.corrVecY.data(), cyc.corrVecZ.data(),
-        gUx[0].data(), gUy[0].data(), gUz[0].data(), gUx[1].data(), gUy[1].data(), gUz[1].data(),
-        gUx[2].data(), gUy[2].data(), gUz[2].data(),
-        cyc.rotational ? cyc.fT.data() : nullptr, cyc.rotational ? 1 : 0, comp, corr.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* nu = gammaCell.data(); const scalar* w = cyc.weights.data(); const scalar* magSf = cyc.magSf.data();
+        const scalar* cvx = cyc.corrVecX.data(); const scalar* cvy = cyc.corrVecY.data(); const scalar* cvz = cyc.corrVecZ.data();
+        const scalar* gx0 = gUx[0].data(); const scalar* gy0 = gUy[0].data(); const scalar* gz0 = gUz[0].data();
+        const scalar* gx1 = gUx[1].data(); const scalar* gy1 = gUy[1].data(); const scalar* gz1 = gUz[1].data();
+        const scalar* gx2 = gUx[2].data(); const scalar* gy2 = gUy[2].data(); const scalar* gz2 = gUz[2].data();
+        const scalar* fT = cyc.rotational ? cyc.fT.data() : nullptr; const int rot = cyc.rotational ? 1 : 0;
+        const int compD = comp; scalar* srcd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycLapCorrKernel(n, own, nbr, nu, w, magSf, cvx, cvy, cvz,
+                              gx0, gy0, gz0, gx1, gy1, gz1, gx2, gy2, gz2, fT, rot, compD, srcd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLapCorr");
 }
 
@@ -847,15 +965,21 @@ void deviceCyclicAddLapCorr(
     DeviceBuffer<scalar>& corr)
 {
     if (cyc.n == 0) return;
-    cycLapCorrKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), gammaCell.data(),
-        cyc.weights.data(), cyc.magSf.data(), cyc.corrVecX.data(), cyc.corrVecY.data(), cyc.corrVecZ.data(),
-        gx.data(), gy.data(), gz.data(), gx.data(), gy.data(), gz.data(), gx.data(), gy.data(), gz.data(),
-        nullptr, 0, 0, corr.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* nu = gammaCell.data(); const scalar* w = cyc.weights.data(); const scalar* magSf = cyc.magSf.data();
+        const scalar* cvx = cyc.corrVecX.data(); const scalar* cvy = cyc.corrVecY.data(); const scalar* cvz = cyc.corrVecZ.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* srcd = corr.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycLapCorrKernel(n, own, nbr, nu, w, magSf, cvx, cvy, cvz,
+                              gxd, gyd, gzd, gxd, gyd, gzd, gxd, gyd, gzd, nullptr, 0, 0, srcd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLapCorrScalar");
 }
 
 
-__global__
+__device__
 void cycLapCorrScalarKernel(
     int n,
     const label* __restrict__ own,
@@ -896,9 +1020,15 @@ void deviceCyclicLapCorrP(
 {
     if (cyc.n == 0) return;
     ffcOut.resize(cyc.n);
-    cycLapCorrScalarKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), gammaCell.data(),
-        cyc.weights.data(), cyc.magSf.data(), cyc.corrVecX.data(), cyc.corrVecY.data(), cyc.corrVecZ.data(),
-        gx.data(), gy.data(), gz.data(), bp.data(), ffcOut.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* gamma = gammaCell.data(); const scalar* w = cyc.weights.data(); const scalar* magSf = cyc.magSf.data();
+        const scalar* cvx = cyc.corrVecX.data(); const scalar* cvy = cyc.corrVecY.data(); const scalar* cvz = cyc.corrVecZ.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* bpd = bp.data(); scalar* ffcOutd = ffcOut.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycLapCorrScalarKernel(n, own, nbr, gamma, w, magSf, cvx, cvy, cvz, gxd, gyd, gzd, bpd, ffcOutd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicLapCorrP");
 }
 
@@ -912,10 +1042,16 @@ void deviceCyclicAddTensorDiv(
     DeviceBuffer<scalar>& srcZ)
 {
     if (cyc.n == 0) return;
-    const scalar* fT = cyc.rotational ? cyc.fT.data() : nullptr;
-    cycTensorDivKernel<<<nBlocks(cyc.n), TPB>>>(cyc.n, cyc.ownCell.data(), cyc.nbrCell.data(), cyc.weights.data(),
-        cyc.Sfx.data(), cyc.Sfy.data(), cyc.Sfz.data(), sigmaC.data(), nC, fT, cyc.rotational ? 1 : 0,
-        srcX.data(), srcY.data(), srcZ.data());
+    {
+        const int n = cyc.n; const label* own = cyc.ownCell.data(); const label* nbr = cyc.nbrCell.data();
+        const scalar* w = cyc.weights.data();
+        const scalar* sfx = cyc.Sfx.data(); const scalar* sfy = cyc.Sfy.data(); const scalar* sfz = cyc.Sfz.data();
+        const scalar* sigmaCd = sigmaC.data(); const int nCd = nC;
+        const scalar* fT = cyc.rotational ? cyc.fT.data() : nullptr; const int rot = cyc.rotational ? 1 : 0;
+        scalar* dXd = srcX.data(); scalar* dYd = srcY.data(); scalar* dZd = srcZ.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            cycTensorDivKernel(n, own, nbr, w, sfx, sfy, sfz, sigmaCd, nCd, fT, rot, dXd, dYd, dZd); });
+    }
     cudaCheck(cudaGetLastError(), "cyclicTensorDiv");
 }
 

--- a/src/cuda/device_ddt.cu
+++ b/src/cuda/device_ddt.cu
@@ -1,5 +1,6 @@
 // Implicit transient ddt kernels -- see device_ddt.cuh for the OF-2412 correspondence + source refs.
 #include "device_ddt.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -9,7 +10,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 // diag[i] += a*V[i]   with a = coefft*rDeltaT*rho.
-__global__ void ddtDiagKernel(const scalar* __restrict__ V, int n, scalar a, scalar* __restrict__ diag)
+__device__ void ddtDiagKernel(const scalar* __restrict__ V, int n, scalar a, scalar* __restrict__ diag)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
@@ -19,7 +20,7 @@ __global__ void ddtDiagKernel(const scalar* __restrict__ V, int n, scalar a, sca
 // backward/Euler : source[i] += V[i]*(b0*old[i] - b00*old2[i])   (b0=rDeltaT*rho*coefft0, b00=rDeltaT*rho*coefft00)
 // CrankNicolson  : source[i] += V[i]*(b0*old[i] + dc*ddt0[i])    (dc=rho*ocCoeff; the ddt0 term REPLACES the old2 term)
 // old2/ddt0 may be null (Euler / bootstrap): the corresponding term is then structurally absent.
-__global__ void ddtSourceKernel(
+__device__ void ddtSourceKernel(
     const scalar* __restrict__ V, int n, scalar b0, scalar b00, scalar dc,
     const scalar* __restrict__ old, const scalar* __restrict__ old2, const scalar* __restrict__ ddt0,
     scalar* __restrict__ source)
@@ -33,7 +34,7 @@ __global__ void ddtSourceKernel(
 }
 
 // CrankNicolson ddt0 recurrence: ddt0[i] = a*(old[i] - old2[i]) - oc*ddt0[i]   with a = coefft*rDeltaT0. In place.
-__global__ void ddt0UpdateKernel(
+__device__ void ddt0UpdateKernel(
     int n, scalar a, scalar oc, const scalar* __restrict__ old, const scalar* __restrict__ old2, scalar* __restrict__ ddt0)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -47,7 +48,8 @@ void deviceFvmDdtDiag(
 {
     if (!c.active) return;                                   // steadyState / bootstrap -> no-op
     const int n = static_cast<int>(V.size());
-    ddtDiagKernel<<<nBlocks(n), TPB>>>(V.data(), n, c.coefft * c.rDeltaT * rho, diag.data());
+    const scalar* Vd = V.data(); const scalar a = c.coefft * c.rDeltaT * rho; scalar* diagd = diag.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { ddtDiagKernel(Vd, n, a, diagd); });
     cudaCheck(cudaGetLastError(), "fvmDdtDiag");
 }
 
@@ -63,7 +65,10 @@ void deviceFvmDdtSource(
     const scalar dc  = rho * c.ocCoeff;                                    // CrankNicolson ddt0 weight
     const scalar* old2p = psiOld2.size() ? psiOld2.data() : nullptr;
     const scalar* ddt0p = (c.cn && ddt0 && ddt0->size()) ? ddt0->data() : nullptr;   // CN uses ddt0, NOT old2
-    ddtSourceKernel<<<nBlocks(n), TPB>>>(V.data(), n, b0, b00, dc, psiOld.data(), old2p, ddt0p, source.data());
+    const scalar* Vd = V.data(); const scalar* psiOldd = psiOld.data(); scalar* sourced = source.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        ddtSourceKernel(Vd, n, b0, b00, dc, psiOldd, old2p, ddt0p, sourced);
+    });
     cudaCheck(cudaGetLastError(), "fvmDdtSource");
 }
 
@@ -72,7 +77,9 @@ void deviceFvmDdtUpdateDdt0(
 {
     if (!c.cn || !psiOld2.size() || !ddt0.size()) return;                  // steady/Euler/backward/first-step -> ddt0 untouched (stays 0)
     const int n = static_cast<int>(psiOld.size());
-    ddt0UpdateKernel<<<nBlocks(n), TPB>>>(n, c.coefft0dd * c.rDeltaT0, c.ocCoeff, psiOld.data(), psiOld2.data(), ddt0.data());
+    const scalar a = c.coefft0dd * c.rDeltaT0, oc = c.ocCoeff;
+    const scalar* psiOldd = psiOld.data(); const scalar* psiOld2d = psiOld2.data(); scalar* ddt0d = ddt0.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { ddt0UpdateKernel(n, a, oc, psiOldd, psiOld2d, ddt0d); });
     cudaCheck(cudaGetLastError(), "fvmDdtUpdateDdt0");
 }
 
@@ -105,7 +112,7 @@ __device__ __forceinline__ scalar ddtCorrFace(scalar phiOld, scalar fluxUold, sc
     return rAUf*coeff*rDeltaT*phiCorrEff;
 }
 
-__global__ void ddtCorrIntK(int nIf, const scalar* phiOld, const scalar* fluxUold, const scalar* rAUf,
+__device__ void ddtCorrIntK(int nIf, const scalar* phiOld, const scalar* fluxUold, const scalar* rAUf,
                             const scalar* phiCorrEff, scalar rDeltaT, scalar* out)
 {
     const int f = blockIdx.x*blockDim.x + threadIdx.x;
@@ -114,7 +121,7 @@ __global__ void ddtCorrIntK(int nIf, const scalar* phiOld, const scalar* fluxUol
     out[f] += ddtCorrFace(phiOld[f], fluxUold[f], eff, rAUf[f], rDeltaT);
 }
 
-__global__ void ddtCorrBndK(int nBf, const scalar* phiOld, const scalar* fluxUold, const scalar* rAUb,
+__device__ void ddtCorrBndK(int nBf, const scalar* phiOld, const scalar* fluxUold, const scalar* rAUb,
                             const scalar* mask, const scalar* phiCorrEff, scalar rDeltaT, scalar* out)
 {
     const int b = blockIdx.x*blockDim.x + threadIdx.x;
@@ -144,27 +151,31 @@ void deviceDdtCorrFlux(
     if (nIf > 0 && (int)phiOldInt.size() >= nIf && (int)fluxUoldInt.size() >= nIf
         && (int)rAUf.size() >= nIf && (int)outInt.size() >= nIf)
     {
-        ddtCorrIntK<<<nBlocks(nIf), TPB>>>(nIf, phiOldInt.data(), fluxUoldInt.data(), rAUf.data(),
-                                           (phiCorrEffInt && (int)phiCorrEffInt->size() >= nIf)
-                                               ? phiCorrEffInt->data() : nullptr,
-                                           rDeltaT, outInt.data());
+        const scalar* phiOldd = phiOldInt.data(); const scalar* fluxUoldd = fluxUoldInt.data(); const scalar* rAUfd = rAUf.data();
+        const scalar* eff = (phiCorrEffInt && (int)phiCorrEffInt->size() >= nIf) ? phiCorrEffInt->data() : nullptr;
+        scalar* outIntd = outInt.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            ddtCorrIntK(nIf, phiOldd, fluxUoldd, rAUfd, eff, rDeltaT, outIntd);
+        });
         cudaCheck(cudaGetLastError(), "ddtCorrInt");
     }
     const int nBf = (int)outBnd.size();
     if (nBf > 0 && (int)phiOldBnd.size() >= nBf && (int)fluxUoldBnd.size() >= nBf
         && (int)rAUbnd.size() >= nBf && (int)coeffMask.size() >= nBf)
     {
-        ddtCorrBndK<<<nBlocks(nBf), TPB>>>(nBf, phiOldBnd.data(), fluxUoldBnd.data(), rAUbnd.data(),
-                                           coeffMask.data(),
-                                           (phiCorrEffBnd && (int)phiCorrEffBnd->size() >= nBf)
-                                               ? phiCorrEffBnd->data() : nullptr,
-                                           rDeltaT, outBnd.data());
+        const scalar* phiOldd = phiOldBnd.data(); const scalar* fluxUoldd = fluxUoldBnd.data(); const scalar* rAUbndd = rAUbnd.data();
+        const scalar* maskd = coeffMask.data();
+        const scalar* eff = (phiCorrEffBnd && (int)phiCorrEffBnd->size() >= nBf) ? phiCorrEffBnd->data() : nullptr;
+        scalar* outBndd = outBnd.data();
+        pcudaParallelFor(nBlocks(nBf), TPB, [=] __device__ () {
+            ddtCorrBndK(nBf, phiOldd, fluxUoldd, rAUbndd, maskd, eff, rDeltaT, outBndd);
+        });
         cudaCheck(cudaGetLastError(), "ddtCorrBnd");
     }
 }
 
 namespace {
-__global__ void correctUfK(int n, const label* __restrict__ idx,
+__device__ void correctUfK(int n, const label* __restrict__ idx,
                            const scalar* __restrict__ Sfx, const scalar* __restrict__ Sfy,
                            const scalar* __restrict__ Sfz, const scalar* __restrict__ magSf,
                            const scalar* __restrict__ phi,
@@ -181,7 +192,7 @@ __global__ void correctUfK(int n, const label* __restrict__ idx,
     ux[i] += nx*c;  uy[i] += ny*c;  uz[i] += nz*c;
 }
 
-__global__ void dotSfK(int n, const label* __restrict__ idx,
+__device__ void dotSfK(int n, const label* __restrict__ idx,
                        const scalar* __restrict__ Sfx, const scalar* __restrict__ Sfy,
                        const scalar* __restrict__ Sfz, const scalar* __restrict__ ux,
                        const scalar* __restrict__ uy, const scalar* __restrict__ uz,
@@ -201,15 +212,18 @@ void deviceCorrectUf(
     DeviceBuffer<scalar>& ufx, DeviceBuffer<scalar>& ufy, DeviceBuffer<scalar>& ufz)
 {
     if (n <= 0 || (int)phi.size() < n || (int)ufx.size() < n) return;
-    correctUfK<<<nBlocks(n), TPB>>>(n, faceIdx, Sfx.data(), Sfy.data(), Sfz.data(), magSf.data(),
-                                    phi.data(), ufx.data(), ufy.data(), ufz.data());
+    const scalar *Sfxd=Sfx.data(),*Sfyd=Sfy.data(),*Sfzd=Sfz.data(),*magSfd=magSf.data(),*phid=phi.data();
+    scalar *ufxd=ufx.data(),*ufyd=ufy.data(),*ufzd=ufz.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        correctUfK(n, faceIdx, Sfxd, Sfyd, Sfzd, magSfd, phid, ufxd, ufyd, ufzd);
+    });
     cudaCheck(cudaGetLastError(), "correctUf");
 }
 
 namespace {
 // OF fvc::surfaceSum(mag(phi)) per cell: |phi| lands on the owner AND the neighbour of every internal
 // face, and on the owner of every boundary face.
-__global__
+__device__
 void surfSumMagIntK(int nIf, const label* __restrict__ own, const label* __restrict__ nei,
                     const scalar* __restrict__ phi, scalar* __restrict__ out)
 {
@@ -219,7 +233,7 @@ void surfSumMagIntK(int nIf, const label* __restrict__ own, const label* __restr
     atomicAdd(&out[own[f]], a);
     atomicAdd(&out[nei[f]], a);
 }
-__global__
+__device__
 void surfSumMagOwnK(int n, const label* __restrict__ own, const scalar* __restrict__ phi,
                     scalar* __restrict__ out)
 {
@@ -245,16 +259,19 @@ void deviceSurfaceSumMagPhi(
     DeviceBuffer<scalar>&       out)
 {
     out.copyFrom(std::vector<scalar>(static_cast<std::size_t>(dm.nCells), scalar(0)));
+    scalar* outd = out.data();
     if (dm.nInternalFaces > 0)
     {
-        surfSumMagIntK<<<nBlocks(dm.nInternalFaces), TPB>>>(dm.nInternalFaces, dm.owner.data(),
-                                                            dm.nei.data(), phiInt.data(), out.data());
+        const int nIf = dm.nInternalFaces;
+        const label *ownd = dm.owner.data(), *neid = dm.nei.data(); const scalar* phiIntd = phiInt.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { surfSumMagIntK(nIf, ownd, neid, phiIntd, outd); });
         cudaCheck(cudaGetLastError(), "surfSumMagInt");
     }
     if (dm.nBndFaces > 0 && (int)phiBnd.size() >= dm.nBndFaces)
     {
-        surfSumMagOwnK<<<nBlocks(dm.nBndFaces), TPB>>>(dm.nBndFaces, dm.bndCell.data(), phiBnd.data(),
-                                                       out.data());
+        const int nBf = dm.nBndFaces;
+        const label* bndCelld = dm.bndCell.data(); const scalar* phiBndd = phiBnd.data();
+        pcudaParallelFor(nBlocks(nBf), TPB, [=] __device__ () { surfSumMagOwnK(nBf, bndCelld, phiBndd, outd); });
         cudaCheck(cudaGetLastError(), "surfSumMagBnd");
     }
     auto addIface = [&](const DeviceBuffer<label>* own, const DeviceBuffer<scalar>* phi)
@@ -262,7 +279,8 @@ void deviceSurfaceSumMagPhi(
         if (!own || !phi) return;
         const int n = static_cast<int>(phi->size());
         if (n == 0 || (int)own->size() < n) return;
-        surfSumMagOwnK<<<nBlocks(n), TPB>>>(n, own->data(), phi->data(), out.data());
+        const label* ownd = own->data(); const scalar* phid = phi->data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { surfSumMagOwnK(n, ownd, phid, outd); });
         cudaCheck(cudaGetLastError(), "surfSumMagIface");
     };
     addIface(cycOwn, cycPhi);
@@ -278,8 +296,9 @@ void deviceDotSf(
 {
     out.resize(n);
     if (n <= 0 || (int)ufx.size() < n) return;
-    dotSfK<<<nBlocks(n), TPB>>>(n, faceIdx, Sfx.data(), Sfy.data(), Sfz.data(),
-                                ufx.data(), ufy.data(), ufz.data(), out.data());
+    const scalar *Sfxd=Sfx.data(),*Sfyd=Sfy.data(),*Sfzd=Sfz.data(),*ufxd=ufx.data(),*ufyd=ufy.data(),*ufzd=ufz.data();
+    scalar* outd = out.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { dotSfK(n, faceIdx, Sfxd, Sfyd, Sfzd, ufxd, ufyd, ufzd, outd); });
     cudaCheck(cudaGetLastError(), "dotSf");
 }
 

--- a/src/cuda/device_deferred_correction.cu
+++ b/src/cuda/device_deferred_correction.cu
@@ -3,6 +3,7 @@
 // (its vector-limited variant), and the LUST linear part (0.75*linear + 0.25*linearUpwind). Split from device_simple.cu
 // (the pressure-velocity coupling stays there). Shared decls: device_simple.cuh.
 #include "device_simple.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -15,7 +16,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 // linearUpwind deferred correction for div(phi,U_i): the matrix stays pure upwind; the explicit correction
 // is the convective transport of grad(U_i)_upwind . (Cf - C_upwind). Per cell: Sum(+/-) phi_f * (grad_upwind . d).
 // (boundary faces use pure upwind -> no correction, as in OpenFOAM.) Caller does source -= corrSource.
-__global__
+__device__
 void linearUpwindCorrKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -64,9 +65,19 @@ void deviceLinearUpwindCorr(
     DeviceBuffer<scalar>& corrSource)
 {
     corrSource.resize(dm.nCells);
-    linearUpwindCorrKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-        dm.owner.data(), dm.nei.data(), phiInt.data(), gx.data(), gy.data(), gz.data(),
-        dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(), dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(), corrSource.data());
+    {
+        const int nC = dm.nCells;
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        const label *own = dm.owner.data(), *nei = dm.nei.data();
+        const scalar *phid = phiInt.data(), *gxd = gx.data(), *gyd = gy.data(), *gzd = gz.data();
+        const scalar *dOwnX = dm.dOwnX.data(), *dOwnY = dm.dOwnY.data(), *dOwnZ = dm.dOwnZ.data();
+        const scalar *dNeiX = dm.dNeiX.data(), *dNeiY = dm.dNeiY.data(), *dNeiZ = dm.dNeiZ.data();
+        scalar* corrSourced = corrSource.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            linearUpwindCorrKernel(nC, ownerStart, losort, losortStart, own, nei, phid, gxd, gyd, gzd,
+                                   dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, corrSourced);
+        });
+    }
     cudaCheck(cudaGetLastError(), "linearUpwindCorr");
 }
 
@@ -75,7 +86,7 @@ void deviceLinearUpwindCorr(
 // components at each face (hence a face kernel, not the per-component linearUpwindCorrKernel):
 //   sfCorr_i = (Cf-C_up).grad(U_i)_up ; maxCorr = (phi>0)?(1-w)(U[nei]-U[own]):w(U[own]-U[nei]) ;
 //   sfCorrs=|sfCorr|^2, maxCorrs=sfCorr.maxCorr ; if maxCorrs<0 -> 0 ; else if sfCorrs>maxCorrs -> *= maxCorrs/sfCorrs.
-__global__
+__device__
 void linearUpwindVFaceKernel(
     int nIf,
     const label* __restrict__ own,
@@ -141,7 +152,7 @@ void linearUpwindVFaceKernel(
     fcZ[f] = cz;
 }
 // div(phi * faceCorr) gather (per cell), same owner(+)/losort(-) sum as linearUpwindCorrKernel but on a precomputed face field.
-__global__
+__device__
 void divFaceCorrKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -178,24 +189,40 @@ void deviceLinearUpwindVCorr(
 {
     const int nIf = dm.nInternalFaces;
     DeviceBuffer<scalar> fcX(nIf), fcY(nIf), fcZ(nIf);
-    linearUpwindVFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), phiInt.data(), dm.w.data(),
-        dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(), dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-        gUx[0].data(), gUy[0].data(), gUz[0].data(), gUx[1].data(), gUy[1].data(), gUz[1].data(),
-        gUx[2].data(), gUy[2].data(), gUz[2].data(), U0.data(), U1.data(), U2.data(),
-        fcX.data(), fcY.data(), fcZ.data());
+    const scalar* phid = phiInt.data();
+    scalar *fcXd = fcX.data(), *fcYd = fcY.data(), *fcZd = fcZ.data();
+    {
+        const label *own = dm.owner.data(), *nei = dm.nei.data();
+        const scalar *wd = dm.w.data();
+        const scalar *dOwnX = dm.dOwnX.data(), *dOwnY = dm.dOwnY.data(), *dOwnZ = dm.dOwnZ.data();
+        const scalar *dNeiX = dm.dNeiX.data(), *dNeiY = dm.dNeiY.data(), *dNeiZ = dm.dNeiZ.data();
+        const scalar *g0x=gUx[0].data(),*g0y=gUy[0].data(),*g0z=gUz[0].data();
+        const scalar *g1x=gUx[1].data(),*g1y=gUy[1].data(),*g1z=gUz[1].data();
+        const scalar *g2x=gUx[2].data(),*g2y=gUy[2].data(),*g2z=gUz[2].data();
+        const scalar *U0d=U0.data(),*U1d=U1.data(),*U2d=U2.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            linearUpwindVFaceKernel(nIf, own, nei, phid, wd, dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ,
+                                    g0x, g0y, g0z, g1x, g1y, g1z, g2x, g2y, g2z, U0d, U1d, U2d, fcXd, fcYd, fcZd);
+        });
+    }
     corrX.resize(dm.nCells);
     corrY.resize(dm.nCells);
     corrZ.resize(dm.nCells);
-    divFaceCorrKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), phiInt.data(), fcX.data(), corrX.data());
-    divFaceCorrKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), phiInt.data(), fcY.data(), corrY.data());
-    divFaceCorrKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), phiInt.data(), fcZ.data(), corrZ.data());
+    {
+        const int nC = dm.nCells;
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        scalar *corrXd = corrX.data(), *corrYd = corrY.data(), *corrZd = corrZ.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { divFaceCorrKernel(nC, ownerStart, losort, losortStart, phid, fcXd, corrXd); });
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { divFaceCorrKernel(nC, ownerStart, losort, losortStart, phid, fcYd, corrYd); });
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { divFaceCorrKernel(nC, ownerStart, losort, losortStart, phid, fcZd, corrZd); });
+    }
     cudaCheck(cudaGetLastError(), "linearUpwindVCorr");
 }
 
 // LUST linear-part deferred correction: div(phi*(linear_face - upwind_face)) = div(phi*(w-pos0)*(field[P]-field[N])).
 // Same divergence gather as linearUpwindCorrKernel. OF LUST = 0.75*linear + 0.25*linearUpwind, so the caller adds
 // 0.75*this + 0.25*linearUpwindCorr. w = owner linear weight (dm.w), pos0 = (phi>=0) = the upwind owner weight.
-__global__
+__device__
 void linearCorrKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -233,8 +260,16 @@ void deviceLinearCorr(
     DeviceBuffer<scalar>& corrSource)
 {
     corrSource.resize(dm.nCells);
-    linearCorrKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-        dm.owner.data(), dm.nei.data(), phiInt.data(), dm.w.data(), field.data(), corrSource.data());
+    {
+        const int nC = dm.nCells;
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        const label *own = dm.owner.data(), *nei = dm.nei.data();
+        const scalar *phid = phiInt.data(), *wd = dm.w.data(), *fieldd = field.data();
+        scalar* corrSourced = corrSource.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            linearCorrKernel(nC, ownerStart, losort, losortStart, own, nei, phid, wd, fieldd, corrSourced);
+        });
+    }
     cudaCheck(cudaGetLastError(), "linearCorr");
 }
 

--- a/src/cuda/device_deshybrid.cu
+++ b/src/cuda/device_deshybrid.cu
@@ -3,13 +3,14 @@
 // deferred correction against brae's upwind matrix.
 #include "device_deshybrid.cuh"
 #include "device_scalar_transport.cuh"   // nBlocks/TPB (shared launch geometry)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
 
 namespace {
 
-__global__
+__device__
 void desSigmaKernel(
     int nC, const scalar* __restrict__ gradU, const scalar* __restrict__ V,
     const scalar* __restrict__ nut, scalar nu, DesHybridCoeffs co,
@@ -58,7 +59,7 @@ void desSigmaKernel(
 // weighted by bf = interpolate(sigma).
 //   linear      : linear_face - upwind_face = (w - pos0(phi))*(field[own] - field[nbr])
 //   linearUpwind: grad[upwind] . (Cf - C[upwind])
-__global__
+__device__
 void desFaceCorrKernel(
     int nIf, const label* __restrict__ own, const label* __restrict__ nei,
     const scalar* __restrict__ phi, const scalar* __restrict__ w, const scalar* __restrict__ sigma,
@@ -86,7 +87,7 @@ void desFaceCorrKernel(
     fc[f] = (scalar(1) - bf)*lin + bf*lu;
 }
 
-__global__
+__device__
 void desDivKernel(
     int nC, const label* __restrict__ ownerStart, const label* __restrict__ losort,
     const label* __restrict__ losortStart, const scalar* __restrict__ phi,
@@ -110,9 +111,14 @@ void deviceDesHybridSigma(int nC, const DeviceBuffer<scalar>& gradU, const Devic
 {
     sigma.resize(nC);
     if (nC == 0) return;
-    desSigmaKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), V.data(),
-                                         nut.size() ? nut.data() : nullptr, nu, co,
-                                         (delta && delta->size()) ? delta->data() : nullptr, sigma.data());
+    const scalar* gradUd = gradU.data();
+    const scalar* Vd = V.data();
+    const scalar* nutd = nut.size() ? nut.data() : nullptr;
+    const scalar* deltad = (delta && delta->size()) ? delta->data() : nullptr;
+    scalar* sigmad = sigma.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        desSigmaKernel(nC, gradUd, Vd, nutd, nu, co, deltad, sigmad);
+    });
     cudaCheck(cudaGetLastError(), "desHybridSigma");
 }
 
@@ -126,13 +132,26 @@ void deviceDesHybridCorr(const DeviceMesh& dm, const DeviceBuffer<scalar>& phiIn
     corr.resize(dm.nCells);
     if (dm.nCells == 0) return;
     DeviceBuffer<scalar> fc(nIf);
+    const scalar* phiIntd = phiInt.data();
+    scalar* fcd = fc.data();
     if (nIf > 0)
-        desFaceCorrKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), phiInt.data(),
-            dm.w.data(), sigma.data(), field.data(), gx.data(), gy.data(), gz.data(),
-            dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(),
-            dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(), fc.data());
-    desDivKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(),
-        dm.losortStart.data(), phiInt.data(), fc.data(), corr.data());
+    {
+        const label* ownerd = dm.owner.data(); const label* neid = dm.nei.data();
+        const scalar* wd = dm.w.data(); const scalar* sigmad = sigma.data(); const scalar* fieldd = field.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        const scalar* dOwnXd = dm.dOwnX.data(); const scalar* dOwnYd = dm.dOwnY.data(); const scalar* dOwnZd = dm.dOwnZ.data();
+        const scalar* dNeiXd = dm.dNeiX.data(); const scalar* dNeiYd = dm.dNeiY.data(); const scalar* dNeiZd = dm.dNeiZ.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            desFaceCorrKernel(nIf, ownerd, neid, phiIntd, wd, sigmad, fieldd, gxd, gyd, gzd,
+                              dOwnXd, dOwnYd, dOwnZd, dNeiXd, dNeiYd, dNeiZd, fcd);
+        });
+    }
+    const int nCells = dm.nCells;
+    const label* ownerStartd = dm.ownerStart.data(); const label* losortd = dm.losort.data(); const label* losortStartd = dm.losortStart.data();
+    scalar* corrd = corr.data();
+    pcudaParallelFor(nBlocks(nCells), TPB, [=] __device__ () {
+        desDivKernel(nCells, ownerStartd, losortd, losortStartd, phiIntd, fcd, corrd);
+    });
     cudaCheck(cudaGetLastError(), "desHybridCorr");
 }
 

--- a/src/cuda/device_dilu.cu
+++ b/src/cuda/device_dilu.cu
@@ -1,6 +1,7 @@
 // DILU on the device by level scheduling. See device_dilu.cuh for why exactness is the requirement.
 #include "device_dilu.cuh"
 #include "device_blas.cuh"
+#include "pcuda_compat.cuh"
 #include <algorithm>
 
 namespace brae {
@@ -14,7 +15,7 @@ inline int nBlk(int n) { return (n + TPB_D - 1) / TPB_D; }
 //     d[c] = diag[c] - sum_{f : nei[f] == c} upper[f]*lower[f]/d[owner[f]]
 // The faces are exactly losort[losortStart[c] .. losortStart[c+1]), in increasing face index -- the order
 // OF's sequential loop meets them in, so the summation order matches.
-__global__ void diluDiagLevelK(
+__device__ void diluDiagLevelK(
     const label* __restrict__ cells, int n,
     const label* __restrict__ owner, const label* __restrict__ losort, const label* __restrict__ losortStart,
     const scalar* __restrict__ upper, const scalar* __restrict__ lower,
@@ -32,13 +33,13 @@ __global__ void diluDiagLevelK(
     d[c] = acc;
 }
 
-__global__ void reciprocalK(scalar* __restrict__ d, scalar* __restrict__ rD, int n)
+__device__ void reciprocalK(scalar* __restrict__ d, scalar* __restrict__ rD, int n)
 {
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
     if (i < n) rD[i] = scalar(1)/d[i];
 }
 
-__global__ void diluInitK(const scalar* __restrict__ rD, const scalar* __restrict__ r,
+__device__ void diluInitK(const scalar* __restrict__ rD, const scalar* __restrict__ r,
                           scalar* __restrict__ w, int n)
 {
     const int i = blockIdx.x*blockDim.x + threadIdx.x;
@@ -47,7 +48,7 @@ __global__ void diluInitK(const scalar* __restrict__ rD, const scalar* __restric
 
 // Forward sweep, one level, as a gather over the faces where this cell is the UPPER cell:
 //     w[c] -= rD[c] * sum_{f : nei[f] == c} lower[f]*w[owner[f]]
-__global__ void diluFwdLevelK(
+__device__ void diluFwdLevelK(
     const label* __restrict__ cells, int n,
     const label* __restrict__ owner, const label* __restrict__ losort, const label* __restrict__ losortStart,
     const scalar* __restrict__ lower, const scalar* __restrict__ rD, scalar* __restrict__ w)
@@ -73,7 +74,7 @@ __global__ void diluFwdLevelK(
 //     w[c] -= rD[c] * sum_{f : owner[f] == c} upper[f]*w[nei[f]]
 // OF walks the faces in DECREASING index, so the gather runs the owner's face run in reverse to keep the
 // same summation order.
-__global__ void diluBwdLevelK(
+__device__ void diluBwdLevelK(
     const label* __restrict__ cells, int n,
     const label* __restrict__ nei, const label* __restrict__ ownerStart,
     const scalar* __restrict__ upper, const scalar* __restrict__ rD, scalar* __restrict__ w)
@@ -152,15 +153,24 @@ DeviceDilu buildDeviceDilu(const std::vector<label>& owner, const std::vector<la
 void diluUpdate(const DeviceLduView& A, DeviceDilu& d)
 {
     if (!d.valid) return;
+    const label *owner = A.owner, *losort = A.losort, *losortStart = A.losortStart;
+    const scalar *upper = A.upper, *lower = A.lower, *diag = A.diag;
+    scalar* workd = d.work.data();
     for (int L = 0; L + 1 < (int)d.fwdOff.size(); ++L)
     {
         const int b = d.fwdOff[(std::size_t)L], e = d.fwdOff[(std::size_t)L+1];
         if (e <= b) continue;
-        diluDiagLevelK<<<nBlk(e-b), TPB_D>>>(d.fwdCells.data() + b, e - b,
-                                             A.owner, A.losort, A.losortStart,
-                                             A.upper, A.lower, A.diag, d.work.data());
+        const label* cells = d.fwdCells.data() + b;
+        const int n = e - b;
+        pcudaParallelFor(nBlk(n), TPB_D, [=] __device__ () {
+            diluDiagLevelK(cells, n, owner, losort, losortStart, upper, lower, diag, workd);
+        });
     }
-    reciprocalK<<<nBlk(d.nCells), TPB_D>>>(d.work.data(), d.rD.data(), d.nCells);
+    {
+        scalar* rDd = d.rD.data();
+        const int nC = d.nCells;
+        pcudaParallelFor(nBlk(nC), TPB_D, [=] __device__ () { reciprocalK(workd, rDd, nC); });
+    }
     cudaCheck(cudaGetLastError(), "dilu update");
 }
 
@@ -168,22 +178,40 @@ void diluApply(const DeviceLduView& A, const DeviceDilu& d, const DeviceBuffer<s
                DeviceBuffer<scalar>& w)
 {
     w.resize(d.nCells);
-    diluInitK<<<nBlk(d.nCells), TPB_D>>>(d.rD.data(), r.data(), w.data(), d.nCells);
-    for (int L = 0; L + 1 < (int)d.fwdOff.size(); ++L)
+    const scalar* rDd = d.rD.data();
+    scalar* wd = w.data();
     {
-        const int b = d.fwdOff[(std::size_t)L], e = d.fwdOff[(std::size_t)L+1];
-        if (e <= b) continue;
-        diluFwdLevelK<<<nBlk(e-b), TPB_D>>>(d.fwdCells.data() + b, e - b,
-                                            A.owner, A.losort, A.losortStart,
-                                            A.lower, d.rD.data(), w.data());
+        const scalar* rd = r.data();
+        const int nC = d.nCells;
+        pcudaParallelFor(nBlk(nC), TPB_D, [=] __device__ () { diluInitK(rDd, rd, wd, nC); });
     }
-    for (int L = 0; L + 1 < (int)d.bwdOff.size(); ++L)
     {
-        const int b = d.bwdOff[(std::size_t)L], e = d.bwdOff[(std::size_t)L+1];
-        if (e <= b) continue;
-        diluBwdLevelK<<<nBlk(e-b), TPB_D>>>(d.bwdCells.data() + b, e - b,
-                                            A.nei, A.ownerStart,
-                                            A.upper, d.rD.data(), w.data());
+        const label *owner = A.owner, *losort = A.losort, *losortStart = A.losortStart;
+        const scalar* lower = A.lower;
+        for (int L = 0; L + 1 < (int)d.fwdOff.size(); ++L)
+        {
+            const int b = d.fwdOff[(std::size_t)L], e = d.fwdOff[(std::size_t)L+1];
+            if (e <= b) continue;
+            const label* cells = d.fwdCells.data() + b;
+            const int n = e - b;
+            pcudaParallelFor(nBlk(n), TPB_D, [=] __device__ () {
+                diluFwdLevelK(cells, n, owner, losort, losortStart, lower, rDd, wd);
+            });
+        }
+    }
+    {
+        const label *nei = A.nei, *ownerStart = A.ownerStart;
+        const scalar* upper = A.upper;
+        for (int L = 0; L + 1 < (int)d.bwdOff.size(); ++L)
+        {
+            const int b = d.bwdOff[(std::size_t)L], e = d.bwdOff[(std::size_t)L+1];
+            if (e <= b) continue;
+            const label* cells = d.bwdCells.data() + b;
+            const int n = e - b;
+            pcudaParallelFor(nBlk(n), TPB_D, [=] __device__ () {
+                diluBwdLevelK(cells, n, nei, ownerStart, upper, rDd, wd);
+            });
+        }
     }
     cudaCheck(cudaGetLastError(), "dilu apply");
 }

--- a/src/cuda/device_divdevreff.cu
+++ b/src/cuda/device_divdevreff.cu
@@ -3,6 +3,7 @@
 #include "device_kepsilon.cuh"   // deviceCellLimitGradU (the named grad(U) scheme)
 #include "stage_dump.cuh"   // sigma comparison against OF (ACMI trace)
 #include "device_blas.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -13,7 +14,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
 // sigma = nuEff * dev2(transpose(gradU)) per cell. T(gradU)_ij = g[j][i]; dev2 subtracts (2/3)tr on diag.
-__global__
+__device__
 void sigmaKernel(
     int n,
     const scalar* __restrict__ gradU,
@@ -41,7 +42,7 @@ void sigmaKernel(
 
 
 // boundary gradient: gradB = gradC + n (x) (snGrad - n & gradC). snGrad = (U_b - U_cell)*deltaCoeffs.
-__global__
+__device__
 void gradBKernel(
     int nB,
     const label* __restrict__ fc,
@@ -90,7 +91,7 @@ void gradBKernel(
 
 
 // tensor divergence gathered per cell: divSig_j = (1/V)[ sum_faces (Sf & sigma_face)_j ].
-__global__
+__device__
 void tensorDivKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -184,9 +185,16 @@ void deviceBoundaryGradU(const DeviceMesh& dm, const DeviceVectorBoundary& dbU,
     deviceBCValue(dbU.comp[1], Uy, uyb);
     deviceBCValue(dbU.comp[2], Uz, uzb);
     gradB.resize(static_cast<std::size_t>(9) * nB);
-    gradBKernel<<<nBlocks(nB), TPB>>>(nB, dm.bndCell.data(), dm.bndGFace.data(), dm.Sfx.data(), dm.Sfy.data(), dm.Sfz.data(),
-                                      gradU.data(), nC, uxb.data(), uyb.data(), uzb.data(), Ux.data(), Uy.data(), Uz.data(),
-                                      dbU.comp[0].deltaCoeffs.data(), gradB.data());
+    {
+        const label *bndCelld = dm.bndCell.data(), *bndGFaced = dm.bndGFace.data();
+        const scalar *Sfxd = dm.Sfx.data(), *Sfyd = dm.Sfy.data(), *Sfzd = dm.Sfz.data();
+        const scalar *gradUd = gradU.data(), *uxbd = uxb.data(), *uybd = uyb.data(), *uzbd = uzb.data();
+        const scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data(), *dcd = dbU.comp[0].deltaCoeffs.data();
+        scalar* gradBd = gradB.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+            gradBKernel(nB, bndCelld, bndGFaced, Sfxd, Sfyd, Sfzd, gradUd, nC, uxbd, uybd, uzbd, Uxd, Uyd, Uzd, dcd, gradBd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "boundaryGradU");
 }
 
@@ -199,10 +207,19 @@ void deviceTensorDivSource(const DeviceMesh& dm,
     srcX.resize(nC);
     srcY.resize(nC);
     srcZ.resize(nC);
-    tensorDivKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), dm.owner.data(),
-                                          dm.nei.data(), dm.w.data(), dm.Sfx.data(), dm.Sfy.data(), dm.Sfz.data(),
-                                          dm.bndCellStart.data(), dm.bndPerm.data(), dm.bndGFace.data(), dm.bndIsEmpty.data(),
-                                          Tcell.data(), Tbnd.data(), nB, dm.V.data(), srcX.data(), srcY.data(), srcZ.data());
+    {
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        const label *own = dm.owner.data(), *nei = dm.nei.data();
+        const scalar *wd = dm.w.data(), *Sfxd = dm.Sfx.data(), *Sfyd = dm.Sfy.data(), *Sfzd = dm.Sfz.data();
+        const label *bndCellStart = dm.bndCellStart.data(), *bndPerm = dm.bndPerm.data();
+        const label *bndGFace = dm.bndGFace.data(), *bndIsEmpty = dm.bndIsEmpty.data();
+        const scalar *Tcelld = Tcell.data(), *Tbndd = Tbnd.data(), *Vd = dm.V.data();
+        scalar *srcXd = srcX.data(), *srcYd = srcY.data(), *srcZd = srcZ.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            tensorDivKernel(nC, ownerStart, losort, losortStart, own, nei, wd, Sfxd, Sfyd, Sfzd,
+                            bndCellStart, bndPerm, bndGFace, bndIsEmpty, Tcelld, Tbndd, nB, Vd, srcXd, srcYd, srcZd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "tensorDivSource");
     if (cyc) interfaceAddTensorDiv(*cyc, Tcell, nC, srcX, srcY, srcZ);
     if (ami) interfaceAddTensorDiv(*ami, Tcell, nC, srcX, srcY, srcZ);
@@ -276,17 +293,30 @@ void deviceDivDevReff(
 
     // sigma cell
     DeviceBuffer<scalar> sigmaC(static_cast<std::size_t>(9) * nC);
-    sigmaKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), nuCell.data(), sigmaC.data());
+    {
+        const scalar *gradUd = gradU.data(), *nuCelld = nuCell.data(); scalar* sigmaCd = sigmaC.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { sigmaKernel(nC, gradUd, nuCelld, sigmaCd); });
+    }
     cudaCheck(cudaGetLastError(), "ddr sigmaC");
 
     // boundary gradient + sigma boundary
     DeviceBuffer<scalar> gradB(static_cast<std::size_t>(9) * nB);
-    gradBKernel<<<nBlocks(nB), TPB>>>(nB, dm.bndCell.data(), dm.bndGFace.data(), dm.Sfx.data(), dm.Sfy.data(), dm.Sfz.data(),
-                                      gradU.data(), nC, uxb.data(), uyb.data(), uzb.data(), Ux.data(), Uy.data(), Uz.data(),
-                                      /* bnd deltaCoeffs */ dbU.comp[0].deltaCoeffs.data(), gradB.data());
+    {
+        const label *bndCelld = dm.bndCell.data(), *bndGFaced = dm.bndGFace.data();
+        const scalar *Sfxd = dm.Sfx.data(), *Sfyd = dm.Sfy.data(), *Sfzd = dm.Sfz.data();
+        const scalar *gradUd = gradU.data(), *uxbd = uxb.data(), *uybd = uyb.data(), *uzbd = uzb.data();
+        const scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data(), *dcd = dbU.comp[0].deltaCoeffs.data();
+        scalar* gradBd = gradB.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+            gradBKernel(nB, bndCelld, bndGFaced, Sfxd, Sfyd, Sfzd, gradUd, nC, uxbd, uybd, uzbd, Uxd, Uyd, Uzd, dcd, gradBd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "ddr gradB");
     DeviceBuffer<scalar> sigmaB(static_cast<std::size_t>(9) * nB);
-    sigmaKernel<<<nBlocks(nB), TPB>>>(nB, gradB.data(), nuBnd.data(), sigmaB.data());
+    {
+        const scalar *gradBd = gradB.data(), *nuBndd = nuBnd.data(); scalar* sigmaBd = sigmaB.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { sigmaKernel(nB, gradBd, nuBndd, sigmaBd); });
+    }
     cudaCheck(cudaGetLastError(), "ddr sigmaB");
 
     // Processor faces: OVERWRITE the sigmaB just computed from dev2(T(gradB)). A cut face is interior to the
@@ -326,10 +356,19 @@ void deviceDivDevReff(
     srcX.resize(nC);
     srcY.resize(nC);
     srcZ.resize(nC);
-    tensorDivKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), dm.owner.data(),
-                                          dm.nei.data(), dm.w.data(), dm.Sfx.data(), dm.Sfy.data(), dm.Sfz.data(),
-                                          dm.bndCellStart.data(), dm.bndPerm.data(), dm.bndGFace.data(), dm.bndIsEmpty.data(),
-                                          sigmaC.data(), sigmaB.data(), nB, dm.V.data(), srcX.data(), srcY.data(), srcZ.data());
+    {
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        const label *own = dm.owner.data(), *nei = dm.nei.data();
+        const scalar *wd = dm.w.data(), *Sfxd = dm.Sfx.data(), *Sfyd = dm.Sfy.data(), *Sfzd = dm.Sfz.data();
+        const label *bndCellStart = dm.bndCellStart.data(), *bndPerm = dm.bndPerm.data();
+        const label *bndGFace = dm.bndGFace.data(), *bndIsEmpty = dm.bndIsEmpty.data();
+        const scalar *sigmaCd = sigmaC.data(), *sigmaBd = sigmaB.data(), *Vd = dm.V.data();
+        scalar *srcXd = srcX.data(), *srcYd = srcY.data(), *srcZd = srcZ.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            tensorDivKernel(nC, ownerStart, losort, losortStart, own, nei, wd, Sfxd, Sfyd, Sfzd,
+                            bndCellStart, bndPerm, bndGFace, bndIsEmpty, sigmaCd, sigmaBd, nB, Vd, srcXd, srcYd, srcZd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "ddr tensorDiv");
     if (cyc) interfaceAddTensorDiv(*cyc, sigmaC, nC, srcX, srcY, srcZ);   // + cyclic-face stress flux (V*fvc::div)
     if (ami) interfaceAddTensorDiv(*ami, sigmaC, nC, srcX, srcY, srcZ);      // + AMI-face stress flux

--- a/src/cuda/device_energy.cu
+++ b/src/cuda/device_energy.cu
@@ -5,6 +5,7 @@
 #include "stage_dump.cuh"
 #include "device_scalar_transport.cuh"
 #include "thermo_model.cuh"
+#include "pcuda_compat.cuh"
 #include <stdexcept>
 
 namespace brae {
@@ -18,7 +19,7 @@ namespace brae {
 // shifts he by a constant and a constant has zero gradient. A fixedGradient T wall whose gradient
 // was copied across UNSCALED would be wrong by a factor of Cpv, i.e. ~1005 for air -- so this is
 // the difference between a heat-flux wall and an essentially adiabatic one.
-__global__
+__device__
 void heBndFromTK(
     int n,
     ThermoCoeffs c,
@@ -45,7 +46,7 @@ void heBndFromTK(
 // The gradient coefficient is d(he)/dT = Cpv, evaluated AT THE FACE TEMPERATURE. For this liquid OF
 // sets CpMCv = 0, so Cpv is Cp(T_b) for both energy forms -- not the gas Cp - R (717.9 vs 4183, a
 // factor of 5.8 on any fixedGradient/heat-flux temperature patch).
-__global__
+__device__
 void heBndFromTLiquidK(
     int n,
     EnergyForm form,
@@ -93,30 +94,32 @@ void deviceEnergyBoundaryFromT(
                 "brae: converting a temperature boundary to energy for a liquid with "
                 "sensibleInternalEnergy needs the boundary pressure (e = h(T) - p/rho(T)); the caller "
                 "passed none, or one sized for a different patch set.");
-        heBndFromTLiquidK<<<nBlocks(dbT.n), TPB>>>(
-            dbT.n,
-            form,
-            (c.internalEnergy && pBnd) ? pBnd->data() : nullptr,
-            dbT.refValue.data(),
-            hasGrad ? dbT.refGrad.data() : nullptr,
-            dbHe.refValue.data(),
-            hasGrad ? dbHe.refGrad.data() : nullptr);
+        const int n = dbT.n;
+        const scalar* pBndD = (c.internalEnergy && pBnd) ? pBnd->data() : nullptr;
+        const scalar* refTD = dbT.refValue.data();
+        const scalar* gradTD = hasGrad ? dbT.refGrad.data() : nullptr;
+        scalar* refHeD = dbHe.refValue.data();
+        scalar* gradHeD = hasGrad ? dbHe.refGrad.data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            heBndFromTLiquidK(n, form, pBndD, refTD, gradTD, refHeD, gradHeD); });
         cudaCheck(cudaGetLastError(), "heBndFromTLiquid");
         return;
     }
-    heBndFromTK<<<nBlocks(dbT.n), TPB>>>(
-        dbT.n,
-        c,
-        dbT.refValue.data(),
-        hasGrad ? dbT.refGrad.data() : nullptr,
-        dbHe.refValue.data(),
-        hasGrad ? dbHe.refGrad.data() : nullptr);
+    {
+        const int n = dbT.n;
+        const scalar* refTD = dbT.refValue.data();
+        const scalar* gradTD = hasGrad ? dbT.refGrad.data() : nullptr;
+        scalar* refHeD = dbHe.refValue.data();
+        scalar* gradHeD = hasGrad ? dbHe.refGrad.data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            heBndFromTK(n, c, refTD, gradTD, refHeD, gradHeD); });
+    }
     cudaCheck(cudaGetLastError(), "heBndFromT");
 }
 
 // alphaEff = alpha + alphat. Separate kernel rather than folded into thermoUpdateK because alphat is
 // owned by the turbulence model, which runs after the thermo update, not before it.
-__global__
+__device__
 void alphaEffK(
     int n,
     scalar CpByCpv,
@@ -139,12 +142,11 @@ void deviceAlphaEff(
 {
     if (th.n == 0) return;
     alphaEff.resize(th.n);
-    alphaEffK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        thermoCpByCpv(c),
-        th.alpha.data(),
-        th.alphat.data(),
-        alphaEff.data());
+    const int n = th.n; const scalar cpByCpv = thermoCpByCpv(c);
+    const scalar* alphaD = th.alpha.data(); const scalar* alphatD = th.alphat.data();
+    scalar* alphaEffD = alphaEff.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        alphaEffK(n, cpByCpv, alphaD, alphatD, alphaEffD); });
     cudaCheck(cudaGetLastError(), "alphaEff");
 }
 
@@ -156,7 +158,7 @@ void deviceAlphaEff(
 // (OF EEqn.H: he.name() == "e" ? fvc::div(phi, Ekp) : fvc::div(phi, K).) The p/rho term is the flow work
 // that enthalpy already carries internally and internal energy does not, so leaving it out of an "e" case
 // loses the pressure work entirely -- and still converges.
-__global__
+__device__
 void kineticEnergyK(
     int n,
     const scalar* __restrict__ Ux,
@@ -179,7 +181,7 @@ void kineticEnergyK(
 // limiter = clamp(twoByk*r, 0, 1) -- the SAME formula divLimitedFaceKernel uses for the implicit term, so
 // the explicit and implicit halves of the energy equation cannot end up on different schemes.
 // Hardcoding upwind here is worth ~6.6e-4 in T on a limitedLinear case whose implicit term is exact.
-__global__
+__device__
 void kineticFaceFluxK(
     int nF,
     const label* __restrict__ owner,
@@ -237,7 +239,7 @@ void kineticFaceFluxK(
 
 // Boundary half: += phi_b*K_b, and the "bounded" correction -K_c*(sum_f phi_f) that OF's
 // boundedConvectionScheme subtracts. Both scattered with atomics onto the adjacent cell.
-__global__
+__device__
 void kineticBoundaryK(
     int nB,
     const label* __restrict__ faceCell,
@@ -253,7 +255,7 @@ void kineticBoundaryK(
     atomicAdd(&sumPhi[c], phiBnd[i]);
 }
 
-__global__
+__device__
 void kineticBoundedK(
     int n,
     const scalar* __restrict__ K,
@@ -290,10 +292,13 @@ void deviceEnergyKineticSource(
     const int nF = dm.nInternalFaces;
     DeviceBuffer<scalar> K;
     K.resize(nC);
-    kineticEnergyK<<<nBlocks(nC), TPB>>>(nC, Ux.data(), Uy.data(), Uz.data(),
-                                         ekp ? p->data() : nullptr,
-                                         ekp ? rho->data() : nullptr,
-                                         K.data());
+    {
+        const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+        const scalar* pd = ekp ? p->data() : nullptr; const scalar* rhod = ekp ? rho->data() : nullptr;
+        scalar* Kd = K.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            kineticEnergyK(nC, Uxd, Uyd, Uzd, pd, rhod, Kd); });
+    }
     cudaCheck(cudaGetLastError(), "kineticEnergy");
     if (stageDumpActive() && stageDumpFirstOnly("Ekp")) stageDump("stage_Ekp", K);
 
@@ -317,10 +322,13 @@ void deviceEnergyKineticSource(
         deviceBCValue(dbU.comp[1], Uy, uby);
         deviceBCValue(dbU.comp[2], Uz, ubz);
         Kb.resize(nB);
-        kineticEnergyK<<<nBlocks(nB), TPB>>>(nB, ubx.data(), uby.data(), ubz.data(),
-                                             ekpB ? pBndIn->data() : nullptr,
-                                             ekpB ? rhoBndIn->data() : nullptr,
-                                             Kb.data());
+        {
+            const scalar* ubxd = ubx.data(); const scalar* ubyd = uby.data(); const scalar* ubzd = ubz.data();
+            const scalar* pd = ekpB ? pBndIn->data() : nullptr; const scalar* rhod = ekpB ? rhoBndIn->data() : nullptr;
+            scalar* Kbd = Kb.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+                kineticEnergyK(nB, ubxd, ubyd, ubzd, pd, rhod, Kbd); });
+        }
         cudaCheck(cudaGetLastError(), "kineticEnergyBnd");
     }
 
@@ -335,15 +343,21 @@ void deviceEnergyKineticSource(
     }
     DeviceBuffer<scalar> ffc;
     ffc.resize(nF);
-    kineticFaceFluxK<<<nBlocks(nF), TPB>>>(nF, dm.owner.data(), dm.nei.data(), phiInt.data(), K.data(),
-                                           limited ? dm.w.data() : nullptr,
-                                           linearUpwind ? 1 : 0,
-                                           (limited || linearUpwind) ? gx.data() : nullptr,
-                                           (limited || linearUpwind) ? gy.data() : nullptr,
-                                           (limited || linearUpwind) ? gz.data() : nullptr,
-                                           dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(),
-                                           dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-                                           twoByk, ffc.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data();
+        const scalar* phiIntD = phiInt.data(); const scalar* Kd = K.data();
+        const scalar* cdwD = limited ? dm.w.data() : nullptr;
+        const int linUp = linearUpwind ? 1 : 0;
+        const scalar* gxd = (limited || linearUpwind) ? gx.data() : nullptr;
+        const scalar* gyd = (limited || linearUpwind) ? gy.data() : nullptr;
+        const scalar* gzd = (limited || linearUpwind) ? gz.data() : nullptr;
+        const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+        const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+        scalar* ffcd = ffc.data();
+        pcudaParallelFor(nBlocks(nF), TPB, [=] __device__ () {
+            kineticFaceFluxK(nF, own, nei, phiIntD, Kd, cdwD, linUp, gxd, gyd, gzd,
+                              dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, twoByk, ffcd); });
+    }
     cudaCheck(cudaGetLastError(), "kineticFaceFlux");
     // deviceFaceDivSource returns MINUS V*div (it exists for the laplacian non-orth correction, which
     // wants that sign). Negate so src is +V*div(phi,K), matching the boundary half added below and the
@@ -359,8 +373,12 @@ void deviceEnergyKineticSource(
         DeviceBuffer<scalar> sumPhi;
         sumPhi.resize(nC);
         cudaCheck(cudaMemsetAsync(sumPhi.data(), 0, nC*sizeof(scalar), cudaStreamPerThread), "sumPhi zero");
-        kineticBoundaryK<<<nBlocks(nB), TPB>>>(nB, dbU.comp[0].faceCell.data(), phiBnd.data(), Kb.data(),
-                                               src.data(), sumPhi.data());
+        {
+            const label* faceCell = dbU.comp[0].faceCell.data(); const scalar* phiBndD = phiBnd.data();
+            const scalar* Kbd = Kb.data(); scalar* srcd = src.data(); scalar* sumPhid = sumPhi.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+                kineticBoundaryK(nB, faceCell, phiBndD, Kbd, srcd, sumPhid); });
+        }
         cudaCheck(cudaGetLastError(), "kineticBoundary");
         // THE bounded CORRECTION IS PART OF THE SCHEME, NOT OF fvc::div. OF writes
         //     fvc::div(phi, Ekp)
@@ -380,7 +398,11 @@ void deviceEnergyKineticSource(
             DeviceBuffer<scalar> divPhiInt;
             deviceFaceDivSource(dm, phiInt, divPhiInt);
             deviceAxpy(-1.0, divPhiInt, sumPhi);
-            kineticBoundedK<<<nBlocks(nC), TPB>>>(nC, K.data(), sumPhi.data(), src.data());
+            {
+                const scalar* Kd = K.data(); const scalar* sumPhid = sumPhi.data(); scalar* srcd = src.data();
+                pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                    kineticBoundedK(nC, Kd, sumPhid, srcd); });
+            }
             cudaCheck(cudaGetLastError(), "kineticBounded");
         }
     }

--- a/src/cuda/device_fvc.cu
+++ b/src/cuda/device_fvc.cu
@@ -2,6 +2,7 @@
 // gaussGrad are per-cell gathers (internal owner/neighbour faces via ownerStart/losort, boundary faces via
 // bndCellStart), race-free, deterministic, matching the CPU fvc to machine precision.
 #include "device_mesh.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -11,7 +12,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void interpKernel(
     int nIf,
     const label* __restrict__ own,
@@ -25,7 +26,7 @@ void interpKernel(
 }
 
 
-__global__
+__device__
 void divKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -52,7 +53,7 @@ void divKernel(
 }
 
 
-__global__
+__device__
 void gradKernel(
     int nC,
     const label* __restrict__ own,
@@ -112,7 +113,11 @@ void gradKernel(
 void deviceInterpolate(const DeviceMesh& dm, const DeviceBuffer<scalar>& vol, DeviceBuffer<scalar>& sfInt)
 {
     sfInt.resize(dm.nInternalFaces);
-    interpKernel<<<nBlocks(dm.nInternalFaces), TPB>>>(dm.nInternalFaces, dm.owner.data(), dm.nei.data(), dm.w.data(), vol.data(), sfInt.data());
+    const int nIf = dm.nInternalFaces;
+    const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+    const scalar* vold = vol.data(); scalar* sfd = sfInt.data();
+    pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+        interpKernel(nIf, own, nei, w, vold, sfd); });
     cudaCheck(cudaGetLastError(), "interp");
 }
 
@@ -120,8 +125,13 @@ void deviceInterpolate(const DeviceMesh& dm, const DeviceBuffer<scalar>& vol, De
 void deviceDiv(const DeviceMesh& dm, const DeviceBuffer<scalar>& phiInt, const DeviceBuffer<scalar>& bval, DeviceBuffer<scalar>& d)
 {
     d.resize(dm.nCells);
-    divKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-                                           phiInt.data(), dm.bndCellStart.data(), dm.bndPerm.data(), bval.data(), dm.V.data(), d.data());
+    const int nC = dm.nCells;
+    const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+    const label* losortStart = dm.losortStart.data(); const scalar* phiIntD = phiInt.data();
+    const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+    const scalar* bvalD = bval.data(); const scalar* Vd = dm.V.data(); scalar* dd = d.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        divKernel(nC, ownerStart, losort, losortStart, phiIntD, bndCellStart, bndPerm, bvalD, Vd, dd); });
     cudaCheck(cudaGetLastError(), "div");
 }
 
@@ -137,11 +147,20 @@ void deviceGaussGrad(
     gx.resize(dm.nCells);
     gy.resize(dm.nCells);
     gz.resize(dm.nCells);
-    gradKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.owner.data(), dm.nei.data(), dm.w.data(),
-                                            dm.Sfx.data(), dm.Sfy.data(), dm.Sfz.data(), vol.data(),
-                                            dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-                                            dm.bndCellStart.data(), dm.bndPerm.data(), dm.bndGFace.data(), bval.data(),
-                                            dm.V.data(), gx.data(), gy.data(), gz.data());
+    {
+        const int nC = dm.nCells;
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* Sfx = dm.Sfx.data(); const scalar* Sfy = dm.Sfy.data(); const scalar* Sfz = dm.Sfz.data();
+        const scalar* vold = vol.data();
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+        const label* bndGFace = dm.bndGFace.data(); const scalar* bvalD = bval.data();
+        const scalar* Vd = dm.V.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            gradKernel(nC, own, nei, w, Sfx, Sfy, Sfz, vold, ownerStart, losort, losortStart,
+                       bndCellStart, bndPerm, bndGFace, bvalD, Vd, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(), "gaussGrad");
 }
 
@@ -158,7 +177,7 @@ scalar limFace(scalar maxD, scalar minD, scalar ex)
 }
 
 
-__global__
+__device__
 void cellLimitGradKernel(
     int nC,
     scalar k,
@@ -260,7 +279,7 @@ __device__ __forceinline__ void atomicFmin(scalar* a, scalar v)
 
 // Phase 1 on cells: maxD/minD from the internal + non-coupled boundary faces only. Split out of
 // cellLimitGradKernel so the interface faces can be folded in between the two halves.
-__global__
+__device__
 void cellLimitMinMaxKernel(
     int nC,
     const scalar* __restrict__ U,
@@ -290,7 +309,7 @@ void cellLimitMinMaxKernel(
 }
 
 // Phase 2 on interface faces: the coupled neighbour joins the cell's range.
-__global__
+__device__
 void ifMinMaxKernel(int n, const label* __restrict__ own, const scalar* __restrict__ nbrVal,
                     const scalar* __restrict__ U, scalar* __restrict__ maxD, scalar* __restrict__ minD)
 {
@@ -303,7 +322,7 @@ void ifMinMaxKernel(int n, const label* __restrict__ own, const scalar* __restri
 }
 
 // Phase 3: OF's k<1 widening, applied once the range is complete (interfaces included).
-__global__
+__device__
 void widenKernel(int nC, scalar k, scalar* __restrict__ maxD, scalar* __restrict__ minD)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -314,7 +333,7 @@ void widenKernel(int nC, scalar k, scalar* __restrict__ maxD, scalar* __restrict
 }
 
 // Phase 4 on cells: the limiter from the internal + non-coupled boundary face extrapolations.
-__global__
+__device__
 void cellLimitFactorKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -343,7 +362,7 @@ void cellLimitFactorKernel(
 }
 
 // Phase 5 on interface faces: OF's second loop is over EVERY boundary face, not just the uncoupled ones.
-__global__
+__device__
 void ifLimitKernel(int n, const label* __restrict__ own,
                    const scalar* __restrict__ dx, const scalar* __restrict__ dy, const scalar* __restrict__ dz,
                    const scalar* __restrict__ maxD, const scalar* __restrict__ minD,
@@ -356,7 +375,7 @@ void ifLimitKernel(int n, const label* __restrict__ own,
     atomicFmin(&lim[c], limFace(maxD[c], minD[c], dx[i]*gx[c] + dy[i]*gy[c] + dz[i]*gz[c]));
 }
 
-__global__
+__device__
 void applyLimitKernel(int nC, const scalar* __restrict__ lim,
                       scalar* __restrict__ gx, scalar* __restrict__ gy, scalar* __restrict__ gz)
 {
@@ -391,34 +410,79 @@ void deviceCellLimitGrad(
         // single-kernel path below, just split where a scatter can be inserted.
         const int nC = dm.nCells;
         DeviceBuffer<scalar> maxD(nC), minD(nC), lim(nC);
-        cellLimitMinMaxKernel<<<nBlocks(nC), TPB>>>(nC, U.data(), Ubnd.data(),
-            dm.ownerStart.data(), dm.nei.data(), dm.losort.data(), dm.losortStart.data(), dm.owner.data(),
-            dm.bndCellStart.data(), dm.bndPerm.data(), maxD.data(), minD.data());
+        {
+            const scalar* Ud = U.data(); const scalar* Ubndd = Ubnd.data();
+            const label* ownerStart = dm.ownerStart.data(); const label* nei = dm.nei.data();
+            const label* losort = dm.losort.data(); const label* losortStart = dm.losortStart.data();
+            const label* owner = dm.owner.data();
+            const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+            scalar* maxDd = maxD.data(); scalar* minDd = minD.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                cellLimitMinMaxKernel(nC, Ud, Ubndd, ownerStart, nei, losort, losortStart, owner,
+                                       bndCellStart, bndPerm, maxDd, minDd); });
+        }
         for (int i = 0; i < nIfs; ++i)
             if (ifs[i].n > 0 && ifs[i].nbrVal)
-                ifMinMaxKernel<<<nBlocks(ifs[i].n), TPB>>>(ifs[i].n, ifs[i].ownCell, ifs[i].nbrVal,
-                                                           U.data(), maxD.data(), minD.data());
-        if (k < 1.0) widenKernel<<<nBlocks(nC), TPB>>>(nC, k, maxD.data(), minD.data());
-        cellLimitFactorKernel<<<nBlocks(nC), TPB>>>(nC,
-            dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-            dm.bndCellStart.data(), dm.bndPerm.data(),
-            dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(), dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-            dm.dBndX.data(), dm.dBndY.data(), dm.dBndZ.data(), maxD.data(), minD.data(),
-            gx.data(), gy.data(), gz.data(), lim.data());
+            {
+                const int n = ifs[i].n; const label* ownCell = ifs[i].ownCell; const scalar* nbrVal = ifs[i].nbrVal;
+                const scalar* Ud = U.data(); scalar* maxDd = maxD.data(); scalar* minDd = minD.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+                    ifMinMaxKernel(n, ownCell, nbrVal, Ud, maxDd, minDd); });
+            }
+        if (k < 1.0)
+        {
+            scalar* maxDd = maxD.data(); scalar* minDd = minD.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { widenKernel(nC, k, maxDd, minDd); });
+        }
+        {
+            const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+            const label* losortStart = dm.losortStart.data();
+            const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+            const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+            const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+            const scalar* dBndX = dm.dBndX.data(); const scalar* dBndY = dm.dBndY.data(); const scalar* dBndZ = dm.dBndZ.data();
+            const scalar* maxDd = maxD.data(); const scalar* minDd = minD.data();
+            const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+            scalar* limd = lim.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                cellLimitFactorKernel(nC, ownerStart, losort, losortStart, bndCellStart, bndPerm,
+                                       dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, dBndX, dBndY, dBndZ,
+                                       maxDd, minDd, gxd, gyd, gzd, limd); });
+        }
         for (int i = 0; i < nIfs; ++i)
             if (ifs[i].n > 0 && ifs[i].nbrVal)
-                ifLimitKernel<<<nBlocks(ifs[i].n), TPB>>>(ifs[i].n, ifs[i].ownCell,
-                    ifs[i].dOwnX, ifs[i].dOwnY, ifs[i].dOwnZ, maxD.data(), minD.data(),
-                    gx.data(), gy.data(), gz.data(), lim.data());
-        applyLimitKernel<<<nBlocks(nC), TPB>>>(nC, lim.data(), gx.data(), gy.data(), gz.data());
+            {
+                const int n = ifs[i].n; const label* ownCell = ifs[i].ownCell;
+                const scalar* dOwnX = ifs[i].dOwnX; const scalar* dOwnY = ifs[i].dOwnY; const scalar* dOwnZ = ifs[i].dOwnZ;
+                const scalar* maxDd = maxD.data(); const scalar* minDd = minD.data();
+                const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+                scalar* limd = lim.data();
+                pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+                    ifLimitKernel(n, ownCell, dOwnX, dOwnY, dOwnZ, maxDd, minDd, gxd, gyd, gzd, limd); });
+            }
+        {
+            const scalar* limd = lim.data(); scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { applyLimitKernel(nC, limd, gxd, gyd, gzd); });
+        }
         cudaCheck(cudaGetLastError(), "cellLimitGradInterface");
         return;
     }
-    cellLimitGradKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, k, U.data(), Ubnd.data(),
-        dm.ownerStart.data(), dm.nei.data(), dm.losort.data(), dm.losortStart.data(), dm.owner.data(),
-        dm.bndCellStart.data(), dm.bndPerm.data(),
-        dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(), dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-        dm.dBndX.data(), dm.dBndY.data(), dm.dBndZ.data(), gx.data(), gy.data(), gz.data());
+    {
+        const int nC = dm.nCells;
+        const scalar* Ud = U.data(); const scalar* Ubndd = Ubnd.data();
+        const label* ownerStart = dm.ownerStart.data(); const label* nei = dm.nei.data();
+        const label* losort = dm.losort.data(); const label* losortStart = dm.losortStart.data();
+        const label* owner = dm.owner.data();
+        const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+        const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+        const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+        const scalar* dBndX = dm.dBndX.data(); const scalar* dBndY = dm.dBndY.data(); const scalar* dBndZ = dm.dBndZ.data();
+        scalar* gxd = gx.data(); scalar* gyd = gy.data(); scalar* gzd = gz.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            cellLimitGradKernel(nC, k, Ud, Ubndd, ownerStart, nei, losort, losortStart, owner,
+                                 bndCellStart, bndPerm, dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ,
+                                 dBndX, dBndY, dBndZ, gxd, gyd, gzd); });
+    }
     cudaCheck(cudaGetLastError(), "cellLimitGrad");
 }
 

--- a/src/cuda/device_fvm.cu
+++ b/src/cuda/device_fvm.cu
@@ -4,6 +4,7 @@
 //   laplacian : upper=lower = deltaCoeffs * gammaf * |Sf|
 //   div upwind: lower = -max(phi,0)... w=(phi>=0); lower=-w*phi; upper=lower+phi
 #include "device_mesh.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -13,7 +14,7 @@ constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
-__global__
+__device__
 void lapFaceKernel(
     int nIf,
     const scalar* __restrict__ dc,
@@ -39,7 +40,7 @@ void lapFaceKernel(
 // So this differs from divFaceKernel by one line -- the weight -- and nothing else. It is UNBOUNDED by
 // construction (that is what central differencing is), which is why OF pairs it with `bounded` on
 // convection-dominated cases and why LES uses it deliberately.
-__global__
+__device__
 void divFaceLinearKernel(int nIf, const scalar* __restrict__ phi, const scalar* __restrict__ w,
                          scalar* __restrict__ upper, scalar* __restrict__ lower)
 {
@@ -53,7 +54,7 @@ void divFaceLinearKernel(int nIf, const scalar* __restrict__ phi, const scalar* 
     }
 }
 
-__global__
+__device__
 void divFaceKernel(int nIf, const scalar* __restrict__ phi, scalar* __restrict__ upper, scalar* __restrict__ lower)
 {
     const int f = blockIdx.x * blockDim.x + threadIdx.x;
@@ -71,7 +72,7 @@ void divFaceKernel(int nIf, const scalar* __restrict__ phi, scalar* __restrict__
 // limitedLinear convection: W_f = limiter*CDweight + (1-limiter)*pos0(phi); limiter = clamp(twoByk*r,0,1),
 // r = NVDTVD gradient ratio. Reduces EXACTLY to upwind divFaceKernel at limiter=0. (OF gaussConvectionScheme +
 // limitedSurfaceInterpolationScheme::weights + NVDTVD::r.) gradc{X,Y,Z} = grad(field); d = (Cf-C_own)-(Cf-C_nei).
-__global__
+__device__
 void divLimitedFaceKernel(
     int nIf,
     const label* __restrict__ own,
@@ -133,7 +134,7 @@ void divLimitedFaceKernel(
 // gradcf = gradfV.(d & gradU[upwind]), r = 2*gradcf/gradf - 1. One limiter -> W applied to all 3 components (the
 // convection matrix is shared, so this feeds mDiag/mUp/mLo implicitly, exactly as the magSqr path does). gU{n}{x,y,z}
 // = grad(U_n) cell fields; d = (Cf-C_own)-(Cf-C_nei) = C[N]-C[P].
-__global__
+__device__
 void divLimitedVFaceKernel(
     int nIf,
     const label* __restrict__ own,
@@ -190,7 +191,7 @@ void divLimitedVFaceKernel(
 }
 
 
-__global__
+__device__
 void diagGatherKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -214,7 +215,7 @@ void diagGatherKernel(
 
 // Fold the boundary into the solve: diagC = rawDiag + sum internalCoeffs over c's boundary faces;
 // b = V*divPhi + sum boundaryCoeffs (= brae::pcg's addBoundaryDiag/addBoundarySource + pEqn source V*div).
-__global__
+__device__
 void foldPressureKernel(
     int nC,
     const label* __restrict__ bndCellStart,
@@ -257,16 +258,27 @@ void deviceLaplacianCoeffs(
     diag.resize(nC);
     // corrected scheme uses nonOrthDeltaCoeffs = 1/max(n.delta, 0.05|delta|) for the implicit part.
     const scalar* dcPtr = nonOrth ? dm.nonOrthDc.data() : dm.dc.data();
-    lapFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dcPtr, gammafInt.data(), dm.magSf.data(), upper.data(), lower.data());
+    {
+        const scalar* gammafD = gammafInt.data(); const scalar* magSf = dm.magSf.data();
+        scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            lapFaceKernel(nIf, dcPtr, gammafD, magSf, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "lapFace");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
 
 namespace {
 // faceFluxCorr_f = gamma_f*|Sf|_f * (corrVec_f . grad(vf)_f), grad linearly interpolated owner/neighbour.
-__global__
+__device__
 void lapCorrFaceKernel(
     int nIf,
     const label* __restrict__ own,
@@ -301,7 +313,7 @@ void lapCorrFaceKernel(
 // psi=1 -> unlimited (== corrected); the caller skips this kernel entirely then (bit-identical). psi<1 caps only the
 // pathological faces where |corr| > |orthSn| (e.g. extreme-aspect-ratio + high-non-orth cells); well-behaved faces
 // (|corr| small) keep limiter==1 == full correction, so accuracy on the bulk mesh is preserved.
-__global__
+__device__
 void lapCorrFaceLimitedKernel(
     int nIf,
     const label* __restrict__ own,
@@ -335,7 +347,7 @@ void lapCorrFaceLimitedKernel(
 
 
 // lapCorrSource[c] = -V*fvc::div(ffc)[c] = -sum_{f: owner=c} ffc + sum_{f: nei=c} ffc.
-__global__
+__device__
 void lapCorrGatherKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -368,9 +380,15 @@ void deviceLaplacianCorrFlux(
 {
     const int nIf = dm.nInternalFaces;
     ffc.resize(nIf);
-    lapCorrFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), gammafInt.data(), dm.magSf.data(),
-                                             dm.corrVecX.data(), dm.corrVecY.data(), dm.corrVecZ.data(),
-                                             gx.data(), gy.data(), gz.data(), ffc.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* gammafD = gammafInt.data(); const scalar* magSf = dm.magSf.data();
+        const scalar* cvx = dm.corrVecX.data(); const scalar* cvy = dm.corrVecY.data(); const scalar* cvz = dm.corrVecZ.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* ffcd = ffc.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            lapCorrFaceKernel(nIf, own, nei, w, gammafD, magSf, cvx, cvy, cvz, gxd, gyd, gzd, ffcd); });
+    }
     cudaCheck(cudaGetLastError(), "lapCorrFace");
 }
 
@@ -394,9 +412,16 @@ void deviceLaplacianCorrFluxLimited(
     }
     const int nIf = dm.nInternalFaces;
     ffc.resize(nIf);
-    lapCorrFaceLimitedKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), gammafInt.data(), dm.magSf.data(),
-                                                    dm.corrVecX.data(), dm.corrVecY.data(), dm.corrVecZ.data(),
-                                                    dm.nonOrthDc.data(), phi.data(), gx.data(), gy.data(), gz.data(), psi, ffc.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* gammafD = gammafInt.data(); const scalar* magSf = dm.magSf.data();
+        const scalar* cvx = dm.corrVecX.data(); const scalar* cvy = dm.corrVecY.data(); const scalar* cvz = dm.corrVecZ.data();
+        const scalar* nonOrthDc = dm.nonOrthDc.data(); const scalar* phid = phi.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* ffcd = ffc.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            lapCorrFaceLimitedKernel(nIf, own, nei, w, gammafD, magSf, cvx, cvy, cvz, nonOrthDc, phid, gxd, gyd, gzd, psi, ffcd); });
+    }
     cudaCheck(cudaGetLastError(), "lapCorrFaceLimited");
 }
 
@@ -406,7 +431,13 @@ void deviceFaceDivSource(const DeviceMesh& dm, const DeviceBuffer<scalar>& ffc, 
 {
     const int nC = dm.nCells;
     src.resize(nC);
-    lapCorrGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), ffc.data(), src.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* ffcD = ffc.data(); scalar* srcd = src.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lapCorrGatherKernel(nC, ownerStart, losort, losortStart, ffcD, srcd); });
+    }
     cudaCheck(cudaGetLastError(), "lapCorrGather");
 }
 
@@ -437,9 +468,20 @@ void deviceDivCentralCoeffs(
     upper.resize(nIf);
     lower.resize(nIf);
     diag.resize(nC);
-    divFaceLinearKernel<<<nBlocks(nIf), TPB>>>(nIf, phiInt.data(), dm.w.data(), upper.data(), lower.data());
+    {
+        const scalar* phiIntD = phiInt.data(); const scalar* w = dm.w.data();
+        scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            divFaceLinearKernel(nIf, phiIntD, w, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "divFaceLinear");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
@@ -454,9 +496,19 @@ void deviceDivUpwindCoeffs(
     upper.resize(nIf);
     lower.resize(nIf);
     diag.resize(nC);
-    divFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, phiInt.data(), upper.data(), lower.data());
+    {
+        const scalar* phiIntD = phiInt.data(); scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            divFaceKernel(nIf, phiIntD, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "divFace");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
@@ -477,13 +529,25 @@ void deviceDivLimitedCoeffs(
     upper.resize(nIf);
     lower.resize(nIf);
     diag.resize(nC);
-    divLimitedFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), phiInt.data(), field.data(),
-                                                gx.data(), gy.data(), gz.data(),
-                                                dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(),
-                                                dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-                                                twoByk, upper.data(), lower.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* phiIntD = phiInt.data(); const scalar* fieldD = field.data();
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+        const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+        scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            divLimitedFaceKernel(nIf, own, nei, w, phiIntD, fieldD, gxd, gyd, gzd,
+                                  dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, twoByk, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "divLimitedFace");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
@@ -504,16 +568,29 @@ void deviceDivLimitedVCoeffs(
     upper.resize(nIf);
     lower.resize(nIf);
     diag.resize(nC);
-    divLimitedVFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), phiInt.data(),
-                                                 U[0].data(), U[1].data(), U[2].data(),
-                                                 gUx[0].data(), gUy[0].data(), gUz[0].data(),
-                                                 gUx[1].data(), gUy[1].data(), gUz[1].data(),
-                                                 gUx[2].data(), gUy[2].data(), gUz[2].data(),
-                                                 dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(),
-                                                 dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-                                                 twoByk, upper.data(), lower.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* phiIntD = phiInt.data();
+        const scalar* U0 = U[0].data(); const scalar* U1 = U[1].data(); const scalar* U2 = U[2].data();
+        const scalar* gU0x = gUx[0].data(); const scalar* gU0y = gUy[0].data(); const scalar* gU0z = gUz[0].data();
+        const scalar* gU1x = gUx[1].data(); const scalar* gU1y = gUy[1].data(); const scalar* gU1z = gUz[1].data();
+        const scalar* gU2x = gUx[2].data(); const scalar* gU2y = gUy[2].data(); const scalar* gU2z = gUz[2].data();
+        const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+        const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+        scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            divLimitedVFaceKernel(nIf, own, nei, w, phiIntD, U0, U1, U2,
+                                   gU0x, gU0y, gU0z, gU1x, gU1y, gU1z, gU2x, gU2y, gU2z,
+                                   dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, twoByk, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "divLimitedVFace");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
@@ -537,16 +614,29 @@ void deviceDivLimitedVCoeffs(
     lower.resize(nIf);
     diag.resize(nC);
     const scalar* g = gradU.data();
-    divLimitedVFaceKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), phiInt.data(),
-                                                 U[0].data(), U[1].data(), U[2].data(),
-                                                 g + 0*nC, g + 3*nC, g + 6*nC,     // d(U_0)/d{x,y,z}
-                                                 g + 1*nC, g + 4*nC, g + 7*nC,     // d(U_1)/d{x,y,z}
-                                                 g + 2*nC, g + 5*nC, g + 8*nC,     // d(U_2)/d{x,y,z}
-                                                 dm.dOwnX.data(), dm.dOwnY.data(), dm.dOwnZ.data(),
-                                                 dm.dNeiX.data(), dm.dNeiY.data(), dm.dNeiZ.data(),
-                                                 twoByk, upper.data(), lower.data());
+    {
+        const label* own = dm.owner.data(); const label* nei = dm.nei.data(); const scalar* w = dm.w.data();
+        const scalar* phiIntD = phiInt.data();
+        const scalar* U0 = U[0].data(); const scalar* U1 = U[1].data(); const scalar* U2 = U[2].data();
+        const scalar* gU0x = g + 0*nC; const scalar* gU0y = g + 3*nC; const scalar* gU0z = g + 6*nC;
+        const scalar* gU1x = g + 1*nC; const scalar* gU1y = g + 4*nC; const scalar* gU1z = g + 7*nC;
+        const scalar* gU2x = g + 2*nC; const scalar* gU2y = g + 5*nC; const scalar* gU2z = g + 8*nC;
+        const scalar* dOwnX = dm.dOwnX.data(); const scalar* dOwnY = dm.dOwnY.data(); const scalar* dOwnZ = dm.dOwnZ.data();
+        const scalar* dNeiX = dm.dNeiX.data(); const scalar* dNeiY = dm.dNeiY.data(); const scalar* dNeiZ = dm.dNeiZ.data();
+        scalar* upperD = upper.data(); scalar* lowerD = lower.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            divLimitedVFaceKernel(nIf, own, nei, w, phiIntD, U0, U1, U2,
+                                   gU0x, gU0y, gU0z, gU1x, gU1y, gU1z, gU2x, gU2y, gU2z,
+                                   dOwnX, dOwnY, dOwnZ, dNeiX, dNeiY, dNeiZ, twoByk, upperD, lowerD); });
+    }
     cudaCheck(cudaGetLastError(), "divLimitedVFacePacked");
-    diagGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(), upper.data(), lower.data(), diag.data());
+    {
+        const label* ownerStart = dm.ownerStart.data(); const label* losort = dm.losort.data();
+        const label* losortStart = dm.losortStart.data();
+        const scalar* upperD = upper.data(); const scalar* lowerD = lower.data(); scalar* diagD = diag.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            diagGatherKernel(nC, ownerStart, losort, losortStart, upperD, lowerD, diagD); });
+    }
     cudaCheck(cudaGetLastError(), "diagGather");
 }
 
@@ -563,14 +653,20 @@ void deviceFoldPressure(
     const int nC = dm.nCells;
     diagC.resize(nC);
     b.resize(nC);
-    foldPressureKernel<<<nBlocks(nC), TPB>>>(nC, dm.bndCellStart.data(), dm.bndPerm.data(), rawDiag.data(),
-                                             dm.V.data(), divPhi.data(), iC.data(), bC.data(), diagC.data(), b.data());
+    {
+        const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+        const scalar* rawDiagD = rawDiag.data(); const scalar* Vd = dm.V.data(); const scalar* divPhiD = divPhi.data();
+        const scalar* iCd = iC.data(); const scalar* bCd = bC.data();
+        scalar* diagCd = diagC.data(); scalar* bd = b.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            foldPressureKernel(nC, bndCellStart, bndPerm, rawDiagD, Vd, divPhiD, iCd, bCd, diagCd, bd); });
+    }
     cudaCheck(cudaGetLastError(), "foldPressure");
 }
 
 
 namespace {
-__global__
+__device__
 void foldKernel(
     int nC,
     const label* __restrict__ bndCellStart,
@@ -611,8 +707,14 @@ void deviceFold(
     const int nC = dm.nCells;
     diagC.resize(nC);
     b.resize(nC);
-    foldKernel<<<nBlocks(nC), TPB>>>(nC, dm.bndCellStart.data(), dm.bndPerm.data(), rawDiag.data(),
-                                     source.data(), iC.data(), bC.data(), diagC.data(), b.data());
+    {
+        const label* bndCellStart = dm.bndCellStart.data(); const label* bndPerm = dm.bndPerm.data();
+        const scalar* rawDiagD = rawDiag.data(); const scalar* sourceD = source.data();
+        const scalar* iCd = iC.data(); const scalar* bCd = bC.data();
+        scalar* diagCd = diagC.data(); scalar* bd = b.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            foldKernel(nC, bndCellStart, bndPerm, rawDiagD, sourceD, iCd, bCd, diagCd, bd); });
+    }
     cudaCheck(cudaGetLastError(), "fold");
 }
 

--- a/src/cuda/device_generalized_newtonian.cu
+++ b/src/cuda/device_generalized_newtonian.cu
@@ -1,5 +1,6 @@
 // device_generalized_newtonian.cu -- see the header for the OF definitions this reproduces.
 #include "device_generalized_newtonian.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -18,7 +19,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 // relying on the clamp is what makes that corner defined.
 constexpr scalar kSmall = 1.0e-15;
 
-__global__
+__device__
 void gnPowerLawMuKernel(
     int nC,
     const scalar* __restrict__ S2,
@@ -52,8 +53,12 @@ void deviceGeneralizedNewtonianPowerLawMu(
     const int nC = static_cast<int>(mu.size());
     if (nC == 0) return;
     if (static_cast<int>(S2.size()) != nC || static_cast<int>(rho.size()) != nC) return;
-    gnPowerLawMuKernel<<<nBlocks(nC), TPB>>>(
-        nC, S2.data(), rho.data(), nuMin, nuMax, n, mu.data());
+    const scalar* S2d = S2.data();
+    const scalar* rhod = rho.data();
+    scalar* mud = mu.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        gnPowerLawMuKernel(nC, S2d, rhod, nuMin, nuMax, n, mud);
+    });
     cudaCheck(cudaGetLastError(), "generalizedNewtonianPowerLawMu");
 }
 

--- a/src/cuda/device_kepsilon.cu
+++ b/src/cuda/device_kepsilon.cu
@@ -13,6 +13,7 @@
 #include "device_interface.cuh"  // interface<Op>() overloads dispatching to the cyclic/AMI backends
 #include "device_amg.cuh"        // deviceSymGaussSeidel (scalar smoothSolver, for stiff low-Re k/omega)
 #include "nut_wall_function.cuh" // nutkWallFunctionValue / yPlusWall (shared wall-nut physics, BRAE_HD)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <vector>
 
@@ -27,7 +28,7 @@ namespace {
 inline scalar yPlusLamHost(scalar kappa, scalar E) { scalar y = 11.0; for (int i = 0; i < 10; ++i) y = std::log(std::fmax(E * y, 1.0)) / kappa; return y; }
 
 
-__global__
+__device__
 void gByNuKernel(int nC, const scalar* __restrict__ gradU, scalar* __restrict__ gByNu)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -49,7 +50,7 @@ void gByNuKernel(int nC, const scalar* __restrict__ gradU, scalar* __restrict__ 
 }
 
 
-__global__
+__device__
 void nutKernel(int nC, const scalar* __restrict__ k, const scalar* __restrict__ eps, scalar Cmu, scalar* __restrict__ nut)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -60,7 +61,7 @@ void nutKernel(int nC, const scalar* __restrict__ k, const scalar* __restrict__ 
 // realizableKE rCmu (variable Cmu) + magS from the gradU tensor. S=devSymm(gradU); S2=2*magSqr(S); magS=sqrt(S2);
 // W=2sqrt2*tr(S^3)/(magS*S2); phis=acos(clamp(sqrt6*W,[-1,1]))/3; As=sqrt6*cos(phis); Us=sqrt(S2/2+magSqr(skew));
 // rCmu=1/(A0 + As*Us*k/eps).  (OF realizableKE::rCmu, gradU_ij = t[i*3+j] = dU_j/dx_i.)
-__global__
+__device__
 void rkeStrainKernel(
     int nC,
     const scalar* __restrict__ gradU,
@@ -107,7 +108,7 @@ void rkeStrainKernel(
 }
 
 
-__global__
+__device__
 void rkeNutKernel(
     int nC,
     const scalar* __restrict__ rCmu,
@@ -122,7 +123,7 @@ void rkeNutKernel(
 
 // realizableKE eps reaction: production C1*magS*eps (explicit), destruction fvm::Sp(C2*eps/(k+sqrt(nu*eps)),eps).
 // C1 = max(eta/(5+eta), 0.43), eta = magS*k/eps. No divU term (unlike standard kEpsilon).
-__global__
+__device__
 void rkeEpsReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -145,7 +146,7 @@ void rkeEpsReactionKernel(
 }
 
 
-__global__
+__device__
 void wallFnKernel(
     int nWF,
     const label* __restrict__ wfCell,
@@ -186,7 +187,7 @@ void wallFnKernel(
 
 
 // boundary nut per face: wall -> nutkWallFunction(k[cell], y, nu); else -> nut[cell] (calculated/extrapolated).
-__global__
+__device__
 void boundaryNutKernel(
     int n,
     const label* __restrict__ fc,
@@ -235,7 +236,7 @@ void boundaryNutKernel(
 }
 
 
-__global__
+__device__
 void epsReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -277,7 +278,7 @@ void epsReactionKernel(
 }
 
 
-__global__
+__device__
 void kReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -305,7 +306,7 @@ void kReactionKernel(
 
 // OF Foam::bound(): negative cells -> fvc::average(max(field,floor)) (local face-neighbour avg), positive cells ->
 // max(field,floor). Prevents nut=Cmu k^2/eps blowing up when limitedLinear overshoots eps<0 (vs clamping to floor).
-__global__
+__device__
 void boundClampKernel(int nC, scalar floor, const scalar* __restrict__ x, scalar* __restrict__ cl)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -313,7 +314,7 @@ void boundClampKernel(int nC, scalar floor, const scalar* __restrict__ x, scalar
 }
 
 
-__global__
+__device__
 void boundAvgGatherKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -338,7 +339,7 @@ void boundAvgGatherKernel(
 }
 
 
-__global__
+__device__
 void boundApplyKernel(int nC, scalar floor, const scalar* __restrict__ avg, scalar* __restrict__ x)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -393,7 +394,8 @@ void deviceGradU(
 void deviceGByNuFromGradU(const DeviceBuffer<scalar>& gradU, int nC, DeviceBuffer<scalar>& gByNu)
 {
     gByNu.resize(nC);
-    gByNuKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), gByNu.data());
+    const scalar* gradUd = gradU.data(); scalar* gByNud = gByNu.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { gByNuKernel(nC, gradUd, gByNud); });
     cudaCheck(cudaGetLastError(), "gByNu");
 }
 
@@ -422,7 +424,8 @@ void deviceNut(
 {
     const int nC = static_cast<int>(k.size());
     nut.resize(nC);
-    nutKernel<<<nBlocks(nC), TPB>>>(nC, k.data(), eps.data(), co.Cmu, nut.data());
+    const scalar* kd = k.data(); const scalar* epsd = eps.data(); const scalar Cmu = co.Cmu; scalar* nutd = nut.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { nutKernel(nC, kd, epsd, Cmu, nutd); });
     cudaCheck(cudaGetLastError(), "nut");
 }
 
@@ -439,7 +442,9 @@ void deviceRealizableStrain(
 {
     rCmu.resize(nC);
     magS.resize(nC);
-    rkeStrainKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), k.data(), eps.data(), A0, rCmu.data(), magS.data());
+    const scalar *gradUd = gradU.data(), *kd = k.data(), *epsd = eps.data();
+    scalar *rCmud = rCmu.data(), *magSd = magS.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { rkeStrainKernel(nC, gradUd, kd, epsd, A0, rCmud, magSd); });
     cudaCheck(cudaGetLastError(), "rkeStrain");
 }
 
@@ -452,7 +457,8 @@ void deviceRealizableNut(
 {
     const int nC = static_cast<int>(k.size());
     nut.resize(nC);
-    rkeNutKernel<<<nBlocks(nC), TPB>>>(nC, rCmu.data(), k.data(), eps.data(), nut.data());
+    const scalar *rCmud = rCmu.data(), *kd = k.data(), *epsd = eps.data(); scalar* nutd = nut.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { rkeNutKernel(nC, rCmud, kd, epsd, nutd); });
     cudaCheck(cudaGetLastError(), "rkeNut");
 }
 
@@ -467,8 +473,14 @@ void deviceEpsReactionRealizable(
     DeviceBuffer<scalar>& diag,
     DeviceBuffer<scalar>& source)
 {
-    rkeEpsReactionKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.V.data(), eps.data(), k.data(), magS.data(),
-                                                      nu, C2, diag.data(), source.data());
+    {
+        const int nC = dm.nCells;
+        const scalar *Vd = dm.V.data(), *epsd = eps.data(), *kd = k.data(), *magSd = magS.data();
+        scalar *diagd = diag.data(), *sourced = source.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            rkeEpsReactionKernel(nC, Vd, epsd, kd, magSd, nu, C2, diagd, sourced);
+        });
+    }
     cudaCheck(cudaGetLastError(), "rkeEpsReaction");
 }
 
@@ -478,13 +490,22 @@ void deviceBoundField(const DeviceMesh& dm, DeviceBuffer<scalar>& x, scalar floo
 {
     const int nC = dm.nCells;
     DeviceBuffer<scalar> cl(static_cast<std::size_t>(nC));
-    boundClampKernel<<<nBlocks(nC), TPB>>>(nC, floor, x.data(), cl.data());
+    scalar* xd = x.data(); scalar* cld = cl.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { boundClampKernel(nC, floor, xd, cld); });
     DeviceBuffer<scalar> fi;
     deviceInterpolate(dm, cl, fi);   // linearInterpolate(max(field,floor))
     DeviceBuffer<scalar> avg(static_cast<std::size_t>(nC));
-    boundAvgGatherKernel<<<nBlocks(nC), TPB>>>(nC, dm.ownerStart.data(), dm.losort.data(), dm.losortStart.data(),
-                                               dm.bndCellStart.data(), fi.data(), cl.data(), avg.data());
-    boundApplyKernel<<<nBlocks(nC), TPB>>>(nC, floor, avg.data(), x.data());
+    {
+        const label *ownerStart = dm.ownerStart.data(), *losort = dm.losort.data(), *losortStart = dm.losortStart.data();
+        const label* bndCellStart = dm.bndCellStart.data(); const scalar* fid = fi.data(); scalar* avgd = avg.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            boundAvgGatherKernel(nC, ownerStart, losort, losortStart, bndCellStart, fid, cld, avgd);
+        });
+    }
+    {
+        const scalar* avgd = avg.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { boundApplyKernel(nC, floor, avgd, xd); });
+    }
     cudaCheck(cudaGetLastError(), "boundField");
 }
 
@@ -512,10 +533,19 @@ void deviceWallEpsG0(
     cudaCheck(cudaMemsetAsync(G0.data(),   0, nC*sizeof(scalar), cudaStreamPerThread), "G0 zero");
     const scalar Cmu25 = std::pow(co.Cmu, 0.25), Cmu75 = std::pow(co.Cmu, 0.75), yplLam = yPlusLamHost(co.kappa, co.E);
     if (w.nWF > 0)
-        wallFnKernel<<<nBlocks(w.nWF), TPB>>>(w.nWF, w.wfCell.data(), w.wfY.data(), w.wfDc.data(), w.wfUwx.data(),
-                                              w.wfUwy.data(), w.wfUwz.data(), w.invNw.data(), k.data(), Ux.data(), Uy.data(),
-                                              Uz.data(), nu, yplLam, Cmu25, Cmu75, co.kappa, co.E, atmZ0, atmBoundNut, nutWall, eps0.data(), G0.data(),
-                                              (nuFace && nuFace->size()) ? nuFace->data() : nullptr);
+    {
+        const int nWF = w.nWF;
+        const label* wfCell = w.wfCell.data();
+        const scalar *wfY = w.wfY.data(), *wfDc = w.wfDc.data();
+        const scalar *wux = w.wfUwx.data(), *wuy = w.wfUwy.data(), *wuz = w.wfUwz.data(), *invNw = w.invNw.data();
+        const scalar *kd = k.data(), *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data();
+        const scalar kappa = co.kappa, E = co.E; scalar *eps0d = eps0.data(), *G0d = G0.data();
+        const scalar* nuFaced = (nuFace && nuFace->size()) ? nuFace->data() : nullptr;
+        pcudaParallelFor(nBlocks(nWF), TPB, [=] __device__ () {
+            wallFnKernel(nWF, wfCell, wfY, wfDc, wux, wuy, wuz, invNw, kd, Uxd, Uyd, Uzd, nu, yplLam, Cmu25, Cmu75,
+                        kappa, E, atmZ0, atmBoundNut, nutWall, eps0d, G0d, nuFaced);
+        });
+    }
     cudaCheck(cudaGetLastError(), "wallFn");
 }
 
@@ -531,11 +561,16 @@ void deviceEpsReaction(
     const KEpsilonCoeffs& co,
     const DeviceBuffer<scalar>* rho)
 {
-    epsReactionKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.V.data(), eps.data(), k.data(), gByNu.data(), divU.data(),
-                                                   co.C1, co.C2, co.C3, co.Cmu,
-                                                   co.rng ? 1 : 0, co.eta0, co.beta,
-                                                   diag.data(), source.data(),
-                                                   rho ? rho->data() : nullptr);
+    {
+        const int nC = dm.nCells;
+        const scalar *Vd = dm.V.data(), *epsd = eps.data(), *kd = k.data(), *gByNud = gByNu.data(), *divUd = divU.data();
+        const scalar C1 = co.C1, C2 = co.C2, C3 = co.C3, Cmu = co.Cmu, eta0 = co.eta0, beta = co.beta;
+        const int rng = co.rng ? 1 : 0;
+        scalar *diagd = diag.data(), *sourced = source.data(); const scalar* rhod = rho ? rho->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            epsReactionKernel(nC, Vd, epsd, kd, gByNud, divUd, C1, C2, C3, Cmu, rng, eta0, beta, diagd, sourced, rhod);
+        });
+    }
     cudaCheck(cudaGetLastError(), "epsReaction");
 }
 
@@ -550,8 +585,14 @@ void deviceKReaction(
     DeviceBuffer<scalar>& source,
     const DeviceBuffer<scalar>* rho)
 {
-    kReactionKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.V.data(), k.data(), eps.data(), G.data(), divU.data(),
-                                                 diag.data(), source.data(), rho ? rho->data() : nullptr);
+    {
+        const int nC = dm.nCells;
+        const scalar *Vd = dm.V.data(), *kd = k.data(), *epsd = eps.data(), *Gd = G.data(), *divUd = divU.data();
+        scalar *diagd = diag.data(), *sourced = source.data(); const scalar* rhod = rho ? rho->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            kReactionKernel(nC, Vd, kd, epsd, Gd, divUd, diagd, sourced, rhod);
+        });
+    }
     cudaCheck(cudaGetLastError(), "kReaction");
 }
 
@@ -577,13 +618,21 @@ void deviceBoundaryNut(
     // argument exists; compressible flow does not, so nuFace overrides it when supplied.
     nutBnd.resize(db.n);
     const scalar Cmu25 = std::pow(co.Cmu, 0.25), yplLam = yPlusLamHost(co.kappa, co.E);
-    boundaryNutKernel<<<nBlocks(db.n), TPB>>>(db.n, db.faceCell.data(), isWall.data(), y.data(), k.data(), nut.data(),
-                                              nu, yplLam, Cmu25, co.kappa, co.E, atmZ0, atmBoundNut, nutBnd.data(),
-                                              nuFace ? nuFace->data() : nullptr,
-                                              calcMask ? calcMask->data() : nullptr,
-                                              kBnd ? kBnd->data() : nullptr,
-                                              epsBnd ? epsBnd->data() : nullptr,
-                                              co.Cmu);
+    {
+        const int n = db.n;
+        const label* fc = db.faceCell.data(); const label* isWalld = isWall.data();
+        const scalar *yd = y.data(), *kd = k.data(), *nutd = nut.data();
+        const scalar kappa = co.kappa, E = co.E, Cmu = co.Cmu;
+        scalar* nutBndd = nutBnd.data();
+        const scalar* nuFaced = nuFace ? nuFace->data() : nullptr;
+        const label* calcMaskd = calcMask ? calcMask->data() : nullptr;
+        const scalar* kBndd = kBnd ? kBnd->data() : nullptr;
+        const scalar* epsBndd = epsBnd ? epsBnd->data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            boundaryNutKernel(n, fc, isWalld, yd, kd, nutd, nu, yplLam, Cmu25, kappa, E, atmZ0, atmBoundNut,
+                              nutBndd, nuFaced, calcMaskd, kBndd, epsBndd, Cmu);
+        });
+    }
     cudaCheck(cudaGetLastError(), "boundaryNut");
 }
 
@@ -592,7 +641,7 @@ void deviceBoundaryNut(
 
 // out = a/b, face by face. Turns the compressible MASS flux back into the volumetric one the turbulence
 // dilatation term needs (OF compressibleTurbulenceModel::phi()).
-__global__
+__device__
 void divideFaceK(
     int n,
     const scalar* __restrict__ a,
@@ -730,10 +779,16 @@ void deviceKEpsilonCorrect(
         deviceInterpolate(dm, *rho, rhoF);
         const int nIf = dm.nInternalFaces;
         DeviceBuffer<scalar> pvI(static_cast<std::size_t>(nIf));
-        divideFaceK<<<nBlocks(nIf), TPB>>>(nIf, phiInt.data(), rhoF.data(), pvI.data());
+        {
+            const scalar *phiIntd = phiInt.data(), *rhoFd = rhoF.data(); scalar* pvId = pvI.data();
+            pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { divideFaceK(nIf, phiIntd, rhoFd, pvId); });
+        }
         const int nB = static_cast<int>(phiBnd.size());
         DeviceBuffer<scalar> pvB(static_cast<std::size_t>(nB));
-        divideFaceK<<<nBlocks(nB), TPB>>>(nB, phiBnd.data(), rhoBnd->data(), pvB.data());
+        {
+            const scalar *phiBndd = phiBnd.data(), *rhoBndd = rhoBnd->data(); scalar* pvBd = pvB.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { divideFaceK(nB, phiBndd, rhoBndd, pvBd); });
+        }
         cudaCheck(cudaGetLastError(), "keVolFlux");
         deviceDiv(dm, pvI, pvB, divU);
         if (ami && ami->n) interfaceAddDiv(*ami, dm.V, divU);
@@ -760,14 +815,22 @@ void deviceKEpsilonCorrect(
             wo << c << ' ' << (int)hIs[c] << ' ' << hW[c] << ' ' << hInv[c] << ' '
                << hE0[c] << ' ' << hG0[c] << ' ' << hE[c] << ' ' << hK[c] << '\n';
     }
-    overrideKernel<<<nBlocks(nC), TPB>>>(nC, wall.isWallCell.data(), G0.data(), eps0.data(), G.data(), eps.data(),
-                                          wall.wallW.size() ? wall.wallW.data() : nullptr);
+    {
+        const label* isWd = wall.isWallCell.data();
+        const scalar* G0d = G0.data(); scalar* eps0d = eps0.data(); scalar* Gd = G.data(); scalar* epsd = eps.data();
+        const scalar* wallWd = wall.wallW.size() ? wall.wallW.data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { overrideKernel(nC, isWd, G0d, eps0d, Gd, epsd, wallWd); });
+    }
 
     // epsilon equation (loose solve) with the near-wall setValues constraint
     // DepsilonEff = nut/sigmaEps + nu. OF's laplacian is alpha*rho*DepsilonEff, so compressible wants
     // rho*(nut/sigmaEps) + mu -- build it kinematic with nu=0 then scale, exactly as the SST does.
     DeviceBuffer<scalar> Deps(static_cast<std::size_t>(nC));
-    depsKernel<<<nBlocks(nC), TPB>>>(nC, nut.data(), co.sigmaEps, (rho ? scalar(0) : nu), Deps.data());
+    {
+        const scalar* nutd = nut.data(); const scalar sigmaEps = co.sigmaEps; const scalar nuArg = rho ? scalar(0) : nu;
+        scalar* Depsd = Deps.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { depsKernel(nC, nutd, sigmaEps, nuArg, Depsd); });
+    }
     if (rho && muLam) scaleDEffCompressibleKE(*rho, *muLam, Deps);
     // OF's laplacian(DepsilonEff, epsilon) uses the PATCH diffusivity, DepsilonEff(patchi) = nut_b/sigmaEps
     // + nu_b -- not the adjacent cell's. Identical wherever nut_b happens to equal nut_cell, which is why
@@ -777,8 +840,12 @@ void deviceKEpsilonCorrect(
     {
         const int nB = static_cast<int>(nutBnd->size());
         DepsB.resize(nB); DkB.resize(nB);
-        depsKernel<<<nBlocks(nB), TPB>>>(nB, nutBnd->data(), co.sigmaEps, (rho ? scalar(0) : nu), DepsB.data());
-        depsKernel<<<nBlocks(nB), TPB>>>(nB, nutBnd->data(), co.sigmaK,   (rho ? scalar(0) : nu), DkB.data());
+        {
+            const scalar* nutBndd = nutBnd->data(); const scalar sigmaEps = co.sigmaEps, sigmaK = co.sigmaK;
+            const scalar nuArg = rho ? scalar(0) : nu; scalar *DepsBd = DepsB.data(), *DkBd = DkB.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { depsKernel(nB, nutBndd, sigmaEps, nuArg, DepsBd); });
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { depsKernel(nB, nutBndd, sigmaK, nuArg, DkBd); });
+        }
         cudaCheck(cudaGetLastError(), "DEffBnd");
         if (rho && rhoBnd && muBnd && muBnd->size())
         {
@@ -796,7 +863,11 @@ void deviceKEpsilonCorrect(
 
     // k equation (loose solve)
     DeviceBuffer<scalar> Dk(static_cast<std::size_t>(nC));
-    depsKernel<<<nBlocks(nC), TPB>>>(nC, nut.data(), co.sigmaK, (rho ? scalar(0) : nu), Dk.data());
+    {
+        const scalar* nutd = nut.data(); const scalar sigmaK = co.sigmaK; const scalar nuArg = rho ? scalar(0) : nu;
+        scalar* Dkd = Dk.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { depsKernel(nC, nutd, sigmaK, nuArg, Dkd); });
+    }
     if (rho && muLam) scaleDEffCompressibleKE(*rho, *muLam, Dk);
     deviceSolveScalarTransport(dm, dbK, k, "k", Dk, phiInt, phiBnd, divPhi, bounded, limitedK, linearUpwindK, nonOrth, twoBykK,
                                relaxK, tol, relTolKE, keCheckEvery, gsK,
@@ -817,7 +888,7 @@ namespace {  // wall-function nut kernels (spaldingNut/blendedNut), used by devi
 // nutUSpaldingWallFunction: wall faces -> Newton uTau from Spalding's law, nut = max(0, uTau^2/magGradU - nu).
 // magGradU = |snGrad U| = |U_cell|*deltaCoeffs (noSlip U_wall=0); magUp = |U_cell|; y = near-wall distance.
 // Warm-started from the previous wall nut (nutBnd in/out), 10 Newton iters with the OF tol=0.01 early-out.
-__global__
+__device__
 void spaldingNutKernel(
     int n,
     const label* __restrict__ fc,
@@ -854,7 +925,7 @@ void spaldingNutKernel(
 //   yPlus = y*uTau/nu ; uTauVis = magUp/yPlus ; uTauLog = kappa*magUp/log(max(E*yPlus, 1+1e-4)).
 // 10 iters, tol 1e-3, under-relaxed uTau update (ut = 0.5*(ut+utNew)), warm-started like the Spalding kernel.
 // magUp/magGradU use the same convention as spaldingNutKernel (|U_cell|, |snGrad U|=|U_cell|*deltaCoeffs).
-__global__
+__device__
 void blendedNutKernel(
     int n,
     const label* __restrict__ fc,
@@ -911,11 +982,17 @@ void deviceBoundaryNutSpalding(
         nutBnd.resize(n);
         cudaCheck(cudaMemsetAsync(nutBnd.data(), 0, n*sizeof(scalar), cudaStreamPerThread), "spalding init");
     }
-    spaldingNutKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].faceCell.data(), isWall.data(), y.data(),
-                                           dbU.comp[0].deltaCoeffs.data(), Ux.data(), Uy.data(), Uz.data(),
-                                           nutCell.data(), nu, co.kappa, co.E, nutBnd.data(),
-                                           nuFace ? nuFace->data() : nullptr,
-                                           nutFile ? nutFile->data() : nullptr);
+    {
+        const label* fc = dbU.comp[0].faceCell.data(); const label* isWalld = isWall.data();
+        const scalar *yd = y.data(), *dcd = dbU.comp[0].deltaCoeffs.data();
+        const scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data(), *nutCelld = nutCell.data();
+        const scalar kappa = co.kappa, E = co.E; scalar* nutBndd = nutBnd.data();
+        const scalar* nuFaced = nuFace ? nuFace->data() : nullptr;
+        const scalar* nutFiled = nutFile ? nutFile->data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            spaldingNutKernel(n, fc, isWalld, yd, dcd, Uxd, Uyd, Uzd, nutCelld, nu, kappa, E, nutBndd, nuFaced, nutFiled);
+        });
+    }
     cudaCheck(cudaGetLastError(), "spaldingNut");
 }
 
@@ -947,11 +1024,17 @@ void deviceBoundaryNutBlended(
         nutBnd.resize(n);
         cudaCheck(cudaMemsetAsync(nutBnd.data(), 0, n*sizeof(scalar), cudaStreamPerThread), "blended init");
     }
-    blendedNutKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].faceCell.data(), isWall.data(), y.data(),
-                                          dbU.comp[0].deltaCoeffs.data(), Ux.data(), Uy.data(), Uz.data(),
-                                          nutCell.data(), nu, kappa, E, nutBnd.data(),
-                                          nuFace ? nuFace->data() : nullptr,
-                                          nutFile ? nutFile->data() : nullptr);
+    {
+        const label* fc = dbU.comp[0].faceCell.data(); const label* isWalld = isWall.data();
+        const scalar *yd = y.data(), *dcd = dbU.comp[0].deltaCoeffs.data();
+        const scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data(), *nutCelld = nutCell.data();
+        scalar* nutBndd = nutBnd.data();
+        const scalar* nuFaced = nuFace ? nuFace->data() : nullptr;
+        const scalar* nutFiled = nutFile ? nutFile->data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            blendedNutKernel(n, fc, isWalld, yd, dcd, Uxd, Uyd, Uzd, nutCelld, nu, kappa, E, nutBndd, nuFaced, nutFiled);
+        });
+    }
     cudaCheck(cudaGetLastError(), "blendedNut");
 }
 
@@ -962,7 +1045,7 @@ namespace brae {
 namespace {
 // nutUWallFunction boundary nut: log-law yPlus, STEPWISE blend (OF's default). Shares the wall-face
 // geometry and the |U_cell - U_wall| convention with the Spalding/Blended kernels above.
-__global__
+__device__
 void nutUWallKernel(
     int n, const label* __restrict__ fc, const label* __restrict__ isWall,
     const scalar* __restrict__ y, const scalar* __restrict__ dc,
@@ -1000,11 +1083,17 @@ void deviceBoundaryNutU(
     const int n = dbU.comp[0].n;
     if (!n) return;
     if (static_cast<int>(nutBnd.size()) != n) nutBnd.resize(n);
-    nutUWallKernel<<<nBlocks(n), TPB>>>(n, dbU.comp[0].faceCell.data(), isWall.data(), y.data(),
-                                        dbU.comp[0].deltaCoeffs.data(), Ux.data(), Uy.data(), Uz.data(),
-                                        nutCell.data(), nu, kappa, E, yPlusLamHost(kappa, E), nutBnd.data(),
-                                        nuFace ? nuFace->data() : nullptr,
-                                        nutFile ? nutFile->data() : nullptr);
+    {
+        const label* fc = dbU.comp[0].faceCell.data(); const label* isWalld = isWall.data();
+        const scalar *yd = y.data(), *dcd = dbU.comp[0].deltaCoeffs.data();
+        const scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data(), *nutCelld = nutCell.data();
+        const scalar yplLam = yPlusLamHost(kappa, E); scalar* nutBndd = nutBnd.data();
+        const scalar* nuFaced = nuFace ? nuFace->data() : nullptr;
+        const scalar* nutFiled = nutFile ? nutFile->data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            nutUWallKernel(n, fc, isWalld, yd, dcd, Uxd, Uyd, Uzd, nutCelld, nu, kappa, E, yplLam, nutBndd, nuFaced, nutFiled);
+        });
+    }
     cudaCheck(cudaGetLastError(), "nutUWall");
 }
 

--- a/src/cuda/device_komega_sst.cu
+++ b/src/cuda/device_komega_sst.cu
@@ -12,6 +12,7 @@
 #include "device_cyclic.cuh"
 #include "device_interface.cuh"
 #include "device_amg.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cmath>
 
@@ -22,7 +23,7 @@ namespace {
 inline scalar yPlusLamHost(scalar kappa, scalar E) { scalar y = 11.0; for (int i = 0; i < 10; ++i) y = std::log(std::fmax(E*y, 1.0)) / kappa; return y; }
 
 
-__global__
+__device__
 void s2Kernel(int nC, const scalar* __restrict__ gradU, scalar* __restrict__ S2)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -42,7 +43,7 @@ void s2Kernel(int nC, const scalar* __restrict__ gradU, scalar* __restrict__ S2)
 }
 
 
-__global__
+__device__
 void cdKernel(
     int nC,
     const scalar* __restrict__ gKx,
@@ -63,7 +64,7 @@ void cdKernel(
 }
 
 
-__global__
+__device__
 void f1Kernel(
     int nC,
     const scalar* __restrict__ k,
@@ -107,7 +108,7 @@ void f1Kernel(
 }
 
 
-__global__
+__device__
 void f2Kernel(
     int nC,
     const scalar* __restrict__ k,
@@ -130,7 +131,7 @@ void f2Kernel(
 }
 
 
-__global__
+__device__
 void blendKernel(int nC, const scalar* __restrict__ F1, scalar psi1, scalar psi2, scalar* __restrict__ out)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -139,7 +140,7 @@ void blendKernel(int nC, const scalar* __restrict__ F1, scalar psi1, scalar psi2
 
 
 // correctNut: nut = a1*k / max(a1*omega, b1*F2*sqrt(S2))
-__global__
+__device__
 void nutSSTKernel(
     int nC,
     const scalar* __restrict__ k,
@@ -159,7 +160,7 @@ void nutSSTKernel(
 
 
 // Pk = min(G, c1*betaStar*k*omega)
-__global__
+__device__
 void pkKernel(
     int nC,
     const scalar* __restrict__ G,
@@ -176,7 +177,7 @@ void pkKernel(
 
 
 // GbyNu = min(GbyNu0, (c1/a1)*betaStar*omega*max(a1*omega, b1*F2*sqrt(S2)))
-__global__
+__device__
 void gbyNuLimitKernel(
     int nC,
     const scalar* __restrict__ GbyNu0,
@@ -198,7 +199,7 @@ void gbyNuLimitKernel(
 
 
 // D = (F1*(alpha1-alpha2)+alpha2)*nut + nu
-__global__
+__device__
 void dEffKernel(
     int nC,
     const scalar* __restrict__ F1,
@@ -218,7 +219,7 @@ void dEffKernel(
 // omega reaction: diag += V*(max(sp1,0) + beta*omega + max(sp2,0));
 //                 source += V*gamma*GbyNu0lim - V*min(sp1,0)*omega - V*min(sp2,0)*omega
 //   sp1 = (2/3)*gamma*divU   (SuSp),   beta*omega (Sp),   sp2 = (F1-1)*CDkOmega/omega   (SuSp)
-__global__
+__device__
 void omegaReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -249,7 +250,7 @@ void omegaReactionKernel(
 
 // k reaction: diag += V*(betaStar*omega + max(sp,0)); source += V*Pk(G) - V*min(sp,0)*k;  sp=(2/3)divU;
 //             Pk = min(G, c1*betaStar*k*omega).  (k-eps kReaction with eps/k->betaStar*omega, G->Pk(G).)
-__global__
+__device__
 void kReactionSSTKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -288,7 +289,7 @@ void kReactionSSTKernel(
 // kOmegaSST-DDES DES factor: FDES = max( (Lt/(CDES*Delta))*(1 - F2), 1 ), Lt = sqrt(k)/(betaStar*omega) (RANS length),
 // Delta = cubeRootVol = V^(1/3), CDES = F1*CDES1 + (1-F1)*CDES2 (SST-blended), F2 = the DDES shielding (RANS in the
 // boundary layer where F2->1 -> FDES=1; LES in free shear where F2->0). Matches OF kOmegaSSTDDES.
-__global__
+__device__
 void kOmegaSSTDESfactorKernel(
     int nC, const scalar* __restrict__ k, const scalar* __restrict__ om, const scalar* __restrict__ V,
     const scalar* __restrict__ F1, const scalar* __restrict__ F2, scalar betaStar, scalar CDES1, scalar CDES2,
@@ -308,7 +309,7 @@ void kOmegaSSTDESfactorKernel(
 // rd denominator sqrt(0.5(S^2+Omega^2)) equals |gradU|). lIDDES = fdTilde*(1+fe)*lRAS + (1-fdTilde)*lLES, and the k
 // destruction beta*k*omega is scaled by FDES = lRAS/lIDDES (== k^(3/2)/lIDDES). NOT clamped to 1: the fe elevated-stress
 // branch makes lIDDES > lRAS -> FDES < 1 (less destruction), which is the intended IDDES behaviour.
-__global__
+__device__
 void kOmegaSSTIDDESfactorKernel(
     int nC, const scalar* __restrict__ k, const scalar* __restrict__ om, const scalar* __restrict__ F1,
     const scalar* __restrict__ gradU, const scalar* __restrict__ nut, const scalar* __restrict__ y,
@@ -345,7 +346,7 @@ void kOmegaSSTIDDESfactorKernel(
 
 // omega wall function (BINOMIAL n=2 default): omega0 = sqrt(omegaVis^2 + omegaLog^2), scattered to wall cells
 // with cornerWeight invNw. G0 IDENTICAL to the epsilon wall function. Clone of device_kepsilon wallFnKernel.
-__global__
+__device__
 void wallOmegaG0Kernel(
     int nWF,
     const label* __restrict__ wfCell,
@@ -392,7 +393,8 @@ void wallOmegaG0Kernel(
 void deviceS2(const DeviceBuffer<scalar>& gradU, int nC, DeviceBuffer<scalar>& S2)
 {
     S2.resize(nC);
-    s2Kernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), S2.data());
+    const scalar* gradUd = gradU.data(); scalar* S2d = S2.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { s2Kernel(nC, gradUd, S2d); });
     cudaCheck(cudaGetLastError(), "S2");
 }
 
@@ -410,8 +412,11 @@ void deviceCDkOmega(
 {
     const int nC = static_cast<int>(omega.size());
     CD.resize(nC);
-    cdKernel<<<nBlocks(nC), TPB>>>(nC, gKx.data(), gKy.data(), gKz.data(), gOx.data(), gOy.data(), gOz.data(),
-                                   omega.data(), 2.0 * alphaOmega2, CD.data());
+    const scalar *gKxd=gKx.data(),*gKyd=gKy.data(),*gKzd=gKz.data(),*gOxd=gOx.data(),*gOyd=gOy.data(),*gOzd=gOz.data();
+    const scalar* omegad = omega.data(); const scalar twoA2 = 2.0 * alphaOmega2; scalar* CDd = CD.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        cdKernel(nC, gKxd, gKyd, gKzd, gOxd, gOyd, gOzd, omegad, twoA2, CDd);
+    });
     cudaCheck(cudaGetLastError(), "CDkOmega");
 }
 
@@ -429,8 +434,14 @@ void deviceF1(
 {
     const int nC = static_cast<int>(k.size());
     F1.resize(nC);
-    f1Kernel<<<nBlocks(nC), TPB>>>(nC, k.data(), omega.data(), y.data(), CD.data(), nu, co.betaStar, co.alphaOmega2, lm ? 1 : 0, F1.data(),
-                                   nuCell ? nuCell->data() : nullptr);
+    {
+        const scalar *kd=k.data(),*omegad=omega.data(),*yd=y.data(),*CDd=CD.data();
+        const scalar betaStar=co.betaStar, alphaOmega2=co.alphaOmega2; const int lmi = lm ? 1 : 0;
+        scalar* F1d = F1.data(); const scalar* nuCelld = nuCell ? nuCell->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            f1Kernel(nC, kd, omegad, yd, CDd, nu, betaStar, alphaOmega2, lmi, F1d, nuCelld);
+        });
+    }
     cudaCheck(cudaGetLastError(), "F1");
 }
 
@@ -446,8 +457,11 @@ void deviceF2(
 {
     const int nC = static_cast<int>(k.size());
     F2.resize(nC);
-    f2Kernel<<<nBlocks(nC), TPB>>>(nC, k.data(), omega.data(), y.data(), nu, co.betaStar, F2.data(),
-                                   nuCell ? nuCell->data() : nullptr);
+    {
+        const scalar *kd=k.data(),*omegad=omega.data(),*yd=y.data(); const scalar betaStar = co.betaStar;
+        scalar* F2d = F2.data(); const scalar* nuCelld = nuCell ? nuCell->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { f2Kernel(nC, kd, omegad, yd, nu, betaStar, F2d, nuCelld); });
+    }
     cudaCheck(cudaGetLastError(), "F2");
 }
 
@@ -456,7 +470,8 @@ void deviceBlend(const DeviceBuffer<scalar>& F1, scalar psi1, scalar psi2, Devic
 {
     const int nC = static_cast<int>(F1.size());
     out.resize(nC);
-    blendKernel<<<nBlocks(nC), TPB>>>(nC, F1.data(), psi1, psi2, out.data());
+    const scalar* F1d = F1.data(); scalar* outd = out.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { blendKernel(nC, F1d, psi1, psi2, outd); });
     cudaCheck(cudaGetLastError(), "blend");
 }
 
@@ -471,7 +486,11 @@ void deviceNutSST(
 {
     const int nC = static_cast<int>(k.size());
     nut.resize(nC);
-    nutSSTKernel<<<nBlocks(nC), TPB>>>(nC, k.data(), omega.data(), F2.data(), S2.data(), co.a1, co.b1, nut.data());
+    {
+        const scalar *kd=k.data(),*omegad=omega.data(),*F2d=F2.data(),*S2d=S2.data();
+        const scalar a1=co.a1, b1=co.b1; scalar* nutd = nut.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { nutSSTKernel(nC, kd, omegad, F2d, S2d, a1, b1, nutd); });
+    }
     cudaCheck(cudaGetLastError(), "nutSST");
 }
 
@@ -485,7 +504,9 @@ void devicePk(
 {
     const int nC = static_cast<int>(k.size());
     Pk.resize(nC);
-    pkKernel<<<nBlocks(nC), TPB>>>(nC, G.data(), k.data(), omega.data(), co.c1 * co.betaStar, Pk.data());
+    const scalar *Gd=G.data(),*kd=k.data(),*omegad=omega.data(); const scalar c1betaStar = co.c1 * co.betaStar;
+    scalar* Pkd = Pk.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { pkKernel(nC, Gd, kd, omegad, c1betaStar, Pkd); });
     cudaCheck(cudaGetLastError(), "Pk");
 }
 
@@ -500,8 +521,13 @@ void deviceGbyNuLimit(
 {
     const int nC = static_cast<int>(omega.size());
     GbyNu.resize(nC);
-    gbyNuLimitKernel<<<nBlocks(nC), TPB>>>(nC, GbyNu0.data(), omega.data(), F2.data(), S2.data(),
-                                           co.a1, co.b1, co.c1, co.betaStar, GbyNu.data());
+    {
+        const scalar *GbyNu0d=GbyNu0.data(),*omegad=omega.data(),*F2d=F2.data(),*S2d=S2.data();
+        const scalar a1=co.a1, b1=co.b1, c1=co.c1, betaStar=co.betaStar; scalar* GbyNud = GbyNu.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            gbyNuLimitKernel(nC, GbyNu0d, omegad, F2d, S2d, a1, b1, c1, betaStar, GbyNud);
+        });
+    }
     cudaCheck(cudaGetLastError(), "GbyNuLimit");
 }
 
@@ -516,7 +542,8 @@ void deviceDEff(
 {
     const int nC = static_cast<int>(F1.size());
     D.resize(nC);
-    dEffKernel<<<nBlocks(nC), TPB>>>(nC, F1.data(), nut.data(), alpha1, alpha2, nu, D.data());
+    const scalar* F1d = F1.data(); const scalar* nutd = nut.data(); scalar* Dd = D.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { dEffKernel(nC, F1d, nutd, alpha1, alpha2, nu, Dd); });
     cudaCheck(cudaGetLastError(), "DEff");
 }
 
@@ -535,16 +562,21 @@ void deviceOmegaReaction(
     const DeviceBuffer<scalar>* rho)   // compressible rho weighting; nullptr -> incompressible (unchanged)
 {
     const int nC = static_cast<int>(V.size());
-    omegaReactionKernel<<<nBlocks(nC), TPB>>>(nC, V.data(), gamma.data(), beta.data(), GbyNu0lim.data(), F1.data(),
-                                              CD.data(), omega.data(), divU.data(), diag.data(), source.data(),
-                                              rho ? rho->data() : nullptr);
+    {
+        const scalar *Vd=V.data(),*gammad=gamma.data(),*betad=beta.data(),*GbyNu0limd=GbyNu0lim.data(),*F1d=F1.data();
+        const scalar *CDd=CD.data(),*omegad=omega.data(),*divUd=divU.data();
+        scalar *diagd=diag.data(),*sourced=source.data(); const scalar* rhod = rho ? rho->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            omegaReactionKernel(nC, Vd, gammad, betad, GbyNu0limd, F1d, CDd, omegad, divUd, diagd, sourced, rhod);
+        });
+    }
     cudaCheck(cudaGetLastError(), "omegaReaction");
 }
 
 
 // nuWall[i] = nuBnd[wfBndIdx[i]] -- the same OF nu(patchi) the nut wall functions read, re-indexed into the
 // wall-face ordering that DeviceWallData (and therefore omegaWallFunction and the near-wall G0) uses.
-__global__
+__device__
 void gatherWallNuK(
     int n,
     const label* __restrict__ idx,
@@ -564,12 +596,13 @@ void deviceGatherWallNu(
     const int n = static_cast<int>(wfBndIdx.size());
     if (n == 0 || nuBnd.size() == 0) return;
     nuWall.resize(n);
-    gatherWallNuK<<<nBlocks(n), TPB>>>(n, wfBndIdx.data(), nuBnd.data(), nuWall.data());
+    const label* wfBndIdxd = wfBndIdx.data(); const scalar* nuBndd = nuBnd.data(); scalar* nuWalld = nuWall.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { gatherWallNuK(n, wfBndIdxd, nuBndd, nuWalld); });
     cudaCheck(cudaGetLastError(), "gatherWallNu");
 }
 
 // out[i] = cell[faceCell[i]] -- plain adjacent-cell extrapolation for a boundary face.
-__global__
+__device__
 void gatherCellToFaceK(
     int n,
     const label* __restrict__ fc,
@@ -593,7 +626,7 @@ void gatherCellToFaceK(
 //
 // The boundary gradient is the same expression device_divdevreff.cu's gradBKernel uses (OF gaussGrad::
 // correctBoundaryConditions), reproduced here so the SST does not depend on the stress module's layout.
-__global__
+__device__
 void sstNutBoundaryK(
     int nB,
     const label* __restrict__ fc,
@@ -682,12 +715,21 @@ void deviceSSTNutBoundary(
     deviceBCValue(dbU.comp[0], Ux, uxb);
     deviceBCValue(dbU.comp[1], Uy, uyb);
     deviceBCValue(dbU.comp[2], Uz, uzb);
-    sstNutBoundaryK<<<nBlocks(nB), TPB>>>(nB, dbU.comp[0].faceCell.data(), kBnd.data(), omBnd.data(),
-                                          yCell.data(), nuB ? nuB->data() : nullptr, nu,
-                                          gradU.data(), nC, dbU.nx.data(), dbU.ny.data(), dbU.nz.data(),
-                                          uxb.data(), uyb.data(), uzb.data(), Ux.data(), Uy.data(), Uz.data(),
-                                          dbU.comp[0].deltaCoeffs.data(), calcMask.data(),
-                                          co.a1, co.b1, co.betaStar, nutCell.data(), nutBnd.data());
+    {
+        const label* fc = dbU.comp[0].faceCell.data();
+        const scalar *kBndd=kBnd.data(), *omBndd=omBnd.data(), *yCelld=yCell.data();
+        const scalar* nuBd = nuB ? nuB->data() : nullptr;
+        const scalar *gradUd=gradU.data(), *nxd=dbU.nx.data(), *nyd=dbU.ny.data(), *nzd=dbU.nz.data();
+        const scalar *uxbd=uxb.data(), *uybd=uyb.data(), *uzbd=uzb.data();
+        const scalar *Uxd=Ux.data(), *Uyd=Uy.data(), *Uzd=Uz.data(), *dcd=dbU.comp[0].deltaCoeffs.data();
+        const label* calcMaskd = calcMask.data();
+        const scalar a1=co.a1, b1=co.b1, betaStar=co.betaStar; const scalar* nutCelld = nutCell.data();
+        scalar* nutBndd = nutBnd.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+            sstNutBoundaryK(nB, fc, kBndd, omBndd, yCelld, nuBd, nu, gradUd, nC, nxd, nyd, nzd,
+                            uxbd, uybd, uzbd, Uxd, Uyd, Uzd, dcd, calcMaskd, a1, b1, betaStar, nutCelld, nutBndd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "sstNutBoundary");
 }
 
@@ -712,11 +754,19 @@ void deviceWallOmegaG0(
     cudaCheck(cudaMemsetAsync(G0.data(),     0, nC*sizeof(scalar), cudaStreamPerThread), "G0 zero");
     const scalar Cmu25 = std::pow(co.betaStar, 0.25), yplLam = yPlusLamHost(co.kappa, co.E);
     if (w.nWF > 0)
-        wallOmegaG0Kernel<<<nBlocks(w.nWF), TPB>>>(w.nWF, w.wfCell.data(), w.wfY.data(), w.wfDc.data(), w.wfUwx.data(),
-                                                   w.wfUwy.data(), w.wfUwz.data(), w.invNw.data(), k.data(), Ux.data(),
-                                                   Uy.data(), Uz.data(), nu, yplLam, Cmu25, co.kappa, co.E, atmZ0, atmBoundNut, co.beta1,
-                                                   nutWall, omega0.data(), G0.data(),
-                                                   (nuFace && nuFace->size()) ? nuFace->data() : nullptr);
+    {
+        const int nWF = w.nWF; const label* wfCell = w.wfCell.data();
+        const scalar *wfY=w.wfY.data(), *wfDc=w.wfDc.data();
+        const scalar *wux=w.wfUwx.data(), *wuy=w.wfUwy.data(), *wuz=w.wfUwz.data(), *invNw=w.invNw.data();
+        const scalar *kd=k.data(), *Uxd=Ux.data(), *Uyd=Uy.data(), *Uzd=Uz.data();
+        const scalar kappa=co.kappa, E=co.E, beta1=co.beta1;
+        scalar *omega0d=omega0.data(), *G0d=G0.data();
+        const scalar* nuFaced = (nuFace && nuFace->size()) ? nuFace->data() : nullptr;
+        pcudaParallelFor(nBlocks(nWF), TPB, [=] __device__ () {
+            wallOmegaG0Kernel(nWF, wfCell, wfY, wfDc, wux, wuy, wuz, invNw, kd, Uxd, Uyd, Uzd, nu, yplLam, Cmu25,
+                              kappa, E, atmZ0, atmBoundNut, beta1, nutWall, omega0d, G0d, nuFaced);
+        });
+    }
     cudaCheck(cudaGetLastError(), "wallOmegaG0");
 }
 
@@ -735,10 +785,15 @@ void deviceKReactionSST(
     const DeviceBuffer<scalar>* rho)    // compressible rho weighting; nullptr -> incompressible (unchanged)
 {
     const int nC = static_cast<int>(V.size());
-    kReactionSSTKernel<<<nBlocks(nC), TPB>>>(nC, V.data(), k.data(), omega.data(), G.data(), divU.data(),
-                                             co.betaStar, co.c1 * co.betaStar, gammaIntEff, diag.data(), source.data(),
-                                             FDES ? FDES->data() : nullptr,
-                                             rho ? rho->data() : nullptr);
+    {
+        const scalar *Vd=V.data(),*kd=k.data(),*omegad=omega.data(),*Gd=G.data(),*divUd=divU.data();
+        const scalar betaStar=co.betaStar, c1betaStar=co.c1*co.betaStar;
+        scalar *diagd=diag.data(),*sourced=source.data();
+        const scalar* FDESd = FDES ? FDES->data() : nullptr; const scalar* rhod = rho ? rho->data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            kReactionSSTKernel(nC, Vd, kd, omegad, Gd, divUd, betaStar, c1betaStar, gammaIntEff, diagd, sourced, FDESd, rhod);
+        });
+    }
     cudaCheck(cudaGetLastError(), "kReactionSST");
 }
 
@@ -748,10 +803,15 @@ void deviceKOmegaSSTDESfactor(int nC, const DeviceBuffer<scalar>& k, const Devic
     const KOmegaSSTCoeffs& co, DeviceBuffer<scalar>& FDES, const DeviceBuffer<scalar>* lesDelta)
 {
     FDES.resize(nC);
-    kOmegaSSTDESfactorKernel<<<nBlocks(nC), TPB>>>(nC, k.data(), omega.data(), V.data(), F1.data(), F2.data(),
-                                                   co.betaStar, co.CDES1, co.CDES2,
-                                                   (lesDelta && lesDelta->size()) ? lesDelta->data() : nullptr,
-                                                   FDES.data());
+    {
+        const scalar *kd=k.data(),*omegad=omega.data(),*Vd=V.data(),*F1d=F1.data(),*F2d=F2.data();
+        const scalar betaStar=co.betaStar, CDES1=co.CDES1, CDES2=co.CDES2;
+        const scalar* lesDeltad = (lesDelta && lesDelta->size()) ? lesDelta->data() : nullptr;
+        scalar* FDESd = FDES.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            kOmegaSSTDESfactorKernel(nC, kd, omegad, Vd, F1d, F2d, betaStar, CDES1, CDES2, lesDeltad, FDESd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "kOmegaSSTDESfactor");
 }
 
@@ -763,8 +823,14 @@ void deviceKOmegaSSTIDDESfactor(int nC, const DeviceBuffer<scalar>& k, const Dev
     const KOmegaSSTCoeffs& co, DeviceBuffer<scalar>& FDES)
 {
     FDES.resize(nC);
-    kOmegaSSTIDDESfactorKernel<<<nBlocks(nC), TPB>>>(nC, k.data(), omega.data(), F1.data(), gradU.data(),
-        nut.data(), y.data(), hmax.data(), hwn.data(), nu, co, FDES.data());
+    {
+        const scalar *kd=k.data(),*omegad=omega.data(),*F1d=F1.data(),*gradUd=gradU.data();
+        const scalar *nutd=nut.data(),*yd=y.data(),*hmaxd=hmax.data(),*hwnd=hwn.data();
+        scalar* FDESd = FDES.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            kOmegaSSTIDDESfactorKernel(nC, kd, omegad, F1d, gradUd, nutd, yd, hmaxd, hwnd, nu, co, FDESd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "kOmegaSSTIDDESfactor");
 }
 
@@ -831,7 +897,7 @@ void deviceCellLimitGradU(
 
 // Elementwise a/b. Used for nu = mu/rho (cells) and for phi/interpolate(rho) (faces), which are the two
 // places the SST has to undo a rho weighting that the rest of the compressible solver applies.
-__global__
+__device__
 void nuFromMuRhoK(
     int n,
     const scalar* __restrict__ mu,
@@ -954,12 +1020,18 @@ void deviceKOmegaSSTCorrect(
         const int nIf = dm.nInternalFaces;
         DeviceBuffer<scalar> phiVolInt;
         phiVolInt.resize(nIf);
-        nuFromMuRhoK<<<nBlocks(nIf), TPB>>>(nIf, phiInt.data(), rhoF.data(), phiVolInt.data());
+        {
+            const scalar *phiIntd = phiInt.data(), *rhoFd = rhoF.data(); scalar* phiVolIntd = phiVolInt.data();
+            pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { nuFromMuRhoK(nIf, phiIntd, rhoFd, phiVolIntd); });
+        }
         cudaCheck(cudaGetLastError(), "phiVolInt");
         const int nB = static_cast<int>(phiBnd.size());
         DeviceBuffer<scalar> phiVolBnd;
         phiVolBnd.resize(nB);
-        nuFromMuRhoK<<<nBlocks(nB), TPB>>>(nB, phiBnd.data(), rhoBnd->data(), phiVolBnd.data());
+        {
+            const scalar *phiBndd = phiBnd.data(), *rhoBndd = rhoBnd->data(); scalar* phiVolBndd = phiVolBnd.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { nuFromMuRhoK(nB, phiBndd, rhoBndd, phiVolBndd); });
+        }
         cudaCheck(cudaGetLastError(), "phiVolBnd");
         deviceDiv(dm, phiVolInt, phiVolBnd, divU);
         if (ami && ami->n) interfaceAddDiv(*ami, dm.V, divU);
@@ -976,8 +1048,12 @@ void deviceKOmegaSSTCorrect(
     // grad(omega)/CDkOmega/F1/F2 and the reaction all see the wall-corrected omega (matches kOmegaSSTBase::correct).
     DeviceBuffer<scalar> omega0, G0;
     deviceWallOmegaG0(wall, k, Ux, Uy, Uz, nu, omega0, G0, co, nutWall, atmZ0, atmBoundNut, nuWallFace);
-    overrideKernel<<<nBlocks(nC), TPB>>>(nC, wall.isWallCell.data(), G0.data(), omega0.data(), G.data(), omega.data(),
-                                          wall.wallW.size() ? wall.wallW.data() : nullptr);
+    {
+        const label* isWd = wall.isWallCell.data();
+        const scalar* G0d = G0.data(); scalar* omega0d = omega0.data(); scalar* Gd = G.data(); scalar* omegad = omega.data();
+        const scalar* wallWd = wall.wallW.size() ? wall.wallW.data() : nullptr;
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { overrideKernel(nC, isWd, G0d, omega0d, Gd, omegad, wallWd); });
+    }
 
     // CDkOmega from grad(k), grad(omega); F1, F2.
     DeviceBuffer<scalar> kbv;
@@ -999,7 +1075,8 @@ void deviceKOmegaSSTCorrect(
     {
         const int nCk = static_cast<int>(muLam->size());
         nuCellBuf.resize(nCk);
-        nuFromMuRhoK<<<nBlocks(nCk), TPB>>>(nCk, muLam->data(), rho->data(), nuCellBuf.data());
+        const scalar *muLamd = muLam->data(), *rhod = rho->data(); scalar* nuCellBufd = nuCellBuf.data();
+        pcudaParallelFor(nBlocks(nCk), TPB, [=] __device__ () { nuFromMuRhoK(nCk, muLamd, rhod, nuCellBufd); });
         cudaCheck(cudaGetLastError(), "nuFromMuRho");
         nuCell = &nuCellBuf;
     }
@@ -1043,7 +1120,10 @@ void deviceKOmegaSSTCorrect(
         // where F1 must lie in [0,1]. Measured: that made omega 100x worse (3.1e-5 -> 3.2e-3).
         DeviceBuffer<scalar> F1b;
         F1b.resize(nB);
-        gatherCellToFaceK<<<nBlocks(nB), TPB>>>(nB, dbOmega.faceCell.data(), F1.data(), F1b.data());
+        {
+            const label* fc = dbOmega.faceCell.data(); const scalar* F1d = F1.data(); scalar* F1bd = F1b.data();
+            pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { gatherCellToFaceK(nB, fc, F1d, F1bd); });
+        }
         cudaCheck(cudaGetLastError(), "F1b");
         DomB.resize(nB); DkB.resize(nB);
         deviceDEff(F1b, *nutBnd, co.alphaOmega1, co.alphaOmega2, rho ? scalar(0) : nu, DomB);
@@ -1101,7 +1181,7 @@ namespace { struct LMCoeffs { scalar ca1=2.0, ca2=0.06, ce1=1.0, ce2=50.0, cThet
 
 
 // DReThetatEff = sigmaThetat*(nut + nu)  (NOT nut/sigma + nu, depsKernel can't express this).
-__global__
+__device__
 void lmReDiffKernel(int nC, const scalar* __restrict__ nut, scalar sigma, scalar nu, scalar* __restrict__ D)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -1110,7 +1190,7 @@ void lmReDiffKernel(int nC, const scalar* __restrict__ nut, scalar sigma, scalar
 
 
 // diag += V*sp ; source += V*su  (apply a precomputed semi-implicit reaction).
-__global__
+__device__
 void lmAddReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -1190,7 +1270,7 @@ scalar lmFlength(scalar R, scalar y, scalar om, scalar nu)
 
 
 // ReThetat reaction prep: ReThetat0 Newton loop + Pthetat; outputs sp=Pthetat, su=Pthetat*ReThetat0, and Fthetat.
-__global__
+__device__
 void lmReThetatPrepKernel(
     int nC,
     const scalar* __restrict__ gradU,
@@ -1253,7 +1333,7 @@ void lmReThetatPrepKernel(
 
 
 // gammaInt reaction prep: Pgamma, Egamma -> sp=ce1*Pgamma+ce2*Egamma, su=Pgamma+Egamma.
-__global__
+__device__
 void lmGammaPrepKernel(
     int nC,
     const scalar* __restrict__ gradU,
@@ -1298,7 +1378,7 @@ void lmGammaPrepKernel(
 
 
 // gammaIntEff = max(gammaInt, gammaSep); gammaSep = min(2*max(Rev/(3.235*ReThetac)-1,0)*Freattach, 2)*Fthetat.
-__global__
+__device__
 void lmGammaEffKernel(
     int nC,
     const scalar* __restrict__ gradU,
@@ -1372,33 +1452,59 @@ void deviceKOmegaSSTLMCorrect(
 
     // ReThetat: DReThetatEff = sigmaThetat*(nut+nu); reaction = Pthetat*ReThetat0 - Sp(Pthetat). Fthetat stored for gammaSep.
     DeviceBuffer<scalar> Fth(nC), spR(nC), suR(nC);
-    lmReThetatPrepKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), nu, lm.cThetat, lm.ce2, 1e-37, lm.lambdaErr, lm.maxIter,
-        Fth.data(), spR.data(), suR.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data();
+        const scalar cThetat=lm.cThetat, ce2=lm.ce2, lambdaErr=lm.lambdaErr; const int maxIter=lm.maxIter;
+        scalar *Fthd=Fth.data(),*spRd=spR.data(),*suRd=suR.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmReThetatPrepKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, nu,
+                                 cThetat, ce2, 1e-37, lambdaErr, maxIter, Fthd, spRd, suRd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "lmReThetatPrep");
     DeviceBuffer<scalar> DRe(nC);
-    lmReDiffKernel<<<nBlocks(nC), TPB>>>(nC, nut.data(), lm.sigmaThetat, nu, DRe.data());   // sigmaThetat*(nut+nu)
+    {
+        const scalar* nutd = nut.data(); const scalar sigmaThetat = lm.sigmaThetat; scalar* DRed = DRe.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { lmReDiffKernel(nC, nutd, sigmaThetat, nu, DRed); });
+    }
     deviceSolveScalarTransport(dm, dbReThetat, ReThetat, "ReThetat", DRe, phiInt, phiBnd, divU, bounded, false, false, nonOrth, 2.0,
                                relax, tol, relTolKE, keCheckEvery, gsEps,
-                               [&](DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src){ lmAddReactionKernel<<<nBlocks(nC), TPB>>>(nC, dm.V.data(), spR.data(), suR.data(), diag.data(), src.data()); },
+                               [&](DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src){ deviceLMAddReaction(dm, spR, suR, diag, src); },
                                nullptr, nullptr, ami, cyc, reDdt);
     deviceBoundField(dm, ReThetat, 0.0);
 
     // gammaInt: DgammaIntEff = nut+nu; reaction = Pgamma+Egamma - Sp(ce1*Pgamma+ce2*Egamma).
     DeviceBuffer<scalar> spG(nC), suG(nC);
-    lmGammaPrepKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), nu, lm.ca1, lm.ca2, lm.ce1, lm.ce2, 1e-37, spG.data(), suG.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data();
+        const scalar ca1=lm.ca1, ca2=lm.ca2, ce1=lm.ce1, ce2=lm.ce2;
+        scalar *spGd=spG.data(),*suGd=suG.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmGammaPrepKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, nu, ca1, ca2, ce1, ce2, 1e-37, spGd, suGd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "lmGammaPrep");
     DeviceBuffer<scalar> DgI(nC);
-    depsKernel<<<nBlocks(nC), TPB>>>(nC, nut.data(), 1.0, nu, DgI.data());   // nut/1 + nu
+    {
+        const scalar* nutd = nut.data(); scalar* DgId = DgI.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { depsKernel(nC, nutd, 1.0, nu, DgId); });   // nut/1 + nu
+    }
     deviceSolveScalarTransport(dm, dbGammaInt, gammaInt, "gammaInt", DgI, phiInt, phiBnd, divU, bounded, false, false, nonOrth, 2.0,
                                relax, tol, relTolKE, keCheckEvery, gsEps,
-                               [&](DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src){ lmAddReactionKernel<<<nBlocks(nC), TPB>>>(nC, dm.V.data(), spG.data(), suG.data(), diag.data(), src.data()); },
+                               [&](DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src){ deviceLMAddReaction(dm, spG, suG, diag, src); },
                                nullptr, nullptr, ami, cyc, giDdt);
     deviceBoundField(dm, gammaInt, 0.0);
     gammaIntEff.resize(nC);
-    lmGammaEffKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), Fth.data(), nu, 1e-37, gammaIntEff.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data(),*Fthd=Fth.data();
+        scalar* gammaIntEffd = gammaIntEff.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmGammaEffKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, Fthd, nu, 1e-37, gammaIntEffd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "lmGammaEff");
 }
 
@@ -1409,7 +1515,8 @@ void deviceKOmegaSSTLMCorrect(
 void deviceLMReDiff(const DeviceBuffer<scalar>& nut, scalar nu, DeviceBuffer<scalar>& D)
 {
     const int nC = static_cast<int>(nut.size()); const LMCoeffs lm; D.resize(nC);
-    lmReDiffKernel<<<nBlocks(nC), TPB>>>(nC, nut.data(), lm.sigmaThetat, nu, D.data());   // sigmaThetat*(nut+nu)
+    const scalar* nutd = nut.data(); const scalar sigmaThetat = lm.sigmaThetat; scalar* Dd = D.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { lmReDiffKernel(nC, nutd, sigmaThetat, nu, Dd); });   // sigmaThetat*(nut+nu)
     cudaCheck(cudaGetLastError(), "deviceLMReDiff");
 }
 void deviceLMReThetatPrep(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU,
@@ -1419,9 +1526,16 @@ void deviceLMReThetatPrep(const DeviceMesh& dm, const DeviceBuffer<scalar>& grad
     DeviceBuffer<scalar>& Fth, DeviceBuffer<scalar>& spR, DeviceBuffer<scalar>& suR)
 {
     const int nC = dm.nCells; const LMCoeffs lm; Fth.resize(nC); spR.resize(nC); suR.resize(nC);
-    lmReThetatPrepKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), nu, lm.cThetat, lm.ce2, 1e-37, lm.lambdaErr, lm.maxIter,
-        Fth.data(), spR.data(), suR.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data();
+        const scalar cThetat=lm.cThetat, ce2=lm.ce2, lambdaErr=lm.lambdaErr; const int maxIter=lm.maxIter;
+        scalar *Fthd=Fth.data(),*spRd=spR.data(),*suRd=suR.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmReThetatPrepKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, nu,
+                                 cThetat, ce2, 1e-37, lambdaErr, maxIter, Fthd, spRd, suRd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "deviceLMReThetatPrep");
 }
 void deviceLMGammaPrep(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU,
@@ -1431,8 +1545,15 @@ void deviceLMGammaPrep(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU,
     DeviceBuffer<scalar>& spG, DeviceBuffer<scalar>& suG)
 {
     const int nC = dm.nCells; const LMCoeffs lm; spG.resize(nC); suG.resize(nC);
-    lmGammaPrepKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), nu, lm.ca1, lm.ca2, lm.ce1, lm.ce2, 1e-37, spG.data(), suG.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data();
+        const scalar ca1=lm.ca1, ca2=lm.ca2, ce1=lm.ce1, ce2=lm.ce2;
+        scalar *spGd=spG.data(),*suGd=suG.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmGammaPrepKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, nu, ca1, ca2, ce1, ce2, 1e-37, spGd, suGd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "deviceLMGammaPrep");
 }
 void deviceLMGammaEff(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU,
@@ -1442,14 +1563,23 @@ void deviceLMGammaEff(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU,
     scalar nu, DeviceBuffer<scalar>& gammaIntEff)
 {
     const int nC = dm.nCells; gammaIntEff.resize(nC);
-    lmGammaEffKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), Ux.data(), Uy.data(), Uz.data(), k.data(), omega.data(),
-        y.data(), ReThetat.data(), gammaInt.data(), Fth.data(), nu, 1e-37, gammaIntEff.data());
+    {
+        const scalar *gradUd=gradU.data(),*Uxd=Ux.data(),*Uyd=Uy.data(),*Uzd=Uz.data(),*kd=k.data(),*omegad=omega.data();
+        const scalar *yd=y.data(),*ReThetatd=ReThetat.data(),*gammaIntd=gammaInt.data(),*Fthd=Fth.data();
+        scalar* gammaIntEffd = gammaIntEff.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            lmGammaEffKernel(nC, gradUd, Uxd, Uyd, Uzd, kd, omegad, yd, ReThetatd, gammaIntd, Fthd, nu, 1e-37, gammaIntEffd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "deviceLMGammaEff");
 }
 void deviceLMAddReaction(const DeviceMesh& dm, const DeviceBuffer<scalar>& sp, const DeviceBuffer<scalar>& su,
     DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& source)
 {
-    lmAddReactionKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.V.data(), sp.data(), su.data(), diag.data(), source.data());
+    const int nC = dm.nCells;
+    const scalar *Vd = dm.V.data(), *spd = sp.data(), *sud = su.data();
+    scalar *diagd = diag.data(), *sourced = source.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { lmAddReactionKernel(nC, Vd, spd, sud, diagd, sourced); });
     cudaCheck(cudaGetLastError(), "deviceLMAddReaction");
 }
 

--- a/src/cuda/device_maxwell.cu
+++ b/src/cuda/device_maxwell.cu
@@ -1,6 +1,7 @@
 // Maxwell viscoelastic laminar model -- the device kernels. See device_maxwell.cuh for the equations.
 #include "device_maxwell.cuh"
 #include "device_divdevreff.cuh"   // deviceBoundaryGradU / deviceTensorDivSource (shared with the stress path)
+#include "pcuda_compat.cuh"
 
 namespace brae {
 
@@ -14,7 +15,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 // convention the rest of brae uses. (sigma & gradU)_ij = S_ik G_kj, and twoSymm(T) = T + T^T, so
 //     P_ij = S_ik G_kj + S_jk G_ki - nuM*rLambda*(G_ij + G_ji)
 // which is symmetric, hence six components rather than nine.
-__global__
+__device__
 void maxwellPKernel(
     int nC,
     const scalar* __restrict__ sxx, const scalar* __restrict__ sxy, const scalar* __restrict__ sxz,
@@ -56,7 +57,7 @@ void maxwellPKernel(
 }
 
 // diag += V*rLambda (fvm::Sp), source += V*P. Same V-weighted convention as every other reaction here.
-__global__
+__device__
 void maxwellReactionKernel(int nC, const scalar* __restrict__ V, scalar rLambda,
                            const scalar* __restrict__ P,
                            scalar* __restrict__ diag, scalar* __restrict__ source)
@@ -69,7 +70,7 @@ void maxwellReactionKernel(int nC, const scalar* __restrict__ V, scalar rLambda,
 
 // Expand the six stored components into the packed 9-component layout the tensor-divergence kernel
 // takes. Cheap, and it keeps ONE divergence implementation rather than a symmetric copy of it.
-__global__
+__device__
 void symmExpandKernel(int n,
                       const scalar* __restrict__ sxx, const scalar* __restrict__ sxy, const scalar* __restrict__ sxz,
                       const scalar* __restrict__ syy, const scalar* __restrict__ syz, const scalar* __restrict__ szz,
@@ -82,7 +83,7 @@ void symmExpandKernel(int n,
     T[6*n + i] = sxz[i];  T[7*n + i] = syz[i];  T[8*n + i] = szz[i];
 }
 
-__global__
+__device__
 void scaleTensorKernel(int n9, const scalar* __restrict__ in, scalar s, scalar* __restrict__ out)
 {
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -90,7 +91,7 @@ void scaleTensorKernel(int n9, const scalar* __restrict__ in, scalar s, scalar* 
 }
 
 // OF magSqr(symmTensor): the off-diagonals appear twice in the full tensor, so they count twice.
-__global__
+__device__
 void symmMagSqrKernel(int nC,
                       const scalar* __restrict__ sxx, const scalar* __restrict__ sxy, const scalar* __restrict__ sxz,
                       const scalar* __restrict__ syy, const scalar* __restrict__ syz, const scalar* __restrict__ szz,
@@ -107,12 +108,12 @@ void deviceMaxwellP(int nC, const DeviceBuffer<scalar>* sigma, const DeviceBuffe
                     scalar nuM, scalar rLambda, DeviceBuffer<scalar>* P)
 {
     for (int k = 0; k < 6; ++k) P[k].resize(static_cast<std::size_t>(nC));
-    maxwellPKernel<<<nBlocks(nC), TPB>>>(nC,
-                                         sigma[0].data(), sigma[1].data(), sigma[2].data(),
-                                         sigma[3].data(), sigma[4].data(), sigma[5].data(),
-                                         gradU.data(), nuM, rLambda,
-                                         P[0].data(), P[1].data(), P[2].data(),
-                                         P[3].data(), P[4].data(), P[5].data());
+    const scalar *s0=sigma[0].data(),*s1=sigma[1].data(),*s2=sigma[2].data(),*s3=sigma[3].data(),*s4=sigma[4].data(),*s5=sigma[5].data();
+    const scalar* gradUd = gradU.data();
+    scalar *p0=P[0].data(),*p1=P[1].data(),*p2=P[2].data(),*p3=P[3].data(),*p4=P[4].data(),*p5=P[5].data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        maxwellPKernel(nC, s0, s1, s2, s3, s4, s5, gradUd, nuM, rLambda, p0, p1, p2, p3, p4, p5);
+    });
     cudaCheck(cudaGetLastError(), "maxwellP");
 }
 
@@ -120,7 +121,11 @@ void deviceMaxwellReaction(const DeviceBuffer<scalar>& V, scalar rLambda, const 
                            DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& source)
 {
     const int nC = static_cast<int>(V.size());
-    maxwellReactionKernel<<<nBlocks(nC), TPB>>>(nC, V.data(), rLambda, Pc.data(), diag.data(), source.data());
+    const scalar* Vd = V.data(); const scalar* Pcd = Pc.data();
+    scalar* diagd = diag.data(); scalar* sourced = source.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        maxwellReactionKernel(nC, Vd, rLambda, Pcd, diagd, sourced);
+    });
     cudaCheck(cudaGetLastError(), "maxwellReaction");
 }
 
@@ -130,13 +135,17 @@ void deviceDivSymmTensor(const DeviceMesh& dm,
 {
     const int nC = dm.nCells, nB = dm.nBndFaces;
     DeviceBuffer<scalar> Tc(static_cast<std::size_t>(9)*nC), Tb(static_cast<std::size_t>(9)*nB);
-    symmExpandKernel<<<nBlocks(nC), TPB>>>(nC, sigCell[0].data(), sigCell[1].data(), sigCell[2].data(),
-                                           sigCell[3].data(), sigCell[4].data(), sigCell[5].data(), Tc.data());
+    {
+        const scalar *c0=sigCell[0].data(),*c1=sigCell[1].data(),*c2=sigCell[2].data(),*c3=sigCell[3].data(),*c4=sigCell[4].data(),*c5=sigCell[5].data();
+        scalar* Tcd = Tc.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { symmExpandKernel(nC, c0, c1, c2, c3, c4, c5, Tcd); });
+    }
     cudaCheck(cudaGetLastError(), "symmExpand cells");
     if (nB)
     {
-        symmExpandKernel<<<nBlocks(nB), TPB>>>(nB, sigBnd[0].data(), sigBnd[1].data(), sigBnd[2].data(),
-                                               sigBnd[3].data(), sigBnd[4].data(), sigBnd[5].data(), Tb.data());
+        const scalar *b0=sigBnd[0].data(),*b1=sigBnd[1].data(),*b2=sigBnd[2].data(),*b3=sigBnd[3].data(),*b4=sigBnd[4].data(),*b5=sigBnd[5].data();
+        scalar* Tbd = Tb.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { symmExpandKernel(nB, b0, b1, b2, b3, b4, b5, Tbd); });
         cudaCheck(cudaGetLastError(), "symmExpand boundary");
     }
     deviceTensorDivSource(dm, Tc, Tb, outX, outY, outZ);
@@ -151,11 +160,17 @@ void deviceDivNuMGradU(const DeviceMesh& dm, const DeviceVectorBoundary& dbU,
     DeviceBuffer<scalar> gradB;
     deviceBoundaryGradU(dm, dbU, Ux, Uy, Uz, gradU, gradB);
     DeviceBuffer<scalar> Tc(static_cast<std::size_t>(9)*nC), Tb(static_cast<std::size_t>(9)*nB);
-    scaleTensorKernel<<<nBlocks(9*nC), TPB>>>(9*nC, gradU.data(), nuM, Tc.data());
+    {
+        const scalar* gradUd = gradU.data();
+        scalar* Tcd = Tc.data();
+        pcudaParallelFor(nBlocks(9*nC), TPB, [=] __device__ () { scaleTensorKernel(9*nC, gradUd, nuM, Tcd); });
+    }
     cudaCheck(cudaGetLastError(), "scale nuM gradU cells");
     if (nB)
     {
-        scaleTensorKernel<<<nBlocks(9*nB), TPB>>>(9*nB, gradB.data(), nuM, Tb.data());
+        const scalar* gradBd = gradB.data();
+        scalar* Tbd = Tb.data();
+        pcudaParallelFor(nBlocks(9*nB), TPB, [=] __device__ () { scaleTensorKernel(9*nB, gradBd, nuM, Tbd); });
         cudaCheck(cudaGetLastError(), "scale nuM gradU boundary");
     }
     deviceTensorDivSource(dm, Tc, Tb, outX, outY, outZ);
@@ -164,8 +179,9 @@ void deviceDivNuMGradU(const DeviceMesh& dm, const DeviceVectorBoundary& dbU,
 void deviceSymmMagSqr(int nC, const DeviceBuffer<scalar>* sigma, DeviceBuffer<scalar>& out)
 {
     out.resize(static_cast<std::size_t>(nC));
-    symmMagSqrKernel<<<nBlocks(nC), TPB>>>(nC, sigma[0].data(), sigma[1].data(), sigma[2].data(),
-                                           sigma[3].data(), sigma[4].data(), sigma[5].data(), out.data());
+    const scalar *s0=sigma[0].data(),*s1=sigma[1].data(),*s2=sigma[2].data(),*s3=sigma[3].data(),*s4=sigma[4].data(),*s5=sigma[5].data();
+    scalar* outd = out.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { symmMagSqrKernel(nC, s0, s1, s2, s3, s4, s5, outd); });
     cudaCheck(cudaGetLastError(), "symmMagSqr");
 }
 

--- a/src/cuda/device_pcg.cu
+++ b/src/cuda/device_pcg.cu
@@ -7,6 +7,7 @@
 #include "device_halo.cuh"
 #include "device_reduce.cuh"   // DeviceReducer: on-stream NVSHMEM global reduction (replaces host MPI_Allreduce)
 #include "cf_pstream.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cmath>
 #include <cstdlib>
@@ -148,17 +149,26 @@ DeviceSolverPerf deviceJacobiBiCGStab(
         {
             if (nIter > 0) deviceScalarCopy(s.rr.data(), s.rrOld.data());   // rA0rAold = rA0rA
             deviceDotInto(rA0, rA, s.rr.data());                  // rA0rA = rA0 . rA
-            bicgRhoSingK<<<1,1>>>(s.rr.data(), s.bd.data());      // OF checkSingularity(mag(rA0rA)) -> flag (no host read)
+            {
+                scalar* rr = s.rr.data(); scalar* bd = s.bd.data();
+                pcudaParallelFor(1, 1, [=] __device__ () { bicgRhoSingK(rr, bd); });   // OF checkSingularity(mag(rA0rA)) -> flag (no host read)
+            }
             if (nIter == 0) deviceCopy(pA, rA);
             else
             {
-                bicgBetaK<<<1,1>>>(s.rr.data(), s.rrOld.data(), s.alpha.data(), s.omega.data(), s.beta.data(), s.bd.data());
+                scalar* rr = s.rr.data(); scalar* rrOld = s.rrOld.data(); scalar* al = s.alpha.data();
+                scalar* om = s.omega.data(); scalar* beta = s.beta.data(); scalar* bd = s.bd.data();
+                pcudaParallelFor(1, 1, [=] __device__ () { bicgBetaK(rr, rrOld, al, om, beta, bd); });
                 deviceFusedBicgP(rA, pA, AyA, s.beta.data(), s.negOmega.data());            // pA = rA + beta*(pA - omega*AyA)  [fused 3->1]
             }
             applyPrecon(yA, pA);
             deviceAmul(A, yA, AyA);          // yA = M^-1 pA; AyA = A yA
             deviceDotInto(rA0, AyA, s.r0Ay.data());
-            bicgAlphaK<<<1,1>>>(s.rr.data(), s.r0Ay.data(), s.alpha.data(), s.negAlpha.data(), s.bd.data());   // alpha = rA0rA/(rA0.AyA), guarded
+            {
+                scalar* rr = s.rr.data(); scalar* r0Ay = s.r0Ay.data(); scalar* al = s.alpha.data();
+                scalar* negAl = s.negAlpha.data(); scalar* bd = s.bd.data();
+                pcudaParallelFor(1, 1, [=] __device__ () { bicgAlphaK(rr, r0Ay, al, negAl, bd); });   // alpha = rA0rA/(rA0.AyA), guarded
+            }
             deviceFusedSxpy(sA, rA, s.negAlpha.data(), AyA);                            // sA = rA - alpha*AyA  [fused 2->1]
             const bool check = ((nIter + 1) % K == 0) || (nIter + 1 >= maxIter);        // read |s|/|r|/bd only on check iters
             if (check)                                          // mid-iter early-exit only when we read |s|
@@ -176,7 +186,11 @@ DeviceSolverPerf deviceJacobiBiCGStab(
             deviceAmul(A, zA, tA);           // zA = M^-1 sA; tA = A zA
             deviceDotInto(tA, tA, s.tt.data());
             deviceDotInto(tA, sA, s.ts.data());
-            omegaK<<<1,1>>>(s.ts.data(), s.tt.data(), s.omega.data(), s.negOmega.data(), s.bd.data());     // omega = tt>tiny ? ts/tt : 0 (+singularity flag)
+            {
+                scalar* ts = s.ts.data(); scalar* tt = s.tt.data(); scalar* om = s.omega.data();
+                scalar* negOm = s.negOmega.data(); scalar* bd = s.bd.data();
+                pcudaParallelFor(1, 1, [=] __device__ () { omegaK(ts, tt, om, negOm, bd); });     // omega = tt>tiny ? ts/tt : 0 (+singularity flag)
+            }
             deviceFusedAxpy2(psi, s.alpha.data(), yA, s.omega.data(), zA);               // psi += alpha*yA + omega*zA  [fused 2->1]
             deviceFusedSxpy(rA, sA, s.negOmega.data(), tA);                             // rA = sA - omega*tA  [fused 2->1]
             if (check)

--- a/src/cuda/device_pcg.cuh
+++ b/src/cuda/device_pcg.cuh
@@ -21,8 +21,12 @@ struct DeviceSolverPerf { scalar initialResidual = 0, finalResidual = 0; int nIt
 // copies here (diagP/upperP/lowerP/ifaceP) that the caller memcpy-refreshes each step -> the graph is captured
 // ONCE and replayed, no per-step re-instantiation. Holds the graph-referenced Krylov vectors + control scalars.
 struct BiCGGraphCache {
+#ifndef BRAE_ACPP
+    // CUDA-graph conditional-node replay has no PCUDA equivalent; the only code touching these fields is
+    // excluded from the ACPP build, so the fields are excluded too rather than left dangling.
     cudaGraphExec_t exec = nullptr; cudaGraph_t graph = nullptr;
     cudaGraphConditionalHandle handle{}; const void* key = nullptr;
+#endif
     DeviceBuffer<scalar> rA, rA0, pA, yA, AyA, sA, zA, tA, Ax;      // persistent Krylov vectors
     DeviceBuffer<scalar> diagP, upperP, lowerP;                     // persistent matrix copies (refreshed per step)
     std::vector<DeviceBuffer<scalar>> ifaceP;                       // persistent interface-coeff copies

--- a/src/cuda/device_pcg_detail.cuh
+++ b/src/cuda/device_pcg_detail.cuh
@@ -13,7 +13,7 @@ namespace brae {
 // breakdown D2H reads). The guarded recurrence stays NaN-safe between checks; for a NON-breakdown solve nothing trips
 // (rho/omega stay >> VSMALL until convergence breaks first) so the iteration is bit-identical to the host-guarded form.
 constexpr scalar BICG_VSMALL = 1e-300;   // = OF solveScalar VSMALL (SolverPerformance.C checkSingularity: mag(x) < vsmall_)
-static __global__
+static __device__
 void omegaK(
     const scalar* __restrict__ ts,
     const scalar* __restrict__ tt,
@@ -30,7 +30,7 @@ void omegaK(
         if (fabs(o) < BICG_VSMALL) *bd = 1.0;            // OF: checkSingularity(mag(omega)) (guards next-iter beta)
     }
 }
-static __global__
+static __device__
 void bicgBetaK(
     const scalar* __restrict__ rr,
     const scalar* __restrict__ rrOld,
@@ -47,14 +47,14 @@ void bicgBetaK(
         if (!ok) *bd = 1.0;
     }
 }
-static __global__
+static __device__
 void bicgRhoSingK(
     const scalar* __restrict__ rr,
     scalar* __restrict__ bd)
 {
     if (threadIdx.x==0 && blockIdx.x==0 && fabs(*rr) < BICG_VSMALL) *bd = 1.0;   // OF: checkSingularity(mag(rA0rA))
 }
-static __global__
+static __device__
 void bicgAlphaK(
     const scalar* __restrict__ rr,
     const scalar* __restrict__ r0Ay,

--- a/src/cuda/device_scalar_transport.cuh
+++ b/src/cuda/device_scalar_transport.cuh
@@ -15,6 +15,7 @@
 #include "device_amg.cuh"         // deviceSymGaussSeidel
 #include "stage_dump.cuh"      // Phase 0 stage harness
 #include "device_ddt.cuh"         // ScalarDdt + deviceFvmDdtDiag/Source (transient turbulence)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <vector>
 #include <fstream>
@@ -32,7 +33,7 @@ inline std::vector<ScalarSolveEntry>& turbStore() { static std::vector<ScalarSol
 
 namespace {
 // setValues (eps wall constraint): zero wall-cell off-diagonals + move the known eps0 to the neighbour RHS.
-__global__
+__device__
 void svFaceKernel(
     int nIf,
     const label* __restrict__ own,
@@ -54,7 +55,7 @@ void svFaceKernel(
 }
 
 
-__global__
+__device__
 void svBndKernel(
     int nB,
     const label* __restrict__ faceCell,
@@ -67,7 +68,7 @@ void svBndKernel(
 }
 
 
-__global__
+__device__
 void svCellKernel(
     int nC,
     const label* __restrict__ isW,
@@ -79,7 +80,7 @@ void svCellKernel(
     if (c < nC && isW[c]) source[c] = relaxedDiag[c] * eps0[c];
 }
 // shared turbulence-common kernels (effective diffusivity D + OF bound override); used by k/eps + k-omega.
-static __global__
+static __device__
 void depsKernel(int nC, const scalar* __restrict__ nut, scalar sigma, scalar nu, scalar* __restrict__ D)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -87,7 +88,7 @@ void depsKernel(int nC, const scalar* __restrict__ nut, scalar sigma, scalar nu,
 }
 
 
-static __global__
+static __device__
 // OF epsilonWallFunctionFvPatchScalarField::updateCoeffs(weights), epsilonWallFunction.C:586 --
 //     G[celli]       = (1 - w)*G[celli]       + w*G0[celli];
 //     epsilon[celli] = (1 - w)*epsilon[celli] + w*epsilon0[celli];
@@ -121,6 +122,22 @@ void overrideKernel(
 }
 } // anon (scaffold setValues kernels)
 
+// Shared by both setValues call sites below. A non-template free function deliberately: nvcc forbids an
+// extended __device__ lambda inside a function templated on a local lambda type (deviceSolveScalarTransport<Reaction>).
+inline void applySetValuesKernels(
+    const DeviceMesh& dm, int nC,
+    const label* __restrict__ isW, const scalar* __restrict__ val,
+    DeviceBuffer<scalar>& aU, DeviceBuffer<scalar>& aL, DeviceBuffer<scalar>& src,
+    DeviceBuffer<scalar>& aIC, DeviceBuffer<scalar>& aBC, DeviceBuffer<scalar>& aRD)
+{
+    const int nIf = dm.nInternalFaces, nB = dm.nBndFaces;
+    const label *own = dm.owner.data(), *nei = dm.nei.data(), *bndCell = dm.bndCell.data();
+    scalar *aUd = aU.data(), *aLd = aL.data(), *srcd = src.data();
+    scalar *aICd = aIC.data(), *aBCd = aBC.data(), *aRDd = aRD.data();
+    pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { svFaceKernel(nIf, own, nei, isW, val, aUd, aLd, srcd); });
+    pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { svBndKernel(nB, bndCell, isW, aICd, aBCd); });
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { svCellKernel(nC, isW, aRDd, val, srcd); });
+}
 
 // One scalar-transport sub-step of a two-equation RAS correct(): assemble div(phi,f) - laplacian(D,f)
 // [- Sp(div(phi),f) if bounded], add the model reaction (diag+source via `reaction`), relax, optionally
@@ -323,16 +340,12 @@ void deviceSolveScalarTransport(
     { DeviceBuffer<scalar> t; deviceHadamard(t, aDelta, field); deviceAxpy(1.0, t, src); }
     if (fvoSetMask && fvoSetVal)   // fvOptions scalarFixedValueConstraint (OF: before boundaryManipulate)
     {
-        svFaceKernel<<<nBlocks(dm.nInternalFaces), TPB>>>(dm.nInternalFaces, dm.owner.data(), dm.nei.data(), fvoSetMask->data(), fvoSetVal->data(), aU.data(), aL.data(), src.data());
-        svBndKernel<<<nBlocks(dm.nBndFaces), TPB>>>(dm.nBndFaces, dm.bndCell.data(), fvoSetMask->data(), aIC.data(), aBC.data());
-        svCellKernel<<<nBlocks(nC), TPB>>>(nC, fvoSetMask->data(), aRD.data(), fvoSetVal->data(), src.data());
+        applySetValuesKernels(dm, nC, fvoSetMask->data(), fvoSetVal->data(), aU, aL, src, aIC, aBC, aRD);
         cudaCheck(cudaGetLastError(), "fvOptionsSetValues");
     }
         if (wall && eps0)   // eps near-wall setValues constraint (k has none)
     {
-        svFaceKernel<<<nBlocks(dm.nInternalFaces), TPB>>>(dm.nInternalFaces, dm.owner.data(), dm.nei.data(), wall->isWallCell.data(), eps0->data(), aU.data(), aL.data(), src.data());
-        svBndKernel<<<nBlocks(dm.nBndFaces), TPB>>>(dm.nBndFaces, dm.bndCell.data(), wall->isWallCell.data(), aIC.data(), aBC.data());
-        svCellKernel<<<nBlocks(nC), TPB>>>(nC, wall->isWallCell.data(), aRD.data(), eps0->data(), src.data());
+        applySetValuesKernels(dm, nC, wall->isWallCell.data(), eps0->data(), aU, aL, src, aIC, aBC, aRD);
         if (ami && ami->n) interfaceZeroWallIfCoeff(*ami, wall->isWallCell);   // wall/interface cells: don't perturb the fixed eps
         if (cyc && cyc->n) interfaceZeroWallIfCoeff(*cyc, wall->isWallCell);
         cudaCheck(cudaGetLastError(), "setValues");

--- a/src/cuda/device_simple.cu
+++ b/src/cuda/device_simple.cu
@@ -1,6 +1,7 @@
 // cf GPU offload (G7): SIMPLE coupling-glue kernels. matrixH and matrixFlux reuse the ownerStart/losort
 // gather; rAU / corrector are elementwise; the HbyA flux is a per-face vector interpolation dotted with Sf.
 #include "device_simple.cuh"
+#include "pcuda_compat.cuh"
 #include <cmath>
 #include <cuda_runtime.h>
 
@@ -10,7 +11,7 @@ namespace {
 constexpr int TPB = 256;
 inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
-__global__
+__device__
 void matrixHKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -49,7 +50,7 @@ void matrixHKernel(
     h += bd * psi[c] + bs;
     H[c] = h / V[c];
 }
-__global__
+__device__
 void reciprocalVKernel(
     int nC,
     const scalar* __restrict__ diagC,
@@ -59,7 +60,7 @@ void reciprocalVKernel(
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
     if (c < nC) rAU[c] = V[c] / diagC[c];
 }
-__global__
+__device__
 void vectorFluxKernel(
     int nIf,
     const label* __restrict__ own,
@@ -82,7 +83,7 @@ void vectorFluxKernel(
     const scalar uz = wf * Uz[o] + (1.0 - wf) * Uz[n];
     phi[f] = ux * Sfx[f] + uy * Sfy[f] + uz * Sfz[f];
 }
-__global__
+__device__
 void matrixFluxKernel(
     int nIf,
     const label* __restrict__ own,
@@ -95,7 +96,7 @@ void matrixFluxKernel(
     const int f = blockIdx.x * blockDim.x + threadIdx.x;
     if (f < nIf) flux[f] = upper[f] * p[nei[f]] - lower[f] * p[own[f]];
 }
-__global__
+__device__
 void correctorKernel(
     int nC,
     const scalar* __restrict__ HbyA,
@@ -106,7 +107,7 @@ void correctorKernel(
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
     if (c < nC) U[c] = HbyA[c] - rAU[c] * gradP[c];
 }
-__global__
+__device__
 void bndFluxKernel(
     int nB,
     const label* __restrict__ bndGFace,
@@ -123,7 +124,7 @@ void bndFluxKernel(
     const int f = bndGFace[i];
     phiB[i] = uxb[i] * Sfx[f] + uyb[i] * Sfy[f] + uzb[i] * Sfz[f];
 }
-__global__
+__device__
 void relaxKernel(
     int nC,
     const label* __restrict__ ownerStart,
@@ -175,15 +176,23 @@ void deviceMatrixH(
 {
     const int nC = dm.nCells;
     Hk.resize(nC);
-    matrixHKernel<<<nBlocks(nC), TPB>>>(nC, A.ownerStart, A.losort, A.losortStart, A.upper, A.lower, A.owner, A.nei,
-                                        psiK.data(), sourceK.data(), dm.V.data(), dm.bndCellStart.data(), dm.bndPerm.data(),
-                                        bdDiagK.data(), bdSrcK.data(), Hk.data());
+    {
+        const label *ownerStart=A.ownerStart, *losort=A.losort, *losortStart=A.losortStart, *own=A.owner, *nei=A.nei;
+        const scalar *upper=A.upper, *lower=A.lower;
+        const scalar *psid=psiK.data(), *sourced=sourceK.data(), *Vd=dm.V.data();
+        const label *bndCellStart=dm.bndCellStart.data(), *bndPerm=dm.bndPerm.data();
+        const scalar *bdDiagd=bdDiagK.data(), *bdSrcd=bdSrcK.data(); scalar* Hd = Hk.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            matrixHKernel(nC, ownerStart, losort, losortStart, upper, lower, own, nei, psid, sourced, Vd,
+                         bndCellStart, bndPerm, bdDiagd, bdSrcd, Hd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "matrixH");
 }
 // linearUpwind / linearUpwindV / LUST deferred convection corrections moved to device_deferred_correction.cu
 
 namespace {
-__global__
+__device__
 void setRefKernel(
     label ref,
     scalar refValue,
@@ -197,7 +206,7 @@ void setRefKernel(
     }
 }
 // adjustPhi: per-face classify (massIn / fixedMassOut / adjustableMassOut) via atomics into sums[0..2].
-__global__
+__device__
 void adjustReduceKernel(
     int n,
     const label* __restrict__ adj,
@@ -211,7 +220,7 @@ void adjustReduceKernel(
     else if (adj[i]) atomicAdd(&sums[2], f);              // adjustableMassOut
     else atomicAdd(&sums[1], f);                          // fixedMassOut
 }
-__global__
+__device__
 void adjustScaleKernel(
     int n,
     const label* __restrict__ adj,
@@ -229,20 +238,22 @@ scalar deviceAdjustPhi(const DeviceBuffer<label>& adjustable, DeviceBuffer<scala
     if (n == 0) return 1.0;
     DeviceBuffer<scalar> sums(3);
     cudaCheck(cudaMemset(sums.data(), 0, 3 * sizeof(scalar)), "adjustPhi memset");
-    adjustReduceKernel<<<nBlocks(n), TPB>>>(n, adjustable.data(), phiB.data(), sums.data());
+    const label* adjd = adjustable.data(); scalar* phiBd = phiB.data(); scalar* sumsd = sums.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { adjustReduceKernel(n, adjd, phiBd, sumsd); });
     scalar h[3];
     cudaCheck(cudaMemcpy(h, sums.data(), 3 * sizeof(scalar), cudaMemcpyDeviceToHost), "adjustPhi D2H");
     const scalar massIn = h[0], fixedOut = h[1], adjOut = h[2];
     scalar massCorr = 1.0;
     if (std::fabs(adjOut) > 1e-300) massCorr = (massIn - fixedOut) / adjOut;       // OF: (massIn-fixedMassOut)/adjustableMassOut
-    adjustScaleKernel<<<nBlocks(n), TPB>>>(n, adjustable.data(), massCorr, phiB.data());
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { adjustScaleKernel(n, adjd, massCorr, phiBd); });
     cudaCheck(cudaGetLastError(), "adjustPhi");
     return massCorr;
 }
 void deviceSetReference(DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& b, label refCell, scalar refValue)
 {
     if (refCell < 0) return;
-    setRefKernel<<<1, 1>>>(refCell, refValue, diag.data(), b.data());
+    scalar* diagd = diag.data(); scalar* bd = b.data();
+    pcudaParallelFor(1, 1, [=] __device__ () { setRefKernel(refCell, refValue, diagd, bd); });
     cudaCheck(cudaGetLastError(), "setReference");
 }
 
@@ -250,12 +261,13 @@ void deviceReciprocalV(const DeviceMesh& dm, const DeviceBuffer<scalar>& diagC, 
 {
     const int nC = dm.nCells;
     rAU.resize(nC);
-    reciprocalVKernel<<<nBlocks(nC), TPB>>>(nC, diagC.data(), dm.V.data(), rAU.data());
+    const scalar* diagCd = diagC.data(); const scalar* Vd = dm.V.data(); scalar* rAUd = rAU.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { reciprocalVKernel(nC, diagCd, Vd, rAUd); });
     cudaCheck(cudaGetLastError(), "reciprocalV");
 }
 // SIMPLEC rAtU = 1/(1/rAU - H1) = V/rowSum, where rowSum = A*1 = diagA + sum(off-diag) (= 1/rAU - H1).
 // OF (pEqn.H:12): rAtU = 1.0/(1.0/rAU - UEqn.H1()) -- NO floor/guard. Faithful: divide by rowSum directly.
-__global__
+__device__
 void simplecRAtUKernel(
     int n,
     const scalar* __restrict__ V,
@@ -275,7 +287,9 @@ void deviceSimplecRAtU(
 {
     const int nC = dm.nCells;
     rAtU.resize(nC);
-    simplecRAtUKernel<<<nBlocks(nC), TPB>>>(nC, dm.V.data(), rowSum.data(), diagA.data(), rAtU.data());
+    const scalar* Vd = dm.V.data(); const scalar* rowSumd = rowSum.data(); const scalar* diagAd = diagA.data();
+    scalar* rAtUd = rAtU.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { simplecRAtUKernel(nC, Vd, rowSumd, diagAd, rAtUd); });
     cudaCheck(cudaGetLastError(), "simplecRAtU");
 }
 void deviceVectorFlux(
@@ -287,14 +301,25 @@ void deviceVectorFlux(
 {
     const int nIf = dm.nInternalFaces;
     phiInt.resize(nIf);
-    vectorFluxKernel<<<nBlocks(nIf), TPB>>>(nIf, dm.owner.data(), dm.nei.data(), dm.w.data(), dm.Sfx.data(), dm.Sfy.data(),
-                                            dm.Sfz.data(), Ux.data(), Uy.data(), Uz.data(), phiInt.data());
+    {
+        const label *own=dm.owner.data(), *nei=dm.nei.data(); const scalar *wd=dm.w.data();
+        const scalar *Sfxd=dm.Sfx.data(), *Sfyd=dm.Sfy.data(), *Sfzd=dm.Sfz.data();
+        const scalar *Uxd=Ux.data(), *Uyd=Uy.data(), *Uzd=Uz.data(); scalar* phiIntd = phiInt.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () {
+            vectorFluxKernel(nIf, own, nei, wd, Sfxd, Sfyd, Sfzd, Uxd, Uyd, Uzd, phiIntd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "vectorFlux");
 }
 void deviceMatrixFluxInternal(const DeviceLduView& A, const DeviceBuffer<scalar>& p, DeviceBuffer<scalar>& fluxInt)
 {
     fluxInt.resize(A.nInternalFaces);
-    matrixFluxKernel<<<nBlocks(A.nInternalFaces), TPB>>>(A.nInternalFaces, A.owner, A.nei, A.upper, A.lower, p.data(), fluxInt.data());
+    {
+        const int nIf = A.nInternalFaces;
+        const label *own=A.owner, *nei=A.nei; const scalar *upper=A.upper, *lower=A.lower;
+        const scalar* pd = p.data(); scalar* fluxIntd = fluxInt.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { matrixFluxKernel(nIf, own, nei, upper, lower, pd, fluxIntd); });
+    }
     cudaCheck(cudaGetLastError(), "matrixFlux");
 }
 void deviceCorrector(
@@ -305,7 +330,8 @@ void deviceCorrector(
 {
     const int nC = static_cast<int>(HbyA.size());
     U.resize(nC);
-    correctorKernel<<<nBlocks(nC), TPB>>>(nC, HbyA.data(), rAU.data(), gradP.data(), U.data());
+    const scalar *HbyAd = HbyA.data(), *rAUd = rAU.data(), *gradPd = gradP.data(); scalar* Ud = U.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { correctorKernel(nC, HbyAd, rAUd, gradPd, Ud); });
     cudaCheck(cudaGetLastError(), "corrector");
 }
 void deviceBoundaryFlux(
@@ -316,8 +342,15 @@ void deviceBoundaryFlux(
     DeviceBuffer<scalar>& phiB)
 {
     phiB.resize(dm.nBndFaces);
-    bndFluxKernel<<<nBlocks(dm.nBndFaces), TPB>>>(dm.nBndFaces, dm.bndGFace.data(), dm.Sfx.data(), dm.Sfy.data(),
-                                                  dm.Sfz.data(), uxb.data(), uyb.data(), uzb.data(), phiB.data());
+    {
+        const int nB = dm.nBndFaces;
+        const label* bndGFaced = dm.bndGFace.data();
+        const scalar *Sfxd=dm.Sfx.data(), *Sfyd=dm.Sfy.data(), *Sfzd=dm.Sfz.data();
+        const scalar *uxbd=uxb.data(), *uybd=uyb.data(), *uzbd=uzb.data(); scalar* phiBd = phiB.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+            bndFluxKernel(nB, bndGFaced, Sfxd, Sfyd, Sfzd, uxbd, uybd, uzbd, phiBd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "bndFlux");
 }
 void deviceRelaxDiag(
@@ -333,13 +366,22 @@ void deviceRelaxDiag(
 {
     relaxedDiag.resize(A.nCells);
     delta.resize(A.nCells);
-    relaxKernel<<<nBlocks(A.nCells), TPB>>>(A.nCells, A.ownerStart, A.losort, A.losortStart, A.upper, A.lower,
-                                            dm.bndCellStart.data(), dm.bndPerm.data(), iCbnd.data(), A.diag, alpha,
-                                            relaxedDiag.data(), delta.data(), cycSumOff, iCmaxMag, iCmin);
+    {
+        const int nC = A.nCells;
+        const label *ownerStart=A.ownerStart, *losort=A.losort, *losortStart=A.losortStart;
+        const scalar *upper=A.upper, *lower=A.lower;
+        const label *bndCellStart=dm.bndCellStart.data(), *bndPerm=dm.bndPerm.data();
+        const scalar *iCbndd = iCbnd.data(), *rawDiag = A.diag;
+        scalar *relaxedDiagd = relaxedDiag.data(), *deltad = delta.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            relaxKernel(nC, ownerStart, losort, losortStart, upper, lower, bndCellStart, bndPerm, iCbndd, rawDiag,
+                       alpha, relaxedDiagd, deltad, cycSumOff, iCmaxMag, iCmin);
+        });
+    }
     cudaCheck(cudaGetLastError(), "relaxDiag");
 }
 namespace {
-__global__
+__device__
 void cmptMaxMag3Kernel(
     int n,
     const scalar* __restrict__ a,
@@ -359,12 +401,13 @@ void deviceCmptMaxMag3(
 {
     const int n = static_cast<int>(a.size());
     out.resize(n);
-    cmptMaxMag3Kernel<<<nBlocks(n), TPB>>>(n, a.data(), b.data(), c.data(), out.data());
+    const scalar *ad = a.data(), *bd = b.data(), *cd = c.data(); scalar* outd = out.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { cmptMaxMag3Kernel(n, ad, bd, cd, outd); });
     cudaCheck(cudaGetLastError(), "cmptMaxMag3");
 }
 
 
-__global__
+__device__
 void cmptMin3Kernel(
     int n,
     const scalar* __restrict__ a,
@@ -385,7 +428,8 @@ void deviceCmptMin3(
 {
     const int n = static_cast<int>(a.size());
     out.resize(n);
-    cmptMin3Kernel<<<nBlocks(n), TPB>>>(n, a.data(), b.data(), c.data(), out.data());
+    const scalar *ad = a.data(), *bd = b.data(), *cd = c.data(); scalar* outd = out.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { cmptMin3Kernel(n, ad, bd, cd, outd); });
     cudaCheck(cudaGetLastError(), "cmptMin3");
 }
 

--- a/src/cuda/device_smagorinsky.cu
+++ b/src/cuda/device_smagorinsky.cu
@@ -7,13 +7,14 @@
 // Incompressible (tr(D)=div(U)->0): nut = Ck*sqrt(2*Ck/Ce)*delta^2*sqrt(S:S), the classic Cs~0.168 Smagorinsky.
 #include "device_smagorinsky.cuh"
 #include "device_scalar_transport.cuh"  // nBlocks/TPB (shared launch geometry)
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
 
 namespace {
 
-__global__
+__device__
 void smagorinskyNutKernel(
     int nC, const scalar* __restrict__ gradU, const scalar* __restrict__ V,
     SmagorinskyCoeffs co, const scalar* __restrict__ dOpt, scalar* __restrict__ nut)
@@ -54,7 +55,7 @@ namespace {
 //     nut       = Ck*delta*sqrt(k)
 // gradU is packed q = 3i + j = d(U_j)/d(x_i), which is OF's own tensor layout, so (A & B)[i][j] is
 // sum_k A[i][k]*B[k][j] on the same indices.
-__global__
+__device__
 void waleNutKernel(
     int nC, const scalar* __restrict__ gradU, const scalar* __restrict__ V,
     WaleCoeffs co, const scalar* __restrict__ dOpt, scalar* __restrict__ nut)
@@ -101,8 +102,11 @@ void deviceWaleNut(int nC, const DeviceBuffer<scalar>& gradU, const DeviceBuffer
 {
     nut.resize(nC);
     if (nC == 0) return;
-    waleNutKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), V.data(), co,
-        (delta && delta->size()) ? delta->data() : nullptr, nut.data());
+    const scalar* gradUd = gradU.data();
+    const scalar* Vd = V.data();
+    const scalar* deltad = (delta && delta->size()) ? delta->data() : nullptr;
+    scalar* nutd = nut.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { waleNutKernel(nC, gradUd, Vd, co, deltad, nutd); });
     cudaCheck(cudaGetLastError(), "deviceWaleNut");
 }
 
@@ -113,8 +117,11 @@ void deviceSmagorinskyNut(int nC, const DeviceBuffer<scalar>& gradU, const Devic
 {
     nut.resize(nC);
     if (nC == 0) return;
-    smagorinskyNutKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), V.data(), co,
-        (delta && delta->size()) ? delta->data() : nullptr, nut.data());
+    const scalar* gradUd = gradU.data();
+    const scalar* Vd = V.data();
+    const scalar* deltad = (delta && delta->size()) ? delta->data() : nullptr;
+    scalar* nutd = nut.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () { smagorinskyNutKernel(nC, gradUd, Vd, co, deltad, nutd); });
     cudaCheck(cudaGetLastError(), "deviceSmagorinskyNut");
 }
 

--- a/src/cuda/device_spalart.cu
+++ b/src/cuda/device_spalart.cu
@@ -13,6 +13,7 @@
 #include "device_interface.cuh"
 #include "device_amg.cuh"
 #include "nut_wall_function.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cmath>
 #include <vector>
@@ -41,7 +42,7 @@ __device__ inline scalar saPsi(scalar chi, const SpalartAllmarasCoeffs& co)
 }
 
 // Stilda = max(Omega + fv2*nuTilda/(kappa*y)^2, Cs*Omega); Omega = sqrt(2)*mag(skew(gradU)) (vorticity magnitude).
-__global__
+__device__
 void saStildaKernel(
     int nC,
     const scalar* __restrict__ gradU,
@@ -65,7 +66,7 @@ void saStildaKernel(
 
 
 // fw = g*((1+Cw3^6)/(g^6+Cw3^6))^(1/6),  g = r + Cw2*(r^6 - r),  r = min(nuTilda/(Stilda*(kappa*y)^2), 10).
-__global__
+__device__
 void saFwKernel(
     int nC,
     const scalar* __restrict__ nt,
@@ -85,7 +86,7 @@ void saFwKernel(
 }
 
 
-__global__
+__device__
 void saReactionKernel(
     int nC,
     const scalar* __restrict__ V,
@@ -107,7 +108,7 @@ void saReactionKernel(
 }
 
 
-__global__
+__device__
 void saDEffKernel(int nC, const scalar* __restrict__ nt, scalar nu, scalar sigma, scalar* __restrict__ D)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -115,7 +116,7 @@ void saDEffKernel(int nC, const scalar* __restrict__ nt, scalar nu, scalar sigma
 }
 
 
-__global__
+__device__
 void saNutKernel(int nC, const scalar* __restrict__ nt, scalar nu, scalar Cv1, scalar* __restrict__ nut)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -126,7 +127,7 @@ void saNutKernel(int nC, const scalar* __restrict__ nt, scalar nu, scalar Cv1, s
 }
 
 
-__global__
+__device__
 void saMagSqrKernel(
     int nC,
     const scalar* __restrict__ gx,
@@ -144,7 +145,7 @@ void saMagSqrKernel(
 // dTilda=y) and switches to LES in detached regions (fd->1 -> dTilda=CDES*Delta). |gradU| = sqrt(sum_ij (dU_i/dx_j)^2)
 // (full 9-cmpt tensor magnitude); nut recomputed from nuTilda via fv1. lLES = Psi*CDES*Delta with the low-Re Psi (ft2=off).
 // Matches OF SpalartAllmarasDDES. dTilda == y wherever fd==0, so a RANS (des=false) run is untouched.
-__global__
+__device__
 void saDdesDTildaKernel(
     int nC, const scalar* __restrict__ y, const scalar* __restrict__ V, const scalar* __restrict__ gradU,
     const scalar* __restrict__ nt, scalar nu, SpalartAllmarasCoeffs co,
@@ -170,7 +171,7 @@ void saDdesDTildaKernel(
 // |curl U| per CELL, from the packed cell gradient. OF fvc::curl = 2*(*skew(grad U)) with the Hodge dual
 // *T = (T.yz, -T.xz, T.xy), which reduces to the textbook curl once gradU is read OF's way (T_ij = dU_j/dx_i):
 //     curl = (dUz/dy - dUy/dz,  dUx/dz - dUz/dx,  dUy/dx - dUx/dy)
-__global__
+__device__
 void saMagCurlKernel(int nC, const scalar* __restrict__ gradU, scalar* __restrict__ out)
 {
     const int c = blockIdx.x * blockDim.x + threadIdx.x;
@@ -187,7 +188,7 @@ void saMagCurlKernel(int nC, const scalar* __restrict__ gradU, scalar* __restric
 //     gradU_b = gradU_c + n (x) (snGrad - n & gradU_c),   snGrad = (U_b - U_c)*deltaCoeffs
 // which is the entire difference between a no-slip wall having a shear gradient and having none. Same
 // expression as device_divdevreff.cu's gradBKernel and the SST's sstNutBoundaryK.
-__global__
+__device__
 void saMagCurlBndKernel(
     int nB, int nC,
     const label*  __restrict__ fc,
@@ -234,7 +235,7 @@ void saMagCurlBndKernel(
 // new gradients are wall-normal derivatives: GnuTilda detects the eddy-viscosity ramp that says "this is
 // still an attached boundary layer" and GOmega the vorticity ramp, and where either says so the second
 // factor pulls fd back towards 0, i.e. back to RANS. pos() is OF's STRICT pos (x > 0), not pos0.
-__global__
+__device__
 void saZdesFdKernel(
     int nC,
     const scalar* __restrict__ y,
@@ -286,7 +287,7 @@ void saZdesFdKernel(
 // lLES = CDES*Delta with the IDDES delta Delta = min(max(Cw*y, Cw*hmax), hmax) (hmax = maxDeltaxyz; the wall-normal
 // spacing hwn term is omitted -> hwn=0, a documented simplification). Blending: rd_t/rd_l from nut/nu, fdt/fl/ft the
 // shielding + elevated-stress functions, fB/fe1/fe the WMLES branch. des==false leaves this path untaken (RANS exact).
-__global__
+__device__
 void saIddesDTildaKernel(
     int nC, const scalar* __restrict__ y, const scalar* __restrict__ gradU,
     const scalar* __restrict__ nt, scalar nu, const scalar* __restrict__ hmax, const scalar* __restrict__ hwn,
@@ -376,46 +377,87 @@ void deviceSpalartAllmarasCorrect(
             deviceGaussGrad(dm, nuTilda, nbv0, gx0, gy0, gz0);          // fvc::grad(nuTilda)
 
             DeviceBuffer<scalar> mc(static_cast<std::size_t>(nC)), mcb, ox, oy, oz;
-            saMagCurlKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), mc.data());
+            {
+                const scalar* gradUd = gradU.data(); scalar* mcd = mc.data();
+                pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                    saMagCurlKernel(nC, gradUd, mcd); });
+            }
             cudaCheck(cudaGetLastError(), "saMagCurl");
             const int nB = dbU.n;
             mcb.resize(static_cast<std::size_t>(nB));
             DeviceBuffer<scalar> ub[3];
             for (int k = 0; k < 3; ++k) deviceBCValue(dbU.comp[k], k == 0 ? Ux : (k == 1 ? Uy : Uz), ub[k]);
-            saMagCurlBndKernel<<<nBlocks(nB), TPB>>>(nB, nC, dbU.comp[0].faceCell.data(), gradU.data(),
-                                                     dbU.nx.data(), dbU.ny.data(), dbU.nz.data(),
-                                                     ub[0].data(), ub[1].data(), ub[2].data(),
-                                                     Ux.data(), Uy.data(), Uz.data(),
-                                                     dbU.comp[0].deltaCoeffs.data(), mcb.data());
+            {
+                const label* fcd = dbU.comp[0].faceCell.data();
+                const scalar* gradUd = gradU.data();
+                const scalar* nxd = dbU.nx.data(); const scalar* nyd = dbU.ny.data(); const scalar* nzd = dbU.nz.data();
+                const scalar* ub0 = ub[0].data(); const scalar* ub1 = ub[1].data(); const scalar* ub2 = ub[2].data();
+                const scalar* Uxd = Ux.data(); const scalar* Uyd = Uy.data(); const scalar* Uzd = Uz.data();
+                const scalar* dcd = dbU.comp[0].deltaCoeffs.data();
+                scalar* mcbd = mcb.data();
+                pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+                    saMagCurlBndKernel(nB, nC, fcd, gradUd, nxd, nyd, nzd, ub0, ub1, ub2, Uxd, Uyd, Uzd, dcd, mcbd); });
+            }
             cudaCheck(cudaGetLastError(), "saMagCurlBnd");
             deviceGaussGrad(dm, mc, mcb, ox, oy, oz);                   // fvc::grad(mag(curl(U)))
 
             zfd.resize(static_cast<std::size_t>(nC));
             const scalar* wn = wallN->data();
-            saZdesFdKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), gradU.data(), nuTilda.data(), nu,
-                                                 wn, wn + nC, wn + 2*nC,
-                                                 gx0.data(), gy0.data(), gz0.data(),
-                                                 ox.data(), oy.data(), oz.data(), co, zfd.data());
+            {
+                const scalar* yd = y.data(); const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data();
+                const scalar* wnx = wn; const scalar* wny = wn + nC; const scalar* wnz = wn + 2*nC;
+                const scalar* gx0d = gx0.data(); const scalar* gy0d = gy0.data(); const scalar* gz0d = gz0.data();
+                const scalar* oxd = ox.data(); const scalar* oyd = oy.data(); const scalar* ozd = oz.data();
+                scalar* zfdd = zfd.data();
+                pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                    saZdesFdKernel(nC, yd, gradUd, nuTildaD, nu, wnx, wny, wnz, gx0d, gy0d, gz0d, oxd, oyd, ozd, co, zfdd); });
+            }
             cudaCheck(cudaGetLastError(), "saZdesFd");
         }
         if (iddes && hmax && hwn)
-            saIddesDTildaKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), gradU.data(), nuTilda.data(), nu, hmax->data(), hwn->data(), co, dTilda.data());
+        {
+            const scalar* yd = y.data(); const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data();
+            const scalar* hmaxd = hmax->data(); const scalar* hwnd = hwn->data(); scalar* dTildad = dTilda.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                saIddesDTildaKernel(nC, yd, gradUd, nuTildaD, nu, hmaxd, hwnd, co, dTildad); });
+        }
         else
-            saDdesDTildaKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), dm.V.data(), gradU.data(), nuTilda.data(), nu, co,
-                                                     (lesDelta && lesDelta->size()) ? lesDelta->data() : nullptr,
-                                                     zfd.size() ? zfd.data() : nullptr, dTilda.data());
+        {
+            const scalar* yd = y.data(); const scalar* Vd = dm.V.data(); const scalar* gradUd = gradU.data();
+            const scalar* nuTildaD = nuTilda.data();
+            const scalar* lesDeltaD = (lesDelta && lesDelta->size()) ? lesDelta->data() : nullptr;
+            const scalar* zfdD = zfd.size() ? zfd.data() : nullptr;
+            scalar* dTildad = dTilda.data();
+            pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+                saDdesDTildaKernel(nC, yd, Vd, gradUd, nuTildaD, nu, co, lesDeltaD, zfdD, dTildad); });
+        }
     }
     const DeviceBuffer<scalar>& dScale = des ? dTilda : y;
     DeviceBuffer<scalar> Stilda(static_cast<std::size_t>(nC));
-    saStildaKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), nuTilda.data(), dScale.data(), nu, co, Stilda.data());
+    {
+        const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data(); const scalar* dScaleD = dScale.data();
+        scalar* Stildad = Stilda.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saStildaKernel(nC, gradUd, nuTildaD, dScaleD, nu, co, Stildad); });
+    }
     DeviceBuffer<scalar> fw(static_cast<std::size_t>(nC));
-    saFwKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), Stilda.data(), dScale.data(), co, fw.data());
+    {
+        const scalar* nuTildaD = nuTilda.data(); const scalar* StildaD = Stilda.data(); const scalar* dScaleD = dScale.data();
+        scalar* fwd = fw.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saFwKernel(nC, nuTildaD, StildaD, dScaleD, co, fwd); });
+    }
     DeviceBuffer<scalar> nbv;
     deviceBCValue(dbNuTilda, nuTilda, nbv);   // |grad nuTilda|^2
     DeviceBuffer<scalar> gnx, gny, gnz;
     deviceGaussGrad(dm, nuTilda, nbv, gnx, gny, gnz);
     DeviceBuffer<scalar> gradNt2(static_cast<std::size_t>(nC));
-    saMagSqrKernel<<<nBlocks(nC), TPB>>>(nC, gnx.data(), gny.data(), gnz.data(), gradNt2.data());
+    {
+        const scalar* gnxd = gnx.data(); const scalar* gnyd = gny.data(); const scalar* gnzd = gnz.data();
+        scalar* gradNt2d = gradNt2.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saMagSqrKernel(nC, gnxd, gnyd, gnzd, gradNt2d); });
+    }
     if (const char* sapath = std::getenv("BRAE_DUMP_SA"))   // cell-level SA-term dump (vs OF reference) -- first call only
     {
         static bool saDumped = false;
@@ -442,7 +484,11 @@ void deviceSpalartAllmarasCorrect(
         }
     }
     DeviceBuffer<scalar> D(static_cast<std::size_t>(nC));
-    saDEffKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), nu, co.sigmaNut, D.data());
+    {
+        const scalar* nuTildaD = nuTilda.data(); scalar* Dd = D.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saDEffKernel(nC, nuTildaD, nu, co.sigmaNut, Dd); });
+    }
     DeviceBuffer<scalar> divU;
     deviceDiv(dm, phiInt, phiBnd, divU);   // for the bounded term
     if (ami && ami->n) interfaceAddDiv(*ami, dm.V, divU);
@@ -463,18 +509,23 @@ void deviceSpalartAllmarasCorrect(
     if (ntBnd.size())
     {
         DB.resize(ntBnd.size());
-        saDEffKernel<<<nBlocks(static_cast<int>(ntBnd.size())), TPB>>>(static_cast<int>(ntBnd.size()),
-                                                                      ntBnd.data(), nu, co.sigmaNut, DB.data());
+        const int nB = static_cast<int>(ntBnd.size());
+        const scalar* ntBndD = ntBnd.data(); scalar* DBd = DB.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () {
+            saDEffKernel(nB, ntBndD, nu, co.sigmaNut, DBd); });
         cudaCheck(cudaGetLastError(), "SA DEff boundary");
     }
     deviceSolveScalarTransport(dm, dbNuTilda, nuTilda, "nuTilda", D, phiInt, phiBnd, divU, bounded, limited, linearUpwind, nonOrth, twoByk,
                                relax, tol, relTol, checkEvery, gsK,
                                [&](DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src){
-                                   saReactionKernel<<<nBlocks(nC), TPB>>>(nC, dm.V.data(), nuTilda.data(), Stilda.data(),
-                                       fw.data(), dScale.data(), gradNt2.data(), co, diag.data(), src.data()); },
+                                   deviceSAReaction(dm, nuTilda, Stilda, fw, dScale, gradNt2, co, diag, src); },
                                nullptr, nullptr, ami, cyc, ntDdt, DB.size() ? &DB : nullptr);
     // deviceSolveScalarTransport already bounds to 1e-15 (~ bound(nuTilda, 0)). correctNut: nut = nuTilda*fv1(new).
-    saNutKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), nu, co.Cv1, nut.data());
+    {
+        const scalar* nuTildaD = nuTilda.data(); scalar* nutd = nut.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saNutKernel(nC, nuTildaD, nu, co.Cv1, nutd); });
+    }
     cudaCheck(cudaGetLastError(), "SA correctNut");
 }
 
@@ -483,7 +534,7 @@ void deviceSpalartAllmarasCorrect(
 // eddyViscosity::validate()->correctNut()), so the FIRST momentum predictor sees a consistent nut.
 // Boundary variant: nu VARIES per face on a compressible mesh (nu = mu/rho), so the scalar-nu form
 // would be wrong there. nuFace == nullptr falls back to the uniform nu.
-__global__
+__device__
 void saNutFaceKernel(int n, const scalar* __restrict__ nt, const scalar* __restrict__ nuFace,
                      scalar nu, scalar Cv1, scalar* __restrict__ nut)
 {
@@ -499,8 +550,11 @@ void deviceNutSABoundary(const DeviceBuffer<scalar>& nuTildaB, const DeviceBuffe
 {
     const int n = static_cast<int>(nuTildaB.size());
     nutB.resize(n);
-    saNutFaceKernel<<<nBlocks(n), TPB>>>(n, nuTildaB.data(), nuFace ? nuFace->data() : nullptr,
-                                         nu, Cv1, nutB.data());
+    const scalar* nuTildaBD = nuTildaB.data();
+    const scalar* nuFaceD = nuFace ? nuFace->data() : nullptr;
+    scalar* nutBd = nutB.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+        saNutFaceKernel(n, nuTildaBD, nuFaceD, nu, Cv1, nutBd); });
     cudaCheck(cudaGetLastError(), "SA correctNut (boundary)");
 }
 
@@ -508,7 +562,9 @@ void deviceNutSA(const DeviceBuffer<scalar>& nuTilda, scalar nu, scalar Cv1, Dev
 {
     const int nC = static_cast<int>(nuTilda.size());
     nut.resize(nC);
-    saNutKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), nu, Cv1, nut.data());
+    const scalar* nuTildaD = nuTilda.data(); scalar* nutd = nut.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        saNutKernel(nC, nuTildaD, nu, Cv1, nutd); });
     cudaCheck(cudaGetLastError(), "SA correctNut (validate)");
 }
 
@@ -524,10 +580,15 @@ void deviceSAZdesFd(
     const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& fd)
 {
     fd.resize(static_cast<std::size_t>(nC));
-    saZdesFdKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), gradU.data(), nuTilda.data(), nu,
-                                         wnx.data(), wny.data(), wnz.data(),
-                                         gnx.data(), gny.data(), gnz.data(),
-                                         gox.data(), goy.data(), goz.data(), co, fd.data());
+    {
+        const scalar* yd = y.data(); const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data();
+        const scalar* wnxd = wnx.data(); const scalar* wnyd = wny.data(); const scalar* wnzd = wnz.data();
+        const scalar* gnxd = gnx.data(); const scalar* gnyd = gny.data(); const scalar* gnzd = gnz.data();
+        const scalar* goxd = gox.data(); const scalar* goyd = goy.data(); const scalar* gozd = goz.data();
+        scalar* fdd = fd.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saZdesFdKernel(nC, yd, gradUd, nuTildaD, nu, wnxd, wnyd, wnzd, gnxd, gnyd, gnzd, goxd, goyd, gozd, co, fdd); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSAZdesFd");
 }
 
@@ -537,7 +598,12 @@ void deviceSADDESdTilda(int nC, const DeviceBuffer<scalar>& y, const DeviceBuffe
     const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& dTilda)
 {
     dTilda.resize(nC);
-    saDdesDTildaKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), V.data(), gradU.data(), nuTilda.data(), nu, co, nullptr, nullptr, dTilda.data());
+    {
+        const scalar* yd = y.data(); const scalar* Vd = V.data(); const scalar* gradUd = gradU.data();
+        const scalar* nuTildaD = nuTilda.data(); scalar* dTildad = dTilda.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saDdesDTildaKernel(nC, yd, Vd, gradUd, nuTildaD, nu, co, nullptr, nullptr, dTildad); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSADDESdTilda");
 }
 
@@ -548,7 +614,12 @@ void deviceSAIDDESdTilda(int nC, const DeviceBuffer<scalar>& y, const DeviceBuff
     const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& dTilda)
 {
     dTilda.resize(nC);
-    saIddesDTildaKernel<<<nBlocks(nC), TPB>>>(nC, y.data(), gradU.data(), nuTilda.data(), nu, hmax.data(), hwn.data(), co, dTilda.data());
+    {
+        const scalar* yd = y.data(); const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data();
+        const scalar* hmaxd = hmax.data(); const scalar* hwnd = hwn.data(); scalar* dTildad = dTilda.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saIddesDTildaKernel(nC, yd, gradUd, nuTildaD, nu, hmaxd, hwnd, co, dTildad); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSAIDDESdTilda");
 }
 
@@ -559,35 +630,63 @@ void deviceSAStilda(const DeviceMesh& dm, const DeviceBuffer<scalar>& gradU, con
     const DeviceBuffer<scalar>& y, scalar nu, const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& Stilda)
 {
     const int nC = dm.nCells; Stilda.resize(nC);
-    saStildaKernel<<<nBlocks(nC), TPB>>>(nC, gradU.data(), nuTilda.data(), y.data(), nu, co, Stilda.data());
+    {
+        const scalar* gradUd = gradU.data(); const scalar* nuTildaD = nuTilda.data(); const scalar* yd = y.data();
+        scalar* Stildad = Stilda.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saStildaKernel(nC, gradUd, nuTildaD, yd, nu, co, Stildad); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSAStilda");
 }
 void deviceSAFw(const DeviceMesh& dm, const DeviceBuffer<scalar>& nuTilda, const DeviceBuffer<scalar>& Stilda,
     const DeviceBuffer<scalar>& y, const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& fw)
 {
     const int nC = dm.nCells; fw.resize(nC);
-    saFwKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), Stilda.data(), y.data(), co, fw.data());
+    {
+        const scalar* nuTildaD = nuTilda.data(); const scalar* StildaD = Stilda.data(); const scalar* yd = y.data();
+        scalar* fwd = fw.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saFwKernel(nC, nuTildaD, StildaD, yd, co, fwd); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSAFw");
 }
 void deviceSAMagSqr(const DeviceMesh& dm, const DeviceBuffer<scalar>& gx, const DeviceBuffer<scalar>& gy,
     const DeviceBuffer<scalar>& gz, DeviceBuffer<scalar>& out)
 {
     const int nC = dm.nCells; out.resize(nC);
-    saMagSqrKernel<<<nBlocks(nC), TPB>>>(nC, gx.data(), gy.data(), gz.data(), out.data());
+    {
+        const scalar* gxd = gx.data(); const scalar* gyd = gy.data(); const scalar* gzd = gz.data();
+        scalar* outd = out.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saMagSqrKernel(nC, gxd, gyd, gzd, outd); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSAMagSqr");
 }
 void deviceSADEff(const DeviceMesh& dm, const DeviceBuffer<scalar>& nuTilda, scalar nu, scalar sigmaNut, DeviceBuffer<scalar>& D)
 {
     const int nC = dm.nCells; D.resize(nC);
-    saDEffKernel<<<nBlocks(nC), TPB>>>(nC, nuTilda.data(), nu, sigmaNut, D.data());
+    {
+        const scalar* nuTildaD = nuTilda.data(); scalar* Dd = D.data();
+        pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+            saDEffKernel(nC, nuTildaD, nu, sigmaNut, Dd); });
+    }
     cudaCheck(cudaGetLastError(), "deviceSADEff");
 }
 void deviceSAReaction(const DeviceMesh& dm, const DeviceBuffer<scalar>& nuTilda, const DeviceBuffer<scalar>& Stilda,
     const DeviceBuffer<scalar>& fw, const DeviceBuffer<scalar>& y, const DeviceBuffer<scalar>& gradNt2,
     const SpalartAllmarasCoeffs& co, DeviceBuffer<scalar>& diag, DeviceBuffer<scalar>& src)
 {
-    saReactionKernel<<<nBlocks(dm.nCells), TPB>>>(dm.nCells, dm.V.data(), nuTilda.data(), Stilda.data(),
-        fw.data(), y.data(), gradNt2.data(), co, diag.data(), src.data());
+    const int nC = dm.nCells;
+    const scalar* Vd = dm.V.data();
+    const scalar* nuTildaD = nuTilda.data();
+    const scalar* StildaD = Stilda.data();
+    const scalar* fwD = fw.data();
+    const scalar* yD = y.data();
+    const scalar* gradNt2D = gradNt2.data();
+    scalar* diagD = diag.data();
+    scalar* srcD = src.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        saReactionKernel(nC, Vd, nuTildaD, StildaD, fwD, yD, gradNt2D, co, diagD, srcD); });
     cudaCheck(cudaGetLastError(), "deviceSAReaction");
 }
 

--- a/src/cuda/device_spmv.cu
+++ b/src/cuda/device_spmv.cu
@@ -3,6 +3,7 @@
 #include "device_ldu.cuh"
 #include "device_halo.cuh"
 #include "distributed_ami.cuh"   // DistributedAMI + distributedAmiAmul: optional cyclicAMI coupling in the matvec
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -11,7 +12,7 @@ namespace {
 constexpr int TPB = 256;
 
 
-__global__
+__device__
 void amulKernel(
     int nC,
     const scalar* __restrict__ diag,
@@ -44,7 +45,7 @@ void amulKernel(
 
 // cyclic (periodic) interface off-diagonal, OpenFOAM cyclicFvPatchField::updateInterfaceMatrix. One thread per
 // cyclic face: Apsi[own] += coeff*psi[nbr]. atomicAdd because a cell may own faces on several interfaces.
-__global__
+__device__
 void cyclicAmulKernel(
     int nCyc,
     const label* __restrict__ own,
@@ -61,7 +62,7 @@ void cyclicAmulKernel(
 
 
 // cyclicAMI weighted-stencil off-diagonal, one thread per source face: Apsi[own] += ifc * sum_k w*psi[nbr].
-__global__
+__device__
 void amiAmulKernel(
     int n,
     const label* __restrict__ own,
@@ -87,17 +88,30 @@ void deviceAmul(const DeviceLduView& A, const DeviceBuffer<scalar>& psi, DeviceB
 {
     Apsi.resize(A.nCells);
     const int blocks = (A.nCells + TPB - 1) / TPB;
-    amulKernel<<<blocks, TPB>>>(A.nCells, A.diag, A.upper, A.lower, A.nei, A.owner,
-                                A.ownerStart, A.losort, A.losortStart, psi.data(), Apsi.data());
+    const scalar* psid = psi.data();
+    scalar* Apsid = Apsi.data();
+    const int nC = A.nCells, nCyc = A.nCyc, nAmi = A.nAmi;
+    const scalar *diag = A.diag, *upper = A.upper, *lower = A.lower;
+    const label *nei = A.nei, *owner = A.owner, *ownerStart = A.ownerStart, *losort = A.losort, *losortStart = A.losortStart;
+    pcudaParallelFor(blocks, TPB, [=] __device__ () {
+        amulKernel(nC, diag, upper, lower, nei, owner, ownerStart, losort, losortStart, psid, Apsid);
+    });
     cudaCheck(cudaGetLastError(), "amul");
     if (A.nCyc > 0)
     {
-        cyclicAmulKernel<<<(A.nCyc + TPB - 1) / TPB, TPB>>>(A.nCyc, A.cycOwn, A.cycNbr, A.cycCoeff, psi.data(), Apsi.data());
+        const label* cycOwn = A.cycOwn; const label* cycNbr = A.cycNbr; const scalar* cycCoeff = A.cycCoeff;
+        pcudaParallelFor((nCyc + TPB - 1) / TPB, TPB, [=] __device__ () {
+            cyclicAmulKernel(nCyc, cycOwn, cycNbr, cycCoeff, psid, Apsid);
+        });
         cudaCheck(cudaGetLastError(), "cyclicAmul");
     }
     if (A.nAmi > 0)
     {
-        amiAmulKernel<<<(A.nAmi + TPB - 1) / TPB, TPB>>>(A.nAmi, A.amiOwn, A.amiOff, A.amiNbr, A.amiW, A.amiIfc, psi.data(), Apsi.data());
+        const label* amiOwn = A.amiOwn; const label* amiOff = A.amiOff; const label* amiNbr = A.amiNbr;
+        const scalar* amiW = A.amiW; const scalar* amiIfc = A.amiIfc;
+        pcudaParallelFor((nAmi + TPB - 1) / TPB, TPB, [=] __device__ () {
+            amiAmulKernel(nAmi, amiOwn, amiOff, amiNbr, amiW, amiIfc, psid, Apsid);
+        });
         cudaCheck(cudaGetLastError(), "amiAmul");
     }
 }

--- a/src/cuda/pcuda_compat.cuh
+++ b/src/cuda/pcuda_compat.cuh
@@ -1,0 +1,31 @@
+#pragma once
+// pcudaParallelFor: portable kernel-launch primitive, replacing kernel<<<grid,block>>>(args) chevron syntax.
+// AdaptiveCpp provides it natively (<pcuda.hpp>); under nvcc this builds an equivalent trampoline kernel.
+//
+// Kernels here must be __device__, not __global__: nvcc refuses to call __global__ except via <<<>>>, even
+// from a lambda. PCUDA doesn't care (JIT marks entries via LLVM IR metadata) -- purely an nvcc requirement.
+#ifdef BRAE_ACPP
+#include <pcuda.hpp>
+#else
+#include <cuda_runtime.h>
+
+template <class F>
+__global__ void braeTrampolineKernel(F f) { f(); }
+
+template <class F>
+inline cudaError_t pcudaParallelFor(dim3 grid, dim3 block, size_t sharedMem, cudaStream_t stream, F f)
+{
+    braeTrampolineKernel<<<grid, block, sharedMem, stream>>>(f);
+    return cudaGetLastError();
+}
+template <class F>
+inline cudaError_t pcudaParallelFor(dim3 grid, dim3 block, size_t sharedMem, F f)
+{
+    return pcudaParallelFor(grid, block, sharedMem, cudaStream_t(0), f);
+}
+template <class F>
+inline cudaError_t pcudaParallelFor(dim3 grid, dim3 block, F f)
+{
+    return pcudaParallelFor(grid, block, size_t(0), cudaStream_t(0), f);
+}
+#endif

--- a/src/cuda/reductions.cu
+++ b/src/cuda/reductions.cu
@@ -2,7 +2,10 @@
 // accumulator), the device-resident "Into" variants, and the device->host scalar read-back. The reduction order
 // differs from the CPU sequential sum, so results match to machine precision (FP non-associativity), not
 // bit-for-bit -- the validation criterion for reductions. Split from device_blas.cu (elementwise ops in blas1.cu).
+//
+// Kernels' static __shared__ arrays work the same as __device__ functions here as they did as __global__.
 #include "device_blas.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -25,7 +28,7 @@ inline void ensureRedScratch()
 }
 
 
-__global__
+__device__
 void dotKernel(const scalar* __restrict__ x, const scalar* __restrict__ y, scalar* result, int n)
 {
     __shared__ scalar sdata[TPB];
@@ -42,7 +45,7 @@ void dotKernel(const scalar* __restrict__ x, const scalar* __restrict__ y, scala
 }
 
 
-__global__
+__device__
 void sumMagKernel(const scalar* __restrict__ x, scalar* result, int n)
 {
     __shared__ scalar sdata[TPB];
@@ -65,7 +68,10 @@ scalar deviceDot(const DeviceBuffer<scalar>& x, const DeviceBuffer<scalar>& y)
     const int n = static_cast<int>(x.size());
     ensureRedScratch();
     cudaCheck(cudaMemsetAsync(g_redDev, 0, sizeof(scalar), cudaStreamPerThread), "dot zero");
-    dotKernel<<<nBlocks(n), TPB>>>(x.data(), y.data(), g_redDev, n);
+    const scalar* xd = x.data();
+    const scalar* yd = y.data();
+    scalar* result = g_redDev;
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { dotKernel(xd, yd, result, n); });
     cudaCheck(cudaGetLastError(), "dot");
     cudaCheck(cudaMemcpy(g_redPinned, g_redDev, sizeof(scalar), cudaMemcpyDeviceToHost), "dot result");
     return *g_redPinned;
@@ -76,7 +82,7 @@ scalar deviceDot(const DeviceBuffer<scalar>& x, const DeviceBuffer<scalar>& y)
 // sum and dot already exist, but the Courant NUMBER is a maximum, and a maximum cannot be assembled
 // from them. Kept as ratio-of-two-arrays rather than max(x) so the division happens in the same pass
 // and no per-cell ratio array is ever materialised.
-__global__
+__device__
 void maxRatioKernel(const scalar* __restrict__ x, const scalar* __restrict__ y, scalar* result, int n)
 {
     __shared__ scalar sdata[TPB];
@@ -98,7 +104,10 @@ scalar deviceMaxRatio(const DeviceBuffer<scalar>& x, const DeviceBuffer<scalar>&
     if (n == 0 || (int)y.size() < n) return 0;
     ensureRedScratch();
     cudaCheck(cudaMemsetAsync(g_redDev, 0, sizeof(scalar), cudaStreamPerThread), "maxratio zero");
-    maxRatioKernel<<<nBlocks(n), TPB>>>(x.data(), y.data(), g_redDev, n);
+    const scalar* xd = x.data();
+    const scalar* yd = y.data();
+    scalar* result = g_redDev;
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { maxRatioKernel(xd, yd, result, n); });
     cudaCheck(cudaGetLastError(), "maxratio");
     cudaCheck(cudaMemcpy(g_redPinned, g_redDev, sizeof(scalar), cudaMemcpyDeviceToHost), "maxratio result");
     return *g_redPinned;
@@ -110,7 +119,9 @@ scalar deviceSumMag(const DeviceBuffer<scalar>& x)
     const int n = static_cast<int>(x.size());
     ensureRedScratch();
     cudaCheck(cudaMemsetAsync(g_redDev, 0, sizeof(scalar), cudaStreamPerThread), "summag zero");
-    sumMagKernel<<<nBlocks(n), TPB>>>(x.data(), g_redDev, n);
+    const scalar* xd = x.data();
+    scalar* result = g_redDev;
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { sumMagKernel(xd, result, n); });
     cudaCheck(cudaGetLastError(), "summag");
     cudaCheck(cudaMemcpy(g_redPinned, g_redDev, sizeof(scalar), cudaMemcpyDeviceToHost), "summag result");
     return *g_redPinned;
@@ -122,7 +133,9 @@ void deviceDotInto(const DeviceBuffer<scalar>& x, const DeviceBuffer<scalar>& y,
 {
     const int n = static_cast<int>(x.size());
     cudaCheck(cudaMemsetAsync(dResult, 0, sizeof(scalar), cudaStreamPerThread), "dotInto zero");
-    dotKernel<<<nBlocks(n), TPB>>>(x.data(), y.data(), dResult, n);
+    const scalar* xd = x.data();
+    const scalar* yd = y.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { dotKernel(xd, yd, dResult, n); });
     cudaCheck(cudaGetLastError(), "dotInto");
 }
 
@@ -131,7 +144,8 @@ void deviceSumMagInto(const DeviceBuffer<scalar>& x, scalar* dResult)
 {
     const int n = static_cast<int>(x.size());
     cudaCheck(cudaMemsetAsync(dResult, 0, sizeof(scalar), cudaStreamPerThread), "summagInto zero");
-    sumMagKernel<<<nBlocks(n), TPB>>>(x.data(), dResult, n);
+    const scalar* xd = x.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { sumMagKernel(xd, dResult, n); });
     cudaCheck(cudaGetLastError(), "summagInto");
 }
 

--- a/src/finiteVolume/cfdTools/MRF/device_mrf.cu
+++ b/src/finiteVolume/cfdTools/MRF/device_mrf.cu
@@ -1,6 +1,7 @@
 // cf device MRF, Coriolis source + relative-flux kernels. See device_mrf.cuh. Mirrors the host MRFZone
 // (mrf_zone.cuh), validated end-to-end by ctest gpu_mrf (closed rotating box -> solid-body rotation).
 #include "device_mrf.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -11,7 +12,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 
 
 // src[c] -= V[c]*(Omega x U)_kk on zone cells.  (Omega x U)_x = oy*Uz-oz*Uy, etc.
-__global__
+__device__
 void mrfCoriolisKernel(
     int nC,
     const label* __restrict__ zc,
@@ -35,7 +36,7 @@ void mrfCoriolisKernel(
 }
 
 
-__global__
+__device__
 void mrfFrameFluxKernel(
     int n,
     const scalar* __restrict__ ff,
@@ -58,8 +59,16 @@ void deviceMrfCoriolis(
     DeviceBuffer<scalar>& src)
 {
     const int nC = static_cast<int>(V.size());
-    mrfCoriolisKernel<<<nBlocks(nC), TPB>>>(nC, mrf.zoneCell.data(), V.data(), Ux.data(), Uy.data(), Uz.data(),
-                                            mrf.Omega.x, mrf.Omega.y, mrf.Omega.z, kk, src.data());
+    const label* zc = mrf.zoneCell.data();
+    const scalar* Vd = V.data();
+    const scalar* Uxd = Ux.data();
+    const scalar* Uyd = Uy.data();
+    const scalar* Uzd = Uz.data();
+    const scalar ox = mrf.Omega.x, oy = mrf.Omega.y, oz = mrf.Omega.z;
+    scalar* srcd = src.data();
+    pcudaParallelFor(nBlocks(nC), TPB, [=] __device__ () {
+        mrfCoriolisKernel(nC, zc, Vd, Uxd, Uyd, Uzd, ox, oy, oz, kk, srcd);
+    });
     cudaCheck(cudaGetLastError(), "mrfCoriolis");
 }
 
@@ -71,8 +80,18 @@ void deviceMrfApplyFrameFlux(
     DeviceBuffer<scalar>& phiBnd)
 {
     const int nIf = static_cast<int>(mrf.frameFluxInt.size()), nB = static_cast<int>(mrf.frameFluxBnd.size());
-    if (nIf) mrfFrameFluxKernel<<<nBlocks(nIf), TPB>>>(nIf, mrf.frameFluxInt.data(), sign, phiInt.data());
-    if (nB)  mrfFrameFluxKernel<<<nBlocks(nB),  TPB>>>(nB,  mrf.frameFluxBnd.data(), sign, phiBnd.data());
+    if (nIf)
+    {
+        const scalar* ffi = mrf.frameFluxInt.data();
+        scalar* phiIntd = phiInt.data();
+        pcudaParallelFor(nBlocks(nIf), TPB, [=] __device__ () { mrfFrameFluxKernel(nIf, ffi, sign, phiIntd); });
+    }
+    if (nB)
+    {
+        const scalar* ffb = mrf.frameFluxBnd.data();
+        scalar* phiBndd = phiBnd.data();
+        pcudaParallelFor(nBlocks(nB), TPB, [=] __device__ () { mrfFrameFluxKernel(nB, ffb, sign, phiBndd); });
+    }
     cudaCheck(cudaGetLastError(), "mrfFrameFlux");
 }
 

--- a/src/finiteVolume/cfdTools/fvOptions/device_fvoptions.cu
+++ b/src/finiteVolume/cfdTools/fvOptions/device_fvoptions.cu
@@ -1,6 +1,7 @@
 // cf device DarcyForchheimer porosity. See device_fvoptions.cuh. Mirrors OF porosityModels::DarcyForchheimer::apply
 // (incompressible: mu=nu, rho=1), implicit isotropic resistance into the diagonal + explicit anisotropic remainder.
 #include "device_fvoptions.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 
 namespace brae {
@@ -42,7 +43,7 @@ void fixedCd(const scalar* a, const scalar* b, scalar rho, scalar magU, scalar* 
     for (int k = 0; k < 9; ++k) Cd[k] = rho*(a[k] + b[k]*magU);
 }
 
-__global__
+__device__
 void porFixedDiagKernel(
     int n,
     const label* __restrict__ cells,
@@ -63,7 +64,7 @@ void porFixedDiagKernel(
     diag[c] += V[c]*(Cd[0] + Cd[4] + Cd[8]);                       // += V*tr(Cd)
 }
 
-__global__
+__device__
 void porFixedSrcKernel(
     int n,
     const label* __restrict__ cells,
@@ -90,7 +91,7 @@ void porFixedSrcKernel(
 }
 
 
-__global__
+__device__
 void porDiagKernel(
     int n,
     const label* __restrict__ cells,
@@ -117,7 +118,7 @@ void porDiagKernel(
 }
 
 
-__global__
+__device__
 void porSrcKernel(
     int n,
     const label* __restrict__ cells,
@@ -160,16 +161,25 @@ void deviceFvoPorosityDiag(
 {
     const int n = static_cast<int>(por.cells.size());
     if (!por.active || !n) return;
+    const label* cellsd = por.cells.data();
+    const scalar *Vd = V.data(), *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data();
+    scalar* diagd = diag.data();
     if (por.fixed)
     {
         DeviceBuffer<scalar> a, b; a.copyFrom(std::vector<scalar>(por.fa, por.fa+9)); b.copyFrom(std::vector<scalar>(por.fb, por.fb+9));
-        porFixedDiagKernel<<<nBlocks(n), TPB>>>(n, por.cells.data(), por.rhoRef, a.data(), b.data(),
-                                                V.data(), Ux.data(), Uy.data(), Uz.data(), diag.data());
+        const scalar rho = por.rhoRef; const scalar *ad = a.data(), *bd = b.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            porFixedDiagKernel(n, cellsd, rho, ad, bd, Vd, Uxd, Uyd, Uzd, diagd);
+        });
         cudaCheck(cudaGetLastError(), "porosityFixedDiag");
         return;
     }
-    porDiagKernel<<<nBlocks(n), TPB>>>(n, por.cells.data(), nu, por.d.x,por.d.y,por.d.z, por.f.x,por.f.y,por.f.z,
-                                       V.data(), Ux.data(), Uy.data(), Uz.data(), diag.data());
+    {
+        const scalar dx=por.d.x,dy=por.d.y,dz=por.d.z,fx=por.f.x,fy=por.f.y,fz=por.f.z;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            porDiagKernel(n, cellsd, nu, dx, dy, dz, fx, fy, fz, Vd, Uxd, Uyd, Uzd, diagd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "porDiag");
 }
 
@@ -186,22 +196,31 @@ void deviceFvoPorositySource(
 {
     const int n = static_cast<int>(por.cells.size());
     if (!por.active || !n) return;
+    const label* cellsd = por.cells.data();
+    const scalar *Vd = V.data(), *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data();
+    scalar* srcd = src.data();
     if (por.fixed)
     {
         DeviceBuffer<scalar> a, b; a.copyFrom(std::vector<scalar>(por.fa, por.fa+9)); b.copyFrom(std::vector<scalar>(por.fb, por.fb+9));
-        porFixedSrcKernel<<<nBlocks(n), TPB>>>(n, por.cells.data(), comp, por.rhoRef, a.data(), b.data(),
-                                               V.data(), Ux.data(), Uy.data(), Uz.data(), src.data());
+        const scalar rho = por.rhoRef; const scalar *ad = a.data(), *bd = b.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            porFixedSrcKernel(n, cellsd, comp, rho, ad, bd, Vd, Uxd, Uyd, Uzd, srcd);
+        });
         cudaCheck(cudaGetLastError(), "porosityFixedSrc");
         return;
     }
-    porSrcKernel<<<nBlocks(n), TPB>>>(n, por.cells.data(), comp, nu, por.d.x,por.d.y,por.d.z, por.f.x,por.f.y,por.f.z,
-                                      V.data(), Ux.data(), Uy.data(), Uz.data(), src.data());
+    {
+        const scalar dx=por.d.x,dy=por.d.y,dz=por.d.z,fx=por.f.x,fy=por.f.y,fz=por.f.z;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            porSrcKernel(n, cellsd, comp, nu, dx, dy, dz, fx, fy, fz, Vd, Uxd, Uyd, Uzd, srcd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "porSrc");
 }
 
 
 namespace {
-__global__
+__device__
 void limitUKernel(
     int n,
     const label* __restrict__ cells,
@@ -226,7 +245,7 @@ void limitUKernel(
 
 
 // he clamp on a cell selection. Same shape as limitUKernel: gather through the selection list.
-__global__
+__device__
 void limitEnergyKernel(int n, const label* __restrict__ cells, scalar heMin, scalar heMax,
                        scalar* __restrict__ he)
 {
@@ -245,14 +264,15 @@ void deviceFvoLimitEnergy(
 {
     const int n = static_cast<int>(cells.size());
     if (!n) return;
-    limitEnergyKernel<<<nBlocks(n), TPB>>>(n, cells.data(), heMin, heMax, he.data());
+    const label* cellsd = cells.data(); scalar* hed = he.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { limitEnergyKernel(n, cellsd, heMin, heMax, hed); });
     cudaCheck(cudaGetLastError(), "limitTemperature");
 }
 
 // Boundary half: every face whose patch does not fix a value. OF's test is fvPatchField::fixesValue(); on
 // the device that is bcType == 1 (brae: 0 extrapolated, 1 fixedValue, 2 calculated), and an inletOutlet
 // face has already been resolved to 0|1 for this iteration, so the same test covers it.
-__global__
+__device__
 void limitEnergyBndKernel(int n, const label* __restrict__ bcType, scalar heMin, scalar heMax,
                           scalar* __restrict__ heBnd)
 {
@@ -271,7 +291,8 @@ void deviceFvoLimitEnergyBoundary(
 {
     const int n = static_cast<int>(heBnd.size());
     if (!n || dbHe.n != n) return;
-    limitEnergyBndKernel<<<nBlocks(n), TPB>>>(n, dbHe.bcType.data(), heMin, heMax, heBnd.data());
+    const label* bcTyped = dbHe.bcType.data(); scalar* heBndd = heBnd.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { limitEnergyBndKernel(n, bcTyped, heMin, heMax, heBndd); });
     cudaCheck(cudaGetLastError(), "limitTemperatureBnd");
 }
 
@@ -284,13 +305,15 @@ void deviceFvoLimitVelocity(
 {
     const int n = static_cast<int>(cells.size());
     if (!n) return;
-    limitUKernel<<<nBlocks(n), TPB>>>(n, cells.data(), maxU*maxU, Ux.data(), Uy.data(), Uz.data());
+    const label* cellsd = cells.data(); const scalar maxSqrU = maxU*maxU;
+    scalar *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { limitUKernel(n, cellsd, maxSqrU, Uxd, Uyd, Uzd); });
     cudaCheck(cudaGetLastError(), "limitVelocity");
 }
 
 
 // velocityDampingConstraint: diag[c] += C*V[c]^(2/3)*(|U|-UMax) where |U| > UMax.
-__global__
+__device__
 void velDampKernel(
     int n,
     const label* __restrict__ cells,
@@ -326,7 +349,10 @@ void deviceFvoVelocityDamping(
 {
     const int n = static_cast<int>(cells.size());
     if (!n) return;
-    velDampKernel<<<nBlocks(n), TPB>>>(n, cells.data(), UMax, C, V.data(), Ux.data(), Uy.data(), Uz.data(), diag.data());
+    const label* cellsd = cells.data();
+    const scalar *Vd = V.data(), *Uxd = Ux.data(), *Uyd = Uy.data(), *Uzd = Uz.data();
+    scalar* diagd = diag.data();
+    pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { velDampKernel(n, cellsd, UMax, C, Vd, Uxd, Uyd, Uzd, diagd); });
     cudaCheck(cudaGetLastError(), "velocityDampingConstraint");
 }
 

--- a/src/finiteVolume/cfdTools/fvOptions/rotor_disk.cu
+++ b/src/finiteVolume/cfdTools/fvOptions/rotor_disk.cu
@@ -1,6 +1,7 @@
 // cf rotorDiskSource (Froude BEM), geometry build (host) + per-iteration body-force kernel. See rotor_disk.cuh.
 // Mirrors OF rotorDiskSource::setFaceArea / calculate (single lookup profile, fixedTrim, no coning).
 #include "rotor_disk.cuh"
+#include "pcuda_compat.cuh"
 #include <cuda_runtime.h>
 #include <cmath>
 
@@ -64,7 +65,7 @@ scalar lookupCdl(
     return C[i1] + w*(C[i2]-C[i1]);
 }
 
-__global__
+__device__
 void rotorForceKernel(
     int n,
     const label* __restrict__ cells,
@@ -219,10 +220,21 @@ void deviceRotorForce(
     cudaCheck(cudaMemsetAsync(fx.data(), 0, nCells*sizeof(scalar), cudaStreamPerThread), "rotor fx zero");
     cudaCheck(cudaMemsetAsync(fy.data(), 0, nCells*sizeof(scalar), cudaStreamPerThread), "rotor fy zero");
     cudaCheck(cudaMemsetAsync(fz.data(), 0, nCells*sizeof(scalar), cudaStreamPerThread), "rotor fz zero");
-    rotorForceKernel<<<nBlocks(rd.n), TPB>>>(rd.n, rd.cells.data(), rd.axis, rd.omega, rd.nBlades, rd.tipEffect, rd.rMax,
-        rd.theta0, rd.localInflow?1:0, rd.inletVel, rd.e2x.data(), rd.e2y.data(), rd.e2z.data(), rd.radius.data(),
-        rd.area.data(), rd.twist.data(), rd.chord.data(), rd.pAlpha.data(), rd.pCd.data(), rd.pCl.data(), rd.nProf,
-        Ux.data(), Uy.data(), Uz.data(), fx.data(), fy.data(), fz.data());
+    {
+        const int n = rd.n; const label* cells = rd.cells.data();
+        const vector axis = rd.axis; const scalar omega = rd.omega, nBlades = rd.nBlades, tipEffect = rd.tipEffect, rMax = rd.rMax;
+        const scalar theta0 = rd.theta0; const int localInflow = rd.localInflow?1:0; const vector inletVel = rd.inletVel;
+        const scalar *e2xd=rd.e2x.data(), *e2yd=rd.e2y.data(), *e2zd=rd.e2z.data(), *radiusd=rd.radius.data();
+        const scalar *aread=rd.area.data(), *twistd=rd.twist.data(), *chordd=rd.chord.data();
+        const scalar *pAd=rd.pAlpha.data(), *pCdd=rd.pCd.data(), *pCld=rd.pCl.data(); const int nProf = rd.nProf;
+        const scalar *Uxd=Ux.data(), *Uyd=Uy.data(), *Uzd=Uz.data();
+        scalar *fxd=fx.data(), *fyd=fy.data(), *fzd=fz.data();
+        pcudaParallelFor(nBlocks(rd.n), TPB, [=] __device__ () {
+            rotorForceKernel(n, cells, axis, omega, nBlades, tipEffect, rMax, theta0, localInflow, inletVel,
+                             e2xd, e2yd, e2zd, radiusd, aread, twistd, chordd, pAd, pCdd, pCld, nProf,
+                             Uxd, Uyd, Uzd, fxd, fyd, fzd);
+        });
+    }
     cudaCheck(cudaGetLastError(), "rotorForce");
 }
 

--- a/src/parallel/pstream/device_halo.cu
+++ b/src/parallel/pstream/device_halo.cu
@@ -1,6 +1,7 @@
 // brae DeviceHalo, NVSHMEM on-stream halo exchange (see device_halo.cuh). Pack/scatter are plain CUDA
 // kernels; the transfer is the host on-stream put + barrier, so no relocatable device code is needed.
 #include "device_halo.cuh"
+#include "pcuda_compat.cuh"
 #ifdef BRAE_WITH_NVSHMEM
 #include <nvshmem_host.h>
 #endif
@@ -10,7 +11,7 @@ namespace {
 constexpr int TPB = 128;
 
 // sendRegion[f] = psi[faceCells[f]]  (gather the interface's own boundary values)
-__global__
+__device__
 void packKernel(
     const scalar* __restrict__ psi,
     const label*  __restrict__ faceCells,
@@ -24,7 +25,7 @@ void packKernel(
 // result[faceCells[f]] -= coeff[f] * recvRegion[f]  (the coupled-interface off-diagonal, OF A.psi convention).
 // atomicAdd because a cell may own several faces on the SAME interface (multiple cut faces to one neighbour),
 // so distinct threads can target the same result cell -- exactly like device_spmv's cyclicAmulKernel.
-__global__
+__device__
 void scatterKernel(
     scalar*       __restrict__ result,
     const label*  __restrict__ faceCells,
@@ -38,7 +39,7 @@ void scatterKernel(
 
 // bvalOut[f] = w[f]*psi[faceCells[f]] + (1 - w[f])*recvRegion[f]  (the coupled processor-face boundary value).
 // bvalOut points at bval + procStart[i], so each interface writes its slice of the flattened boundary array.
-__global__
+__device__
 void bvalKernel(
     const scalar* __restrict__ psi,
     const label*  __restrict__ faceCells,
@@ -102,11 +103,14 @@ void DeviceHalo::postExchange(
     const int nI = static_cast<int>(nbr_.size());
     for (int i = 0; i < nI; ++i)
         if (size_[i] > 0)
-            packKernel<<<(size_[i] + TPB - 1) / TPB, TPB, 0, stream>>>(
-                psi_d,
-                faceCellsD_[i].data(),
-                sendBuf_.data() + recvOffset_[i],
-                static_cast<int>(size_[i]));
+        {
+            const label* fc = faceCellsD_[i].data();
+            scalar* sb = sendBuf_.data() + recvOffset_[i];
+            const int n = static_cast<int>(size_[i]);
+            pcudaParallelFor((n + TPB - 1) / TPB, TPB, 0, stream, [=] __device__ () {
+                packKernel(psi_d, fc, sb, n);
+            });
+        }
 #ifdef BRAE_WITH_NVSHMEM
     for (int i = 0; i < nI; ++i)
         if (size_[i] > 0)
@@ -143,12 +147,14 @@ void DeviceHalo::updateInterfaceMatrix(
     cudaStream_t stream)
 {
     if (size_[i] > 0)
-        scatterKernel<<<(size_[i] + TPB - 1) / TPB, TPB, 0, stream>>>(
-            result_d,
-            faceCellsD_[i].data(),
-            coeff_d,
-            recvBuf_.data() + recvOffset_[i],
-            static_cast<int>(size_[i]));
+    {
+        const label* fc = faceCellsD_[i].data();
+        const scalar* rb = recvBuf_.data() + recvOffset_[i];
+        const int n = static_cast<int>(size_[i]);
+        pcudaParallelFor((n + TPB - 1) / TPB, TPB, 0, stream, [=] __device__ () {
+            scatterKernel(result_d, fc, coeff_d, rb, n);
+        });
+    }
 }
 
 void DeviceHalo::scatterBoundaryValues(
@@ -162,13 +168,14 @@ void DeviceHalo::scatterBoundaryValues(
     for (int i = 0; i < nI; ++i)
     {
         if (size_[i] <= 0) continue;
-        bvalKernel<<<(size_[i] + TPB - 1) / TPB, TPB, 0, stream>>>(
-            psi_d,
-            faceCellsD_[i].data(),
-            weights[i].data(),
-            recvBuf_.data() + recvOffset_[i],
-            bval_d + procStart[i],
-            static_cast<int>(size_[i]));
+        const label* fc = faceCellsD_[i].data();
+        const scalar* wd = weights[i].data();
+        const scalar* rb = recvBuf_.data() + recvOffset_[i];
+        scalar* bo = bval_d + procStart[i];
+        const int n = static_cast<int>(size_[i]);
+        pcudaParallelFor((n + TPB - 1) / TPB, TPB, 0, stream, [=] __device__ () {
+            bvalKernel(psi_d, fc, wd, rb, bo, n);
+        });
     }
 }
 

--- a/src/thermophysicalModels/device_thermo.cu
+++ b/src/thermophysicalModels/device_thermo.cu
@@ -8,6 +8,7 @@
 #include "device_buffer.cuh"
 #include "device_blas.cuh"   // deviceCopy/deviceHadamard, for thermo.rho()
 #include "device_boundary.cuh"
+#include "pcuda_compat.cuh"
 #include <stdexcept>
 #include <cstdio>
 #include <vector>
@@ -28,7 +29,7 @@ inline int nBlocks(int n) { return (n + TPB - 1) / TPB; }
 // One pass over the cells: invert he to get T, then evaluate every T-dependent property from it.
 // Fused rather than split per property because each one is a handful of flops on a value already in a
 // register -- splitting would re-read T from global memory four times for no benefit.
-__global__
+__device__
 void thermoUpdateK(
     int n,
     ThermoCoeffs c,
@@ -61,7 +62,7 @@ void thermoUpdateK(
 }
 
 // he from T, used once at startup: cases ship a T field, the energy equation wants he.
-__global__
+__device__
 void heFromTK(
     int n,
     ThermoCoeffs c,
@@ -81,10 +82,12 @@ void deviceHePsiThermoCalculate(
     const ThermoCoeffs& c)
 {
     if (th.n == 0) return;
-    thermoUpdateK<<<nBlocks(th.n), TPB>>>(
-        th.n, c, p.data(), th.he.data(), th.T.data(),
-        nullptr,                       // hePsiThermo::calculate has no rho argument
-        th.psi.data(), th.mu.data(), th.alpha.data());
+    {
+        const int n = th.n; const scalar* pd = p.data(); const scalar* hed = th.he.data();
+        scalar* Td = th.T.data(); scalar* psid = th.psi.data(); scalar* mud = th.mu.data(); scalar* alphad = th.alpha.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            thermoUpdateK(n, c, pd, hed, Td, nullptr, psid, mud, alphad); });
+    }
     cudaCheck(cudaGetLastError(), "hePsiThermoCalculate");
 }
 
@@ -95,10 +98,13 @@ void deviceHeRhoThermoCalculate(
     const ThermoCoeffs& c)
 {
     if (th.n == 0) return;
-    thermoUpdateK<<<nBlocks(th.n), TPB>>>(
-        th.n, c, p.data(), th.he.data(), th.T.data(),
-        th.rhoThermo.data(),           // heRhoThermo::calculate writes the THERMO's rho_, not the solver's
-        th.psi.data(), th.mu.data(), th.alpha.data());
+    {
+        const int n = th.n; const scalar* pd = p.data(); const scalar* hed = th.he.data();
+        scalar* Td = th.T.data(); scalar* rhod = th.rhoThermo.data();
+        scalar* psid = th.psi.data(); scalar* mud = th.mu.data(); scalar* alphad = th.alpha.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            thermoUpdateK(n, c, pd, hed, Td, rhod, psid, mud, alphad); });
+    }
     cudaCheck(cudaGetLastError(), "heRhoThermoCalculate");
 }
 
@@ -195,7 +201,7 @@ void deviceThermoRho(
 
 // rho = rhoPrev + a*(rho - rhoPrev), then rhoPrev = rho. Bounds are re-applied because relaxing toward a
 // previous value cannot violate them, but relaxing AWAY from a clamped value can.
-__global__
+__device__
 void rhoRelaxK(
     int n,
     scalar a,
@@ -212,7 +218,7 @@ void rhoRelaxK(
     rhoPrev[i] = bounded;
 }
 
-__global__
+__device__
 void rhoSeedPrevK(
     int n,
     const scalar* __restrict__ rho,
@@ -235,7 +241,12 @@ void deviceRhoRelaxBuffer(
 {
     const int n = static_cast<int>(rho.size());
     if (n == 0 || rhoPrev.size() != rho.size()) return;
-    rhoRelaxK<<<nBlocks(n), TPB>>>(n, c.relaxRho, c.rhoMin, c.rhoMax, rho.data(), rhoPrev.data());
+    {
+        const scalar a = c.relaxRho; const scalar rMin = c.rhoMin; const scalar rMax = c.rhoMax;
+        scalar* rhod = rho.data(); scalar* rhoPrevd = rhoPrev.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            rhoRelaxK(n, a, rMin, rMax, rhod, rhoPrevd); });
+    }
     cudaCheck(cudaGetLastError(), "rhoRelaxBuffer");
 }
 
@@ -244,30 +255,30 @@ void deviceRhoRelax(
     const ThermoCoeffs& c)
 {
     if (th.n == 0) return;
-    rhoRelaxK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        c.relaxRho,
-        c.rhoMin,
-        c.rhoMax,
-        th.rho.data(),
-        th.rhoPrev.data());
+    {
+        const int n = th.n; const scalar a = c.relaxRho; const scalar rMin = c.rhoMin; const scalar rMax = c.rhoMax;
+        scalar* rhod = th.rho.data(); scalar* rhoPrevd = th.rhoPrev.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            rhoRelaxK(n, a, rMin, rMax, rhod, rhoPrevd); });
+    }
     cudaCheck(cudaGetLastError(), "rhoRelax");
 }
 
 void deviceRhoSeedPrev(DeviceThermo& th)
 {
     if (th.n == 0) return;
-    rhoSeedPrevK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        th.rho.data(),
-        th.rhoPrev.data());
+    {
+        const int n = th.n; const scalar* rhod = th.rho.data(); scalar* rhoPrevd = th.rhoPrev.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            rhoSeedPrevK(n, rhod, rhoPrevd); });
+    }
     cudaCheck(cudaGetLastError(), "rhoSeedPrev");
 }
 
 // alphat = rho*nut/Prt. Kept in its own kernel rather than folded into thermoUpdateK because nut is
 // owned by the turbulence model and is only valid after correctTurbulence(), which runs at the END of the
 // outer iteration -- whereas thermoUpdateK runs in the middle of it.
-__global__
+__device__
 void alphatK(
     int n,
     scalar Prt,
@@ -287,12 +298,12 @@ void deviceAlphat(
 {
     if (th.n == 0) return;
     if (static_cast<int>(nut.size()) != th.n) return;   // laminar: no nut field, alphat stays zero
-    alphatK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        c.Prt,
-        th.rho.data(),
-        nut.data(),
-        th.alphat.data());
+    {
+        const int n = th.n; const scalar prt = c.Prt;
+        const scalar* rhod = th.rho.data(); const scalar* nutd = nut.data(); scalar* alphatd = th.alphat.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            alphatK(n, prt, rhod, nutd, alphatd); });
+    }
     cudaCheck(cudaGetLastError(), "alphat");
 }
 
@@ -310,7 +321,7 @@ void deviceAlphat(
 // T_b = -21369.6 K, from which transportMu took sqrt of a negative and produced NaN in all 112000 cells.
 // The gas inversion is exact and closed-form; the liquid one is Newton, and OF runs Newton at the
 // boundary too (mixture_.THE(phe, pp, pT) is the same thermo::T as the cell path).
-__global__
+__device__
 void TBoundaryGasK(
     int n,
     ThermoCoeffs c,
@@ -327,7 +338,7 @@ void TBoundaryGasK(
 // this function stateless. It only sets the iteration count in any case: acceptance is on the energy
 // residual (see nsrds_functions.cuh), so the answer does not depend on where the iteration started, and
 // tests/test_hetot.cu proves recovery from the opposite end of the valid range.
-__global__
+__device__
 void TBoundaryLiquidK(
     int n,
     EnergyForm form,
@@ -393,21 +404,26 @@ void deviceThermoTBoundary(
         // refValue is what a fixedValue he face contributes to the matrix, so refreshing it here is
         // what actually propagates the corrected energy into the next energy solve.
         const bool haveRef = dbHe.refValue.size() == static_cast<std::size_t>(dbHe.n);
-        TBoundaryLiquidK<<<nBlocks(dbHe.n), TPB>>>(
-            dbHe.n,
-            c.internalEnergy ? EnergyForm::sensibleInternalEnergy : EnergyForm::sensibleEnthalpy,
-            needP ? pBnd.data() : nullptr,
-            heBnd.data(),
-            haveGuess ? dbHe.faceCell.data() : nullptr,
-            haveGuess ? Tcell->data() : nullptr,
-            haveFix ? TFixMask->data() : nullptr,
-            haveFix ? TFix->data() : nullptr,
-            TBnd.data(),
-            (haveFix && haveRef) ? dbHe.refValue.data() : nullptr);
+        const int n = dbHe.n;
+        const EnergyForm form = c.internalEnergy ? EnergyForm::sensibleInternalEnergy : EnergyForm::sensibleEnthalpy;
+        const scalar* pBndD = needP ? pBnd.data() : nullptr;
+        const scalar* heBndD = heBnd.data();
+        const label* faceCellD = haveGuess ? dbHe.faceCell.data() : nullptr;
+        const scalar* TcellD = haveGuess ? Tcell->data() : nullptr;
+        const label* fixMaskD = haveFix ? TFixMask->data() : nullptr;
+        const scalar* TFixD = haveFix ? TFix->data() : nullptr;
+        scalar* TBndD = TBnd.data();
+        scalar* heRefD = (haveFix && haveRef) ? dbHe.refValue.data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            TBoundaryLiquidK(n, form, pBndD, heBndD, faceCellD, TcellD, fixMaskD, TFixD, TBndD, heRefD); });
         cudaCheck(cudaGetLastError(), "TBoundaryLiquid");
         return;
     }
-    TBoundaryGasK<<<nBlocks(dbHe.n), TPB>>>(dbHe.n, c, heBnd.data(), TBnd.data());
+    {
+        const int n = dbHe.n; const scalar* heBndD = heBnd.data(); scalar* TBndD = TBnd.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            TBoundaryGasK(n, c, heBndD, TBndD); });
+    }
     cudaCheck(cudaGetLastError(), "TBoundaryGas");
 }
 
@@ -415,7 +431,7 @@ void deviceThermoTBoundary(
 // clamps. Liquid: the NSRDS rho(T) correlation, which has no pressure dependence at all and is NOT
 // clamped, because rhoMin/rhoMax exist to keep a compressible EOS away from its singularity at T -> 0
 // and a liquid correlation has none.
-__global__
+__device__
 void rhoBoundaryK(
     int n,
     ThermoCoeffs c,
@@ -445,12 +461,11 @@ void deviceThermoRhoBoundary(
     DeviceBuffer<scalar> pBnd;
     deviceBCValue(dbP, p, pBnd);
     rhoBnd.resize(dbP.n);
-    rhoBoundaryK<<<nBlocks(dbP.n), TPB>>>(
-        dbP.n,
-        c,
-        pBnd.data(),
-        TBnd.data(),
-        rhoBnd.data());
+    {
+        const int n = dbP.n; const scalar* pBndD = pBnd.data(); const scalar* TBndD = TBnd.data(); scalar* rhoBndD = rhoBnd.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            rhoBoundaryK(n, c, pBndD, TBndD, rhoBndD); });
+    }
     cudaCheck(cudaGetLastError(), "rhoBoundary");
 }
 
@@ -459,7 +474,7 @@ void deviceThermoRhoBoundary(
 // Needed because the compressible momentum boundary wants muEff_b = mu_b + rho_b*nut_b, and the wall
 // functions want the KINEMATIC nu_b = mu_b/rho_b. Both are per-face: a single scalar viscosity is only
 // right for a constant-property incompressible case.
-__global__
+__device__
 void muBoundaryK(
     int n,
     ThermoCoeffs c,
@@ -483,11 +498,11 @@ void deviceThermoMuBoundary(
     const int n = static_cast<int>(TBnd.size());
     if (n == 0) return;
     muBnd.resize(n);
-    muBoundaryK<<<nBlocks(n), TPB>>>(
-        n,
-        c,
-        TBnd.data(),
-        muBnd.data());
+    {
+        const scalar* TBndD = TBnd.data(); scalar* muBndD = muBnd.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            muBoundaryK(n, c, TBndD, muBndD); });
+    }
     cudaCheck(cudaGetLastError(), "muBoundary");
 }
 
@@ -495,7 +510,7 @@ void deviceThermoMuBoundary(
 // transport_.mu(patchi)/rho_.boundaryField()[patchi]. Every OF wall function reads this, so brae's wall
 // functions need it too: in compressible flow it is a field, not the single number a constant-property
 // incompressible case can get away with.
-__global__
+__device__
 void nuBoundaryK(
     int n,
     ThermoCoeffs c,
@@ -527,12 +542,11 @@ void deviceThermoNuBoundary(
     DeviceBuffer<scalar> pBnd;
     deviceBCValue(dbP, p, pBnd);
     nuBnd.resize(dbP.n);
-    nuBoundaryK<<<nBlocks(dbP.n), TPB>>>(
-        dbP.n,
-        c,
-        pBnd.data(),
-        TBnd.data(),
-        nuBnd.data());
+    {
+        const int n = dbP.n; const scalar* pBndD = pBnd.data(); const scalar* TBndD = TBnd.data(); scalar* nuBndD = nuBnd.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            nuBoundaryK(n, c, pBndD, TBndD, nuBndD); });
+    }
     cudaCheck(cudaGetLastError(), "nuBoundary");
 }
 
@@ -546,7 +560,7 @@ void deviceThermoNuBoundary(
 // own (default 0.85) on its patches, and the turbulence model's (default 1.0) everywhere else. nut_b is
 // the wall-function nut on a wall face and the extrapolated cell nut elsewhere, matching what the momentum
 // boundary already uses -- so momentum and energy see one consistent wall eddy viscosity.
-__global__
+__device__
 void alphaEffBoundaryK(
     int n,
     ThermoCoeffs c,
@@ -593,15 +607,14 @@ void deviceAlphaEffBoundary(
             "faces as mu -- alphah is kappa(T)/Cp(T) for a liquid and cannot be recovered from mu.");
     }
     alphaEffBnd.resize(n);
-    alphaEffBoundaryK<<<nBlocks(n), TPB>>>(
-        n,
-        c,
-        muBnd.data(),
-        rhoBnd.data(),
-        (nutBnd && nutBnd->size() == muBnd.size()) ? nutBnd->data() : nullptr,
-        (prtBnd && prtBnd->size() == muBnd.size()) ? prtBnd->data() : nullptr,
-        TBnd.data(),
-        alphaEffBnd.data());
+    {
+        const scalar* muBndD = muBnd.data(); const scalar* rhoBndD = rhoBnd.data();
+        const scalar* nutBndD = (nutBnd && nutBnd->size() == muBnd.size()) ? nutBnd->data() : nullptr;
+        const scalar* prtBndD = (prtBnd && prtBnd->size() == muBnd.size()) ? prtBnd->data() : nullptr;
+        const scalar* TBndD = TBnd.data(); scalar* alphaEffBndD = alphaEffBnd.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            alphaEffBoundaryK(n, c, muBndD, rhoBndD, nutBndD, prtBndD, TBndD, alphaEffBndD); });
+    }
     cudaCheck(cudaGetLastError(), "alphaEffBoundary");
 }
 
@@ -613,7 +626,7 @@ void deviceAlphaEffBoundary(
 //   pressureControl: p min -241053.81  (NEGATIVE)
 // during start-up. A negative p gives a negative rho through the perfect-gas EOS, and the next momentum
 // solve is NaN -- which is exactly what brae did on that case before this existed.
-__global__
+__device__
 void clampPressureK(
     int n,
     scalar pMin,
@@ -632,13 +645,16 @@ void deviceLimitPressure(
 {
     const int n = static_cast<int>(p.size());
     if (n == 0) return;
-    clampPressureK<<<nBlocks(n), TPB>>>(n, pMin, pMax, p.data());
+    {
+        scalar* pd = p.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { clampPressureK(n, pMin, pMax, pd); });
+    }
     cudaCheck(cudaGetLastError(), "limitPressure");
 }
 
 // Liquid he-from-T: e = h(T) - p/rho(T) for sensibleInternalEnergy, h(T) for sensibleEnthalpy.
 // PRESSURE IS REQUIRED here, which the gas form never needed -- hConstTToHe is a pure function of T.
-__global__
+__device__
 void liquidHeFromTK(
     int n,
     EnergyForm form,
@@ -670,16 +686,17 @@ void deviceThermoHeFromT(
             throw std::runtime_error(
                 "brae: seeding he from T for a liquid with sensibleInternalEnergy needs the pressure "
                 "field (e = h(T) - p/rho(T)); the caller passed none.");
-        liquidHeFromTK<<<nBlocks(th.n), TPB>>>(
-            th.n, form, p ? p->data() : nullptr, th.T.data(), th.he.data());
+        const int n = th.n; const scalar* pd = p ? p->data() : nullptr;
+        const scalar* Td = th.T.data(); scalar* hed = th.he.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            liquidHeFromTK(n, form, pd, Td, hed); });
         cudaCheck(cudaGetLastError(), "liquidHeFromT");
         return;
     }
-    heFromTK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        c,
-        th.T.data(),
-        th.he.data());
+    {
+        const int n = th.n; const scalar* Td = th.T.data(); scalar* hed = th.he.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () { heFromTK(n, c, Td, hed); });
+    }
     cudaCheck(cudaGetLastError(), "heFromT");
 }
 
@@ -691,7 +708,7 @@ void deviceThermoHeFromT(
 // conductivity directly, so deriving it from a Prandtl number would discard kappa(T) and substitute a
 // constant-Pr assumption that is not what the case asked for. (OF: thermophysicalProperties' alpha is
 // kappa/Cp for these mixtures; the Pr route belongs to the const/sutherland transport models.)
-__global__
+__device__
 void liquidPropsK(
     int n,
     const scalar* __restrict__ T,
@@ -721,14 +738,14 @@ void deviceThermoLiquidProperties(
     if (c.model != ThermoModel::liquidH2O)
         return;   // the gas path owns its own scalars; silently doing nothing here would hide a miswire
     if (th.CpField.size() != static_cast<std::size_t>(th.n)) th.allocateLiquid();
-    liquidPropsK<<<nBlocks(th.n), TPB>>>(
-        th.n,
-        th.T.data(),
-        th.CpField.data(),
-        th.mu.data(),
-        th.kappa.data(),
-        th.rhoThermo.data(),          // the THERMO density; the solver's rho is assigned separately
-        th.alpha.size() == static_cast<std::size_t>(th.n) ? th.alpha.data() : nullptr);
+    {
+        const int n = th.n; const scalar* Td = th.T.data();
+        scalar* Cpd = th.CpField.data(); scalar* mud = th.mu.data(); scalar* kappad = th.kappa.data();
+        scalar* rhod = th.rhoThermo.data();
+        scalar* alphad = th.alpha.size() == static_cast<std::size_t>(th.n) ? th.alpha.data() : nullptr;
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            liquidPropsK(n, Td, Cpd, mud, kappad, rhod, alphad); });
+    }
     cudaCheck(cudaGetLastError(), "liquidProperties");
 }
 
@@ -749,14 +766,12 @@ void deviceThermoLiquidBoundary(
     muB.resize(n);
     kappaB.resize(n);
     rhoB.resize(n);
-    liquidPropsK<<<nBlocks(n), TPB>>>(
-        n,
-        Tb.data(),
-        CpB.data(),
-        muB.data(),
-        kappaB.data(),
-        rhoB.data(),
-        nullptr);                     // no boundary alpha consumer yet; added when the EEqn needs it
+    {
+        const scalar* Tbd = Tb.data();
+        scalar* CpBd = CpB.data(); scalar* muBd = muB.data(); scalar* kappaBd = kappaB.data(); scalar* rhoBd = rhoB.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            liquidPropsK(n, Tbd, CpBd, muBd, kappaBd, rhoBd, nullptr); });
+    }
     cudaCheck(cudaGetLastError(), "liquidBoundary");
 }
 
@@ -767,7 +782,7 @@ void deviceThermoLiquidBoundary(
 // invert is a diagnosable condition (a bad enthalpy from a diverging pressure iterate, say), and the
 // caller is better placed than the kernel to decide whether that is fatal. OF aborts because it is on
 // the host and has one cell in hand; here the whole field is in flight at once.
-__global__
+__device__
 void h2oEnergyToTK(
     int n,
     EnergyForm form,
@@ -804,14 +819,14 @@ void deviceH2OEnergyToT(
     T.resize(n);
     ok.resize(n);
     residual.resize(n);
-    h2oEnergyToTK<<<nBlocks(n), TPB>>>(
-        n, form, tol, maxIter,
-        target.data(),
-        (p && p->size() == target.size()) ? p->data() : nullptr,
-        Tguess.data(),
-        T.data(),
-        ok.data(),
-        residual.data());
+    {
+        const scalar* targetD = target.data();
+        const scalar* pD = (p && p->size() == target.size()) ? p->data() : nullptr;
+        const scalar* TguessD = Tguess.data();
+        scalar* Td = T.data(); label* okd = ok.data(); scalar* residualD = residual.data();
+        pcudaParallelFor(nBlocks(n), TPB, [=] __device__ () {
+            h2oEnergyToTK(n, form, tol, maxIter, targetD, pD, TguessD, Td, okd, residualD); });
+    }
     cudaCheck(cudaGetLastError(), "h2oEnergyToT");
 }
 


### PR DESCRIPTION

  ## What this does

  Adds an opt-in second compute backend using [AdaptiveCpp](https://github.com/AdaptiveCpp/AdaptiveCpp)'s
  PCUDA — a CUDA/HIP-syntax dialect AdaptiveCpp supports alongside SYCL, sharing the same generic-JIT
  compiler/runtime but not implemented on top of SYCL. The default build is unchanged: `find_package(AdaptiveCpp)`
  only runs when `-DBRAE_BACKEND=ACPP` is passed explicitly.

  - `CMakeLists.txt`: `BRAE_BACKEND` option (`CUDA` default / `ACPP`), a `brae_route_target_through_acpp()`
    helper to retrofit every target with `.cu` sources without editing each `add_executable()`.
  - `pcuda_compat.cuh`: the portable kernel-launch primitive `pcudaParallelFor`, replacing
    `kernel<<<grid,block>>>(args)` chevron syntax at ~350 launch sites project-wide. AdaptiveCpp's own
    `pcudaParallelFor` takes a callable functor by value (compiled via a compiler intrinsic, not a
    launch-by-name API); to keep every call site textually identical on both backends, every kernel body
    invoked that way had to become `__device__` rather than `__global__` — nvcc otherwise refuses to call a
    `__global__` function except via `<<<>>>`. Purely mechanical: same grid/block geometry, same arithmetic.
  - Three genuinely CUDA-only capabilities, with no PCUDA equivalent, kept behind `#ifdef BRAE_ACPP` (~24
    occurrences across 8 files, concentrated in the AMG core) rather than ported:
    - `device_coded_bc.cu` (NVRTC + driver-API JIT for user BC snippets) — ACPP links a throwing stub.
    - `device_cluster.cu` / the AMG coarsest-grid thread-block-cluster solve (Hopper+/DSM only) — ACPP falls
      back to the single-block Jacobi/PCG coarse solve, the same fallback pre-Hopper CUDA already uses.
    - The CUDA-graph-conditional device-resident PCG/Gauss-Seidel replay loop — ACPP runs the identical
      algorithm as a plain host loop instead.

  ## How I validated this on a GPU

  RTX 3070 (Ampere, sm_86), CUDA 13.0, AdaptiveCpp built from source against the generic JIT target.

  - **No-op proof for the CUDA side**: built the pristine pre-change commit and this branch from scratch in
    separate worktrees, ran the full `ctest` suite on both, and diffed the complete output line by line —
    every printed numeric diagnostic across all 236 tests is byte-for-byte identical, not just pass/fail
    counts. Did this twice (before and after a machine reboot) to rule out any environment artifact.
  - **Full suite, both backends**, with OpenFOAM v2412 installed so the `*_vs_openfoam` comparison tests run
    for real (not skipped): CUDA backend, 228/236 run and pass; the ACPP backend was last checked without
    OpenFOAM installed (so those specific comparisons weren't exercised there), 228/236 by the same
    before/after count.
  - The 7 CUDA-side failures are identical before and after this change, and none are caused by it:
    `dilu` (1-ULP FP delta) and `gpu_divdevreff` (4.9e-2 delta) reproduce on the *unmodified* pristine code
    on this same GPU (checked via `git stash`); `gpu_cluster`/`gpu_amg_fused`/`gpu_cluster_spmv` fail because
    thread-block clusters are genuinely unsupported pre-Hopper (the CUDA driver itself refuses the launch);
    `restart_continuity`/`tracer_transport` fail because their `.sh` scripts don't exist in the repo at all,
    unrelated to this change. The one remaining skip, `boundary_mu_eff`, needs a case fixture
    (`validation/airfoil`) that was never checked into the repo.
  - ACPP-only expected failure: the coded-BC stub, by design (see above).

  ## The honest tradeoff

  This adds a real, if optional and auto-detected, third-party dependency (following the project's existing
  NVSHMEM precedent — same opt-in, same graceful fallback if not found), plus the `#ifdef` surface described
  above. It's also a large diff bundling backend plumbing with a project-wide mechanical refactor — happy to
  split this into separate PRs (plumbing / launch-syntax conversion / AMG fallbacks) if that's preferred over
  reviewing it as one.